### PR TITLE
Add magazineActiveIssue support for mailing before, after & between support.

### DIFF
--- a/packages/web-common/src/block-loaders/magazine-active-issues.js
+++ b/packages/web-common/src/block-loaders/magazine-active-issues.js
@@ -10,6 +10,7 @@ module.exports = async (apolloClient, {
   publicationId,
   excludeIssueIds,
   requiresCoverImage,
+  mailing,
 
   queryFragment,
   queryName,
@@ -24,6 +25,7 @@ module.exports = async (apolloClient, {
     publicationId,
     excludeIssueIds,
     requiresCoverImage,
+    mailing,
     sort,
     pagination,
   };

--- a/services/graphql-server/src/graphql/definitions/magazine/issue.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/issue.js
@@ -93,6 +93,7 @@ input MagazineActiveIssuesQueryInput {
   requiresCoverImage: Boolean = false
   sort: MagazineIssueSortInput = { field: mailDate, order: desc }
   pagination: PaginationInput = {}
+  mailing: IssueMailingDateInput = {}
 }
 
 input MagazineIssuesQueryInput {
@@ -100,6 +101,11 @@ input MagazineIssuesQueryInput {
   requiresCoverImage: Boolean = false
   sort: MagazineIssueSortInput = {}
   pagination: PaginationInput = {}
+}
+
+input IssueMailingDateInput {
+  before: Date
+  after: Date
 }
 
 input MagazineIssuePublicationInput {

--- a/services/graphql-server/src/graphql/definitions/magazine/issue.js
+++ b/services/graphql-server/src/graphql/definitions/magazine/issue.js
@@ -93,7 +93,7 @@ input MagazineActiveIssuesQueryInput {
   requiresCoverImage: Boolean = false
   sort: MagazineIssueSortInput = { field: mailDate, order: desc }
   pagination: PaginationInput = {}
-  mailing: IssueMailingDateInput = {}
+  mailing: MagazineActiveIssuesMailingInput = {}
 }
 
 input MagazineIssuesQueryInput {
@@ -103,7 +103,7 @@ input MagazineIssuesQueryInput {
   pagination: PaginationInput = {}
 }
 
-input IssueMailingDateInput {
+input MagazineActiveIssuesMailingInput {
   before: Date
   after: Date
 }

--- a/services/graphql-server/src/graphql/query-builders/magazine-active-issues.js
+++ b/services/graphql-server/src/graphql/query-builders/magazine-active-issues.js
@@ -5,9 +5,14 @@ module.exports = ({ query }, { input }) => {
     publicationId,
     excludeIssueIds,
     requiresCoverImage,
+    mailing,
   } = input;
 
   q.mailDate = { $lte: new Date() };
+  const $and = [];
+  if (mailing.before) $and.push({ mailDate: { $lte: mailing.before } });
+  if (mailing.after) $and.push({ mailDate: { $gte: mailing.after } });
+  if ($and) q.$and = $and;
   q['publication.$id'] = publicationId;
   if (excludeIssueIds.length) q._id = { $nin: excludeIssueIds };
   if (requiresCoverImage) q['coverImage.$id'] = { $exists: true };

--- a/services/graphql-server/src/graphql/query-builders/magazine-active-issues.js
+++ b/services/graphql-server/src/graphql/query-builders/magazine-active-issues.js
@@ -8,11 +8,10 @@ module.exports = ({ query }, { input }) => {
     mailing,
   } = input;
 
-  q.mailDate = { $lte: new Date() };
   const $and = [];
-  if (mailing.before) $and.push({ mailDate: { $lte: mailing.before } });
+  $and.push({ mailDate: { $lte: mailing.before ? mailing.before : new Date() } });
   if (mailing.after) $and.push({ mailDate: { $gte: mailing.after } });
-  if ($and) q.$and = $and;
+  q.$and = $and;
   q['publication.$id'] = publicationId;
   if (excludeIssueIds.length) q._id = { $nin: excludeIssueIds };
   if (requiresCoverImage) q['coverImage.$id'] = { $exists: true };


### PR DESCRIPTION
Add the ability to query for issue before, after or between dates.  Example below gets all of 2016 issues:

<img width="1724" alt="Screen Shot 2021-02-15 at 8 58 29 AM" src="https://user-images.githubusercontent.com/3845869/107961956-1f775f00-6f6c-11eb-9149-1385c13ce2b7.png">
