### PR TITLE
Create hook support and add `onAuthenticationSuccess`

### DIFF
--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -1,4 +1,7 @@
 const { get, getAsArray, getAsObject } = require('@parameter1/base-cms-object-path');
+const { isFunction: isFn } = require('@parameter1/base-cms-utils');
+
+const validHooks = ['onAuthenticationSuccess'];
 
 class IdentityXConfiguration {
   /**
@@ -15,6 +18,23 @@ class IdentityXConfiguration {
     this.options = options && typeof options === 'object' ? options : {};
 
     this.endpointTypes = ['authenticate', 'login', 'logout', 'register', 'profile'];
+    this.hooks = {
+      onAuthenticationSuccess: [],
+    };
+  }
+
+  /**
+   * Adds a function to the hook queue.
+   *
+   * @param {object} params
+   * @param {string} params.string The hook name to register the function with.
+   * @param {function} params.fn The function to call. Can be async/promise.
+   * @param {boolean} [params.shouldAwait=false] Whether the function should be awaited.
+   */
+  addHook({ name, fn, shouldAwait = false } = {}) {
+    if (!validHooks.includes(name)) throw new Error(`No hook found for '${name}'`);
+    if (!isFn(fn)) throw new Error('The hook `fn` must be a function.');
+    this.hooks[name].push({ fn, shouldAwait });
   }
 
   getAppId() {

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -35,6 +35,7 @@ class IdentityXConfiguration {
     if (!validHooks.includes(name)) throw new Error(`No hook found for '${name}'`);
     if (!isFn(fn)) throw new Error('The hook `fn` must be a function.');
     this.hooks[name].push({ fn, shouldAwait });
+    return this;
   }
 
   getAppId() {

--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -1,6 +1,7 @@
 const gql = require('graphql-tag');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const tokenCookie = require('../utils/token-cookie');
+const callHooksFor = require('../utils/call-hooks-for');
 const userFragment = require('../api/fragments/active-user');
 
 const loginAppUser = gql`
@@ -28,6 +29,9 @@ module.exports = asyncRoute(async (req, res) => {
   const variables = { input };
   const { data = {} } = await identityX.client.mutate({ mutation: loginAppUser, variables });
   const { token: authToken, user } = data.loginAppUser;
+
+  // call authentication hooks
+  await callHooksFor(identityX, 'onAuthenticationSuccess', { user, authToken });
   tokenCookie.setTo(res, authToken.value);
   res.json({ ok: true, user });
 });

--- a/packages/marko-web-identity-x/utils/call-hooks-for.js
+++ b/packages/marko-web-identity-x/utils/call-hooks-for.js
@@ -1,0 +1,23 @@
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+const { isFunction: isFn } = require('@parameter1/base-cms-utils');
+
+/**
+ * Calls all registered hooks for the provided hook queue name.
+ *
+ * @param {IdentityX} service The IdentityX service instance.
+ * @param {string} name The hook queue name
+ * @param {object} params Parameters to send to the hook function
+ */
+module.exports = async (service, name, params = {}) => {
+  const { error } = console;
+  const onError = service.config.get('onHookError');
+  const onHookError = isFn(onError) ? onError : e => error(e);
+  const promises = { wait: [], skip: [] };
+  getAsArray(service, `config.hooks.${name}`).forEach(({ fn, shouldAwait }) => {
+    const key = shouldAwait ? 'wait' : 'skip';
+    const maybePromise = fn({ ...params, service });
+    if (maybePromise.catch) maybePromise.catch(onHookError);
+    promises[key].push(maybePromise);
+  });
+  if (promises.wait.length) await Promise.all(promises.wait).catch(onHookError);
+};


### PR DESCRIPTION
Adds support for registering hook functions. Currently, only `onAuthenticationSuccess` has been added. Hooks can be registered with the `IdentityXConfiguration` object:

```js
// your-identity-x-config.js
const IdentityXConfiguration = require('@parameter1/base-cms-marko-web-identity-x/config');

const config = new IdentityXConfiguration({
  appId: 'your-app-id',
  onHookError: (e) => {
    // handle/log hook errors here...
  },
});
config.addHook({
  name: 'onAuthenticationSuccess',
  shouldAwait: true, // whether async functions or promises should be awaited. false by default
  fn: async ({ user, authToken, service }) => {
    // do stuff with the data. the `service` parameter is the `IdentityX` service instance.
    console.log({ user, authToken, service });
  },
});
module.exports = config;
```

Multiple functions can be registered for the same hook queue:
```js
config.addHook({
  name: 'onAuthenticationSuccess',
  fn: async ({ user, authToken, service }) => {
    console.log('hook 1');
  },
}).addHook({
  name: 'onAuthenticationSuccess',
  fn: async ({ user, authToken, service }) => {
    console.log('hook 2');
  },
});
```