### PR TITLE
Add support for pretty HTML output via response middleware

### DIFF
--- a/packages/marko-core/middleware/clean-marko-response.js
+++ b/packages/marko-core/middleware/clean-marko-response.js
@@ -1,10 +1,37 @@
+const { getAsObject } = require('@parameter1/base-cms-object-path');
+const pretty = require('pretty');
 const cleanChunk = require('../utils/clean-marko-chunk');
+const buildMarkoGlobal = require('../utils/build-marko-global');
 
-module.exports = ({ enabled = true } = {}) => (req, res, next) => {
+module.exports = ({ enabled = true, prettyQueryParam = 'pretty', prettyEnvVar = 'MARKO_PRETTY_OUTPUT' } = {}) => (req, res, next) => {
+  if (!enabled || !res.marko) return next();
   const { write } = res;
+  const prettyOutput = process.env[prettyEnvVar]
+    || Object.hasOwnProperty.call(req.query, prettyQueryParam);
+
+  if (prettyOutput) {
+    res.marko = function output(template, data) {
+      if (typeof template === 'string') {
+        throw new Error('The Marko template cannot be a string.');
+      }
+      const $global = buildMarkoGlobal(this);
+      const d = { ...data, $global: { ...$global, ...getAsObject(data, '$global') } };
+      this.set({ 'content-type': 'text/html; charset=utf-8' });
+      const out = template.createOut();
+      template.render(d, out);
+
+      out.on('finish', () => {
+        const html = cleanChunk(out.getOutput());
+        this.send(pretty(html));
+      });
+      out.end();
+    };
+    return next();
+  }
+
   res.write = function clean(...args) {
     const [chunk] = args;
-    if (!enabled || typeof chunk !== 'string') {
+    if (typeof chunk !== 'string') {
       write.apply(this, args);
     } else {
       const cleanedArgs = [...args];
@@ -12,5 +39,5 @@ module.exports = ({ enabled = true } = {}) => (req, res, next) => {
       write.apply(this, cleanedArgs);
     }
   };
-  next();
+  return next();
 };

--- a/packages/marko-core/middleware/clean-marko-response.js
+++ b/packages/marko-core/middleware/clean-marko-response.js
@@ -5,6 +5,9 @@ const buildMarkoGlobal = require('../utils/build-marko-global');
 
 module.exports = ({ enabled = true, prettyQueryParam = 'pretty', prettyEnvVar = 'MARKO_PRETTY_OUTPUT' } = {}) => (req, res, next) => {
   if (!enabled || !res.marko) return next();
+  if (res.locals.cleanMarkoResponseApplied) return next();
+
+  res.locals.cleanMarkoResponseApplied = true;
   const { write } = res;
   const prettyOutput = process.env[prettyEnvVar]
     || Object.hasOwnProperty.call(req.query, prettyQueryParam);

--- a/packages/marko-core/middleware/clean-marko-response.js
+++ b/packages/marko-core/middleware/clean-marko-response.js
@@ -23,6 +23,7 @@ module.exports = ({ enabled = true, prettyQueryParam = 'pretty', prettyEnvVar = 
       const out = template.createOut();
       template.render(d, out);
 
+      out.on('error', next);
       out.on('finish', () => {
         const html = cleanChunk(out.getOutput());
         this.send(pretty(html));

--- a/packages/marko-core/package.json
+++ b/packages/marko-core/package.json
@@ -17,7 +17,8 @@
     "@parameter1/base-cms-web-common": "^2.5.0",
     "marko": "~4.20.0",
     "moment": "^2.29.1",
-    "moment-timezone": "^0.5.32"
+    "moment-timezone": "^0.5.32",
+    "pretty": "^2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/marko-newsletters/express/template-router.js
+++ b/packages/marko-newsletters/express/template-router.js
@@ -1,11 +1,8 @@
 const { Router } = require('express');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
-const buildMarkoGlobal = require('@parameter1/base-cms-marko-core/utils/build-marko-global');
-const cleanChunk = require('@parameter1/base-cms-marko-core/utils/clean-marko-chunk');
 const gql = require('graphql-tag');
 const createError = require('http-errors');
 const moment = require('moment-timezone');
-const pretty = require('pretty');
 const cleanResponse = require('@parameter1/base-cms-marko-core/middleware/clean-marko-response');
 const siteContextFragment = require('@parameter1/base-cms-web-common/graphql/website-context-fragment');
 const { extractFragmentData } = require('@parameter1/base-cms-web-common/utils');
@@ -47,7 +44,7 @@ const buildQuery = ({ queryFragment }) => {
 module.exports = ({ templates }) => {
   const router = Router();
 
-  router.use(cleanResponse());
+  router.use(cleanResponse({ prettyEnvVar: 'MARKO_NEWSLETTERS_PRETTY' }));
 
   templates.forEach(({
     route,
@@ -125,19 +122,7 @@ module.exports = ({ templates }) => {
         isStatic: !newsletter,
       };
 
-      const prettyOutput = process.env.MARKO_NEWSLETTERS_PRETTY || Object.hasOwnProperty.call(req.query, 'pretty');
-      if (prettyOutput) {
-        const $global = buildMarkoGlobal(res);
-        const out = template.createOut();
-        template.render({ $global, ...templateData }, out);
-        out.on('finish', () => {
-          const html = cleanChunk(out.getOutput());
-          res.send(pretty(html));
-        });
-        out.end();
-      } else {
-        res.marko(template, templateData);
-      }
+      res.marko(template, templateData);
     }));
   });
   return router;

--- a/packages/marko-newsletters/package.json
+++ b/packages/marko-newsletters/package.json
@@ -28,7 +28,6 @@
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.32",
     "node-fetch": "^2.6.1",
-    "pretty": "^2.0.0",
     "recursive-readdir": "^2.2.2"
   },
   "peerDependencies": {

--- a/packages/marko-web/express/index.js
+++ b/packages/marko-web/express/index.js
@@ -4,6 +4,7 @@ const express = require('express');
 const marko = require('marko/express');
 const path = require('path');
 const helmet = require('helmet');
+const cleanMarkoResponse = require('@parameter1/base-cms-marko-core/middleware/clean-marko-response');
 const apollo = require('./apollo');
 const graphqlProxy = require('./graphql-proxy');
 const embeddedMedia = require('./embedded-media');
@@ -92,6 +93,7 @@ module.exports = (config = {}) => {
 
   // Register the Marko middleware.
   app.use(marko());
+  app.use(cleanMarkoResponse());
 
   // Serve static assets
   app.use('/dist/css', express.static(`${distDir}/css`, { maxAge: '2y', immutable: true }));


### PR DESCRIPTION
And apply response cleaning by default to all Marko web and newsletter instances.