### PR TITLE
Track section context within Leaders Data Card events

### DIFF
--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -145,8 +145,12 @@ export default {
       return `${this.blockName}__${name}`;
     },
 
-    emitAction(...args) {
-      this.$emit('action', ...args);
+    emitAction(event, payload = {}) {
+      this.$emit('action', event, {
+        ...payload,
+        sectionId: this.sectionId,
+        sectionName: this.title,
+      });
     },
 
     emitCategoryItems(items) {

--- a/packages/marko-web-leaders/browser/p1events-tracker.vue
+++ b/packages/marko-web-leaders/browser/p1events-tracker.vue
@@ -48,12 +48,14 @@ export default {
           ...baseEvent,
           action: 'Open',
           entity: { id: payload.companyId, ns: this.ns('content-company') },
+          context: { id: payload.sectionId, ns: this.ns('website-section') },
         });
       } else if (type === 'click' && category === 'Leaders Data Card') {
         queue.push({
           ...baseEvent,
           action: 'Click',
           entity: { id: payload.companyId, ns: this.ns('content-company') },
+          context: { id: payload.sectionId, ns: this.ns('website-section') },
           props: { url: payload.href },
         });
       } else if (type === 'click' && category === 'Leaders Company Profile') {


### PR DESCRIPTION
The `sectionId` and `sectionName` values will be appended to all event payloads emitted from a Leaders section, including all Leaders Data Card events. The P1 Event tracker will then send the section context with all `open` and `click` events.