### PR TITLE
Add withSite parameter to related content field

### DIFF
--- a/packages/leaders-program/src/graphql/queries/content-for-section.js
+++ b/packages/leaders-program/src/graphql/queries/content-for-section.js
@@ -73,6 +73,7 @@ query ContentForLeadersSection(
           teaser(input: { maxLength: 0 })
           website
           promotions: relatedContent(input: {
+            withSite: false,
             queryTypes: [company],
             includeContentTypes: [Promotion],
             pagination: { limit: $promotionLimit },

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -430,6 +430,7 @@ input RelatedPublishedContentQueryInput {
 }
 
 input ContentRelatedContentInput {
+  withSite: Boolean = true
   siteId: ObjectID
   excludeContentTypes: [ContentType!] = []
   includeContentTypes: [ContentType!] = []

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -498,15 +498,14 @@ module.exports = {
     relatedContent: (doc, { input }, { basedb, site }, info) => {
       const {
         queryTypes,
+        withSite,
       } = input;
       // If no query types were specified (owned, inverse, etc), return an empty response.
       if (!queryTypes.length) return BaseDB.paginateEmpty();
 
-      const siteId = input.siteId || site.id();
-
       // Run perform the related content query.
       return relatedContent.performQuery(doc, {
-        siteId,
+        ...(withSite && { siteId: input.siteId || site.id() }),
         input,
         basedb,
         info,


### PR DESCRIPTION
[FD 411](https://parameter1.freshdesk.com/a/tickets/411) Promotions missing in leaders block from content primary to another site.

Ref #21, add the withSite parameter to the `relatedContent` field as well as the `relatedPublishedContent` query.