### PR TITLE
Windows file watching

### DIFF
--- a/packages/cli-utils/task-callback.js
+++ b/packages/cli-utils/task-callback.js
@@ -4,7 +4,7 @@ module.exports = (e, cb) => {
   if (e) {
     logError(e);
     process.exit(1);
-  } else {
+  } else if (typeof cb === 'function') {
     cb();
   }
 };

--- a/packages/export-cli/src/gulp/lint.js
+++ b/packages/export-cli/src/gulp/lint.js
@@ -4,15 +4,11 @@ const pump = require('pump');
 const { src } = require('gulp');
 const completeTask = require('@parameter1/base-cms-cli-utils/task-callback');
 
-module.exports = (cwd, options) => (cb) => {
+module.exports = (cwd, options, ignore = ['**/node_modules/**/*']) => (cb) => {
   pump([
-    src(['**/*.js'], { cwd }),
+    src(['**/*.js'], { cwd, ignore }),
     cache('basecms-exports-lint-js'),
     eslint(options),
-    eslint.results((results, lintCb) => {
-      lintCb();
-      cb();
-    }),
     eslint.format(),
   ], e => completeTask(e, cb));
 };

--- a/packages/export-cli/src/gulp/serve.js
+++ b/packages/export-cli/src/gulp/serve.js
@@ -9,6 +9,7 @@ const lint = require('./lint');
 const server = require('./server');
 
 module.exports = (cwd, serverFile) => () => {
+  if (process.env.GULP_POLLING_ENABLED) log('Falling back to polling to watch files!');
   const watcher = watch(
     ['**/*.js'],
     {
@@ -16,6 +17,12 @@ module.exports = (cwd, serverFile) => () => {
       queue: false,
       ignoreInitial: false,
       ignored: ['node_modules'],
+      ...(process.env.GULP_POLLING_ENABLED && {
+        // Use polling on windows https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16
+        interval: process.env.GULP_POLLING_INTERVAL || 1000,
+        usePolling: true,
+        useFsEvents: false,
+      }),
     },
     parallel(lint(cwd), server(serverFile)),
   );

--- a/packages/export-cli/src/gulp/serve.js
+++ b/packages/export-cli/src/gulp/serve.js
@@ -19,7 +19,8 @@ module.exports = (cwd, serverFile) => () => {
       ignored: ['node_modules'],
       ...(process.env.GULP_POLLING_ENABLED && {
         // Use polling on windows https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16
-        interval: process.env.GULP_POLLING_INTERVAL ? parseInt(process.env.GULP_POLLING_INTERVAL, 10) : 1000,
+        interval: process.env.GULP_POLLING_INTERVAL
+          ? parseInt(process.env.GULP_POLLING_INTERVAL, 10) : 1000,
         usePolling: true,
         useFsEvents: false,
       }),

--- a/packages/export-cli/src/gulp/serve.js
+++ b/packages/export-cli/src/gulp/serve.js
@@ -19,7 +19,7 @@ module.exports = (cwd, serverFile) => () => {
       ignored: ['node_modules'],
       ...(process.env.GULP_POLLING_ENABLED && {
         // Use polling on windows https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16
-        interval: process.env.GULP_POLLING_INTERVAL || 1000,
+        interval: process.env.GULP_POLLING_INTERVAL ? parseInt(process.env.GULP_POLLING_INTERVAL, 10) : 1000,
         usePolling: true,
         useFsEvents: false,
       }),

--- a/packages/newsletter-cli/src/gulp/lint.js
+++ b/packages/newsletter-cli/src/gulp/lint.js
@@ -4,15 +4,11 @@ const pump = require('pump');
 const { src } = require('gulp');
 const completeTask = require('@parameter1/base-cms-cli-utils/task-callback');
 
-module.exports = (cwd, options) => (cb) => {
+module.exports = (cwd, options, ignore = ['**/node_modules/**/*']) => (cb) => {
   pump([
-    src(['**/*.js', '!**/*.marko.js'], { cwd }),
+    src(['**/*.js', '!**/*.marko.js'], { cwd, ignore }),
     cache('basecms-newsletters-lint-js'),
     eslint(options),
-    eslint.results((results, lintCb) => {
-      lintCb();
-      cb();
-    }),
     eslint.format(),
   ], e => completeTask(e, cb));
 };

--- a/packages/newsletter-cli/src/gulp/serve.js
+++ b/packages/newsletter-cli/src/gulp/serve.js
@@ -18,6 +18,7 @@ const { LIVERELOAD_PORT } = process.env;
 module.exports = (cwd, serverFile) => () => {
   livereload.listen({ port: LIVERELOAD_PORT, quiet: true });
   log(`Livereload ${green('listening')} on port ${magenta(LIVERELOAD_PORT)}`);
+  if (process.env.GULP_POLLING_ENABLED) log('Falling back to polling to watch files!');
   const watcher = watch(
     [
       '**/*.js',
@@ -30,6 +31,12 @@ module.exports = (cwd, serverFile) => () => {
       queue: false,
       ignoreInitial: false,
       ignored: ['**/*.marko.js', 'node_modules'],
+      ...(process.env.GULP_POLLING_ENABLED && {
+        // Use polling on windows https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16
+        interval: process.env.GULP_POLLING_INTERVAL || 1000,
+        usePolling: true,
+        useFsEvents: false,
+      }),
     },
     parallel(lint(cwd), server(serverFile)),
   );

--- a/packages/newsletter-cli/src/gulp/serve.js
+++ b/packages/newsletter-cli/src/gulp/serve.js
@@ -33,7 +33,8 @@ module.exports = (cwd, serverFile) => () => {
       ignored: ['**/*.marko.js', 'node_modules'],
       ...(process.env.GULP_POLLING_ENABLED && {
         // Use polling on windows https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16
-        interval: process.env.GULP_POLLING_INTERVAL ? parseInt(process.env.GULP_POLLING_INTERVAL, 10) : 1000,
+        interval: process.env.GULP_POLLING_INTERVAL
+          ? parseInt(process.env.GULP_POLLING_INTERVAL, 10) : 1000,
         usePolling: true,
         useFsEvents: false,
       }),

--- a/packages/newsletter-cli/src/gulp/serve.js
+++ b/packages/newsletter-cli/src/gulp/serve.js
@@ -33,7 +33,7 @@ module.exports = (cwd, serverFile) => () => {
       ignored: ['**/*.marko.js', 'node_modules'],
       ...(process.env.GULP_POLLING_ENABLED && {
         // Use polling on windows https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16
-        interval: process.env.GULP_POLLING_INTERVAL || 1000,
+        interval: process.env.GULP_POLLING_INTERVAL ? parseInt(process.env.GULP_POLLING_INTERVAL, 10) : 1000,
         usePolling: true,
         useFsEvents: false,
       }),

--- a/packages/web-cli/src/gulp/lint-js.js
+++ b/packages/web-cli/src/gulp/lint-js.js
@@ -4,15 +4,11 @@ const pump = require('pump');
 const { src } = require('gulp');
 const completeTask = require('@parameter1/base-cms-cli-utils/task-callback');
 
-module.exports = (cwd, options) => (cb) => {
+module.exports = (cwd, options, ignore = ['**/node_modules/**/*']) => (cb) => {
   pump([
-    src(['server/**/*.js', '!server/**/*.marko.js'], { cwd }),
+    src(['server/**/*.js', '!server/**/*.marko.js'], { cwd, ignore }),
     cache('basecms-lint-js'),
     eslint(options),
-    eslint.results((results, lintCb) => {
-      lintCb();
-      cb();
-    }),
     eslint.format(),
     eslint.failAfterError(),
   ], e => completeTask(e, cb));

--- a/packages/web-cli/src/gulp/lint-sass.js
+++ b/packages/web-cli/src/gulp/lint-sass.js
@@ -4,9 +4,9 @@ const styelint = require('gulp-stylelint');
 const { src } = require('gulp');
 const completeTask = require('@parameter1/base-cms-cli-utils/task-callback');
 
-module.exports = (cwd, options) => (cb) => {
+module.exports = (cwd, options, ignore = ['**/node_modules/**/*']) => (cb) => {
   pump([
-    src('server/styles/**/*.scss', { cwd }),
+    src('server/styles/**/*.scss', { cwd, ignore }),
     cache('basecms-lint-sass'),
     styelint({
       ...options,

--- a/packages/web-cli/src/gulp/serve.js
+++ b/packages/web-cli/src/gulp/serve.js
@@ -19,6 +19,7 @@ const { LIVERELOAD_PORT } = process.env;
 module.exports = (cwd, serverFile) => () => {
   livereload.listen({ port: LIVERELOAD_PORT, quiet: true });
   log(`Livereload ${green('listening')} on port ${magenta(LIVERELOAD_PORT)}`);
+  if (process.env.GULP_POLLING_ENABLED) log('Falling back to polling to watch files!');
   const watcher = watch(
     [
       serverFile,
@@ -36,6 +37,12 @@ module.exports = (cwd, serverFile) => () => {
       queue: false,
       ignoreInitial: false,
       ignored: 'server/**/*.marko.js',
+      ...(process.env.GULP_POLLING_ENABLED && {
+        // Use polling on windows https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16
+        interval: process.env.GULP_POLLING_INTERVAL || 1000,
+        usePolling: true,
+        useFsEvents: false,
+      }),
     },
     parallel(lint(cwd), series(build(cwd), server(serverFile))),
   );

--- a/packages/web-cli/src/gulp/serve.js
+++ b/packages/web-cli/src/gulp/serve.js
@@ -39,7 +39,8 @@ module.exports = (cwd, serverFile) => () => {
       ignored: 'server/**/*.marko.js',
       ...(process.env.GULP_POLLING_ENABLED && {
         // Use polling on windows https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16
-        interval: process.env.GULP_POLLING_INTERVAL ? parseInt(process.env.GULP_POLLING_INTERVAL, 10) : 1000,
+        interval: process.env.GULP_POLLING_INTERVAL
+          ? parseInt(process.env.GULP_POLLING_INTERVAL, 10) : 1000,
         usePolling: true,
         useFsEvents: false,
       }),

--- a/packages/web-cli/src/gulp/serve.js
+++ b/packages/web-cli/src/gulp/serve.js
@@ -39,7 +39,7 @@ module.exports = (cwd, serverFile) => () => {
       ignored: 'server/**/*.marko.js',
       ...(process.env.GULP_POLLING_ENABLED && {
         // Use polling on windows https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038/16
-        interval: process.env.GULP_POLLING_INTERVAL || 1000,
+        interval: process.env.GULP_POLLING_INTERVAL ? parseInt(process.env.GULP_POLLING_INTERVAL, 10) : 1000,
         usePolling: true,
         useFsEvents: false,
       }),


### PR DESCRIPTION
- [x] new: Provides support for alternate file watching (specifically for Docker on Windows)
- [x] bugfix: Only attempt to execute callback in cli-utils if it is a function
- [x] new: allow specifying ignore paths for gulp via fn input
- [x] bugfix: do not attempt to lint `node_modules` when booting the newsletter cli
- [x] cleanup: Remove deprecated `eslint.results` calls

Consuming applications can now specify two additional environment variables to be picked up by the various CLIs:
- `GULP_POLLING_ENABLED` - If set, the file watching method will use polling instead of the default fs.watch.
- `GULP_POLLING_INTERVAL` - (Default 1000ms) Sets the interval that watched files will be polled for changes (via modification dates)

![image](https://user-images.githubusercontent.com/1778222/110551055-6df6c400-80fa-11eb-8b4c-49a923b31b92.png)

![image](https://user-images.githubusercontent.com/1778222/110830090-7700a600-825e-11eb-91dc-467e04bac1cc.png)
