### PR TITLE
Update youtube playlist url format

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -602,7 +602,7 @@ module.exports = {
       const { playlistId, channelId, username } = asObject(youtube);
       switch (true) {
         case Boolean(playlistId):
-          return `https://youtube.com/playlist/${playlistId}`;
+          return `https://youtube.com/playlist?list=${playlistId}`;
         case Boolean(channelId):
           return `https://youtube.com/channel/${channelId}`;
         case Boolean(username):


### PR DESCRIPTION
[Trello #10: Fix "View all videos" button URL](https://trello.com/c/UgDPH2pO/10-fix-view-all-videos-button-url)

The Youtube playlist URL should use the listId as a parameter, not as a path parameter.