### PR TITLE
Restore eslint callbacks

### DIFF
--- a/packages/export-cli/src/gulp/lint.js
+++ b/packages/export-cli/src/gulp/lint.js
@@ -9,6 +9,10 @@ module.exports = (cwd, options, ignore = ['**/node_modules/**/*']) => (cb) => {
     src(['**/*.js'], { cwd, ignore }),
     cache('basecms-exports-lint-js'),
     eslint(options),
+    eslint.results((results, lintCb) => {
+      lintCb();
+      cb();
+    }),
     eslint.format(),
   ], e => completeTask(e, cb));
 };

--- a/packages/newsletter-cli/src/gulp/lint.js
+++ b/packages/newsletter-cli/src/gulp/lint.js
@@ -9,6 +9,10 @@ module.exports = (cwd, options, ignore = ['**/node_modules/**/*']) => (cb) => {
     src(['**/*.js', '!**/*.marko.js'], { cwd, ignore }),
     cache('basecms-newsletters-lint-js'),
     eslint(options),
+    eslint.results((results, lintCb) => {
+      lintCb();
+      cb();
+    }),
     eslint.format(),
   ], e => completeTask(e, cb));
 };

--- a/packages/web-cli/src/gulp/lint-js.js
+++ b/packages/web-cli/src/gulp/lint-js.js
@@ -9,6 +9,10 @@ module.exports = (cwd, options, ignore = ['**/node_modules/**/*']) => (cb) => {
     src(['server/**/*.js', '!server/**/*.marko.js'], { cwd, ignore }),
     cache('basecms-lint-js'),
     eslint(options),
+    eslint.results((results, lintCb) => {
+      lintCb();
+      cb();
+    }),
     eslint.format(),
     eslint.failAfterError(),
   ], e => completeTask(e, cb));


### PR DESCRIPTION
Evidently I was wrong in #40 -- while the `completeTask` CLI utility will execute the user-supplied callback regardless of error state, the `pump` utility *only* calls the supplied callback (`completeTask`) if the stream encountered an error: https://github.com/mafintosh/pump/blob/master/index.js#L75

Reverts change to `eslint.results` calls to restore the callback.