### PR TITLE
Use large image for Twitter summary card

### DIFF
--- a/packages/marko-web/components/page/metadata/components/common.marko
+++ b/packages/marko-web/components/page/metadata/components/common.marko
@@ -33,11 +33,11 @@ $ const image = imageSrc || fallbackImage;
 <meta property="og:locale" content=config.website("language.primaryCode") />
 
 <!-- Twitter -->
-<meta name="twitter:card" content="summary" />
+<meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content=title />
 <if(description)>
   <meta name="twitter:description" content=description />
 </if>
 <if(image)>
-  <meta name="twitter:image:src" content=image />
+  <meta name="twitter:image" content=image />
 </if>


### PR DESCRIPTION
See: https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image