### PR TITLE
Restrict related content by primarySite

### DIFF
--- a/packages/utils/src/get-published-content-criteria.js
+++ b/packages/utils/src/get-published-content-criteria.js
@@ -8,6 +8,7 @@ module.exports = ({
   excludeContentTypes = [],
   since,
   after,
+  primarySite,
 } = {}) => {
   const date = since || new Date();
   const types = isArray(contentTypes) && contentTypes.length
@@ -25,6 +26,7 @@ module.exports = ({
       $lte: date,
       ...(after && { $gte: after }),
     },
+    ...(primarySite && { 'mutations.Website.primarySite': primarySite }),
     $and: [
       {
         $or: [

--- a/packages/web-common/src/block-loaders/related-published-content.js
+++ b/packages/web-common/src/block-loaders/related-published-content.js
@@ -9,6 +9,7 @@ const buildQuery = require('../gql/query-factories/block-related-published-conte
  * @param {string} [params.after] The cursor to start returning results from.
  * @param {string[]} [params.excludeContentTypes] An array of content types to exclude.
  * @param {string[]} [params.includeContentTypes] An array of content types to include.
+ * @param {boolean} [params.withSite] Whether the content must belong to the current site.
  * @param {boolean} [params.requiresImage] Whether the content must have an image.
  * @param {string} [params.queryFragment] The `graphql-tag` fragment
  *                                        to apply to the `relatedPublishedContent` query.
@@ -24,6 +25,7 @@ module.exports = async (apolloClient, {
   excludeContentTypes,
   includeContentTypes,
   requiresImage,
+  withSite,
 
   queryFragment,
   queryName,
@@ -36,6 +38,7 @@ module.exports = async (apolloClient, {
     excludeContentTypes,
     includeContentTypes,
     requiresImage,
+    withSite,
   };
   const query = buildQuery({ queryFragment, queryName });
   const variables = { input };

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -418,6 +418,7 @@ input WebsiteScheduledContentQueryInput {
 }
 
 input RelatedPublishedContentQueryInput {
+  withSite: Boolean = true
   siteId: ObjectID
   contentId: Int!
   excludeContentTypes: [ContentType!] = []

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1205,6 +1205,7 @@ module.exports = {
       const {
         contentId,
         queryTypes,
+        withSite,
       } = input;
       // If no query types were specified (owned, inverse, etc), return an empty response.
       if (!queryTypes.length) return BaseDB.paginateEmpty();
@@ -1217,11 +1218,9 @@ module.exports = {
       // If no content document was found, return an empty response.
       if (!doc) return BaseDB.paginateEmpty();
 
-      const siteId = input.siteId || site.id();
-
       // Run perform the related content query.
       return relatedContent.performQuery(doc, {
-        siteId,
+        ...(withSite && { siteId: input.siteId || site.id() }),
         input,
         basedb,
         info,


### PR DESCRIPTION
[FD 534](https://parameter1.freshdesk.com/a/tickets/534) [PT #176927783](https://www.pivotaltracker.com/story/show/176927783)

In 1d1c20fe75d78d3779343500c989c51b02aaa30d, `siteId` was added to the relatedPublishedContent query, but was never utilized within the related content utility. Similar to the AllPublishedContent query, limit related content to the specified site (or current site, if present, and parameter is not sent).

Adds a new `withSite` flag (default true) to the query which can be used to bypass the inclusion of a siteId in the query (the current production behavior), if needed.