### PR TITLE
Disable section bubbling, pass content types

### DIFF
--- a/packages/leaders-program/src/graphql/queries/content-for-section.js
+++ b/packages/leaders-program/src/graphql/queries/content-for-section.js
@@ -2,11 +2,18 @@ import gql from 'graphql-tag';
 
 export default gql`
 
-query ContentForLeadersSection($sectionId: Int!, $promotionLimit: Int = 4, $videoLimit: Int = 3) {
+query ContentForLeadersSection(
+  $sectionId: Int!,
+  $promotionLimit: Int = 4,
+  $videoLimit: Int = 3,
+  $includeContentTypes: [ContentType!] = [Company]
+) {
   websiteScheduledContent(input: {
     sectionId: $sectionId,
     pagination: { limit: 0 },
     sort: { field: name, order: asc },
+    sectionBubbling: false,
+    includeContentTypes: Company
   }) {
     edges {
       node {


### PR DESCRIPTION
Currently sectionBubbling is causing inaccurate results on AC/FL warehousing content. Disable section bubbling for this query, and allow passing included content types through. By default, only include companies.