### PR TITLE
Add Advertiser name to native-x ad to content converter

### DIFF
--- a/packages/marko-web-native-x/utils/convert-ad-to-content.js
+++ b/packages/marko-web-native-x/utils/convert-ad-to-content.js
@@ -29,6 +29,9 @@ module.exports = (ad = {}, { sectionName = 'Sponsored' } = {}) => {
       fullName: sectionName,
       __typename: 'WebsiteSection',
     },
+    company: {
+      name: campaign.advertiserName,
+    },
     __typename: 'ContentTextAd',
   };
 };


### PR DESCRIPTION
Set advertiserName as the company name on native-x ads for https://github.com/parameter1/randall-reilly-websites/pull/70