### PR TITLE
Support querying allPublishedContent by label

### DIFF
--- a/packages/db/src/utils/filter-dsn.js
+++ b/packages/db/src/utils/filter-dsn.js
@@ -8,8 +8,8 @@ const { get } = require('@parameter1/base-cms-object-path');
 
 const filter = (connection) => {
   const url = get(connection, 's.url');
-  const pwd = get(connection, 's.options.password');
-  const usr = get(connection, 's.options.user');
+  const pwd = get(connection, 's.options.auth.password', get(connection, 's.auth.password'));
+  const usr = get(connection, 's.options.auth.user', get(connection, 's.auth.user'));
   if (pwd || usr) return `${url}`.replace(usr, '*****').replace(pwd, '*****');
   return url;
 };

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -294,6 +294,7 @@ input AllPublishedContentQueryInput {
   excludeContentTypes: [ContentType!] = []
   excludeContentIds: [Int!] = []
   includeTaxonomyIds: [Int!] = []
+  includeLabels: [String!] = []
   requiresImage: Boolean = false
   sectionBubbling: Boolean = true
   sort: ContentSortInput = { field: published, order: desc }

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -645,6 +645,7 @@ module.exports = {
         excludeContentTypes,
         excludeContentIds,
         includeTaxonomyIds,
+        includeLabels,
         requiresImage,
         sectionBubbling,
         sort,
@@ -688,6 +689,9 @@ module.exports = {
       }
       if (includeTaxonomyIds.length) {
         query['taxonomy.$id'] = { $in: includeTaxonomyIds };
+      }
+      if (includeLabels.length) {
+        query.labels = { $in: includeLabels };
       }
 
       const projection = connectionProjection(info);


### PR DESCRIPTION
The addition of the label appears to have a negligible impact on query performance, so I don't think there's any need to add an additional index for this field.

Allows specification of one or more labels to limit the AllPublishedContent query results by.

### Query
```graphql
query SponsoredPublishedContent($input: AllPublishedContentQueryInput!) {
  allPublishedContent(input: $input) {
    edges {
      node {
        id
        type
        name
        labels
      }
    }
    pageInfo {
      endCursor
      hasNextPage
    }
  }
}
```

### Input
```json
{
  "input": {
    "includeLabels": ["Sponsored"]
  }
}
```

### Result
```json
{
  "data": {
    "allPublishedContent": {
      "edges": [
        {
          "node": {
            "id": 21198232,
            "type": "article",
            "name": "[Giveaway] Forget Acrylic. Get Strong Nails With This Revolutionary Product!",
            "labels": [
              "Sponsored"
            ]
          }
        },
        {
          "node": {
            "id": 21195751,
            "type": "document",
            "name": "NP - Sample Document",
            "labels": [
              "Sponsored"
            ]
          }
        }
      ],
      "pageInfo": {
        "endCursor": null,
        "hasNextPage": false
      }
    }
  }
}
```