### PR TITLE
Emit event when Leaders category companies are loaded

### DIFF
--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -179,7 +179,11 @@ export default {
         this.isLoading = true;
         this.error = null;
         try {
-          const variables = { sectionId: this.sectionId, promotionLimit: this.promotionLimit, videoLimit: this.videoLimit };
+          const variables = {
+            sectionId: this.sectionId,
+            promotionLimit: this.promotionLimit,
+            videoLimit: this.videoLimit,
+          };
           const { data } = await this.$apollo.query({ query, variables });
           this.items = getEdgeNodes(data, 'websiteScheduledContent');
           this.hasLoaded = true;

--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -23,6 +23,7 @@
         :offset-bottom="offsetBottom"
         nav-direction="vertical"
         @link-action="emitAction"
+        @mounted="emitCategoryItems"
       >
         <template #nav-link="{ item, isActive }">
           <link-contents
@@ -146,6 +147,19 @@ export default {
 
     emitAction(...args) {
       this.$emit('action', ...args);
+    },
+
+    emitCategoryItems(items) {
+      if (!items || !items.length) return;
+      this.emitAction({
+        type: 'viewed',
+        label: 'Section Company Items',
+        category: 'Leaders Sections Nav',
+      }, {
+        sectionId: this.sectionId,
+        sectionName: this.title,
+        items: items.map(item => ({ id: item.id, name: item.name })),
+      });
     },
 
     toggleExpanded() {

--- a/packages/leaders-program/src/components/list/index.vue
+++ b/packages/leaders-program/src/components/list/index.vue
@@ -46,7 +46,6 @@
             v-for="(item, index) in items"
             ref="sections"
             :key="index"
-            #default="{ isActive }"
             :index="index"
             :active-index="activeIndex"
             :last-active-index="lastActiveIndex"

--- a/packages/leaders-program/src/components/list/index.vue
+++ b/packages/leaders-program/src/components/list/index.vue
@@ -179,6 +179,7 @@ export default {
     document.addEventListener('touchmove', this.onTouchMove);
     document.addEventListener('touchstart', this.onTouchStart);
     document.body.addEventListener(pointerEvent.end, this.onPointerEnd);
+    this.$emit('mounted', this.items);
   },
 
   beforeDestroy() {


### PR DESCRIPTION
When a Leaders category is expanded, an event will fire that includes the category's section information and the companies listed with the category. This event will _not_ fire if no companies were found for the expanded section