### PR TITLE
Update leaders query

### DIFF
--- a/packages/leaders-program/src/graphql/queries/content-for-section.js
+++ b/packages/leaders-program/src/graphql/queries/content-for-section.js
@@ -13,7 +13,7 @@ query ContentForLeadersSection(
     pagination: { limit: 0 },
     sort: { field: name, order: asc },
     sectionBubbling: false,
-    includeContentTypes: Company
+    includeContentTypes: $includeContentTypes
   }) {
     edges {
       node {


### PR DESCRIPTION
Pass variable through to the query. Fixes bug introduced in #16.