### PR TITLE
Add support for querying and adding external user IDs

### DIFF
--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -11,10 +11,6 @@ fragment ActiveUserFragment on AppUser {
   organization
   organizationTitle
   countryCode
-  country {
-    id
-    alpha3
-  }
   regionCode
   postalCode
   receiveEmail

--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -18,6 +18,18 @@ fragment ActiveUserFragment on AppUser {
   regionCode
   postalCode
   receiveEmail
+  externalIds {
+    id
+    identifier {
+      value
+      type
+    }
+    namespace {
+      provider
+      tenant
+      type
+    }
+  }
   regionalConsentAnswers {
     id
     given

--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -11,6 +11,10 @@ fragment ActiveUserFragment on AppUser {
   organization
   organizationTitle
   countryCode
+  country {
+    id
+    alpha3
+  }
   regionCode
   postalCode
   receiveEmail

--- a/packages/marko-web-identity-x/api/mutations/add-external-user-id.js
+++ b/packages/marko-web-identity-x/api/mutations/add-external-user-id.js
@@ -1,14 +1,24 @@
 const gql = require('graphql-tag');
-const userFragment = require('../fragments/active-user');
 
 module.exports = gql`
 
 mutation AddExternalUserId($input: SetAppUserExternalIdMutationInput!) {
   addAppUserExternalId(input: $input) {
-    ...ActiveUserFragment
+    id
+    email
+    externalIds {
+      id
+      identifier {
+        value
+        type
+      }
+      namespace {
+        provider
+        tenant
+        type
+      }
+    }
   }
-
-  ${userFragment}
 }
 
 `;

--- a/packages/marko-web-identity-x/api/mutations/add-external-user-id.js
+++ b/packages/marko-web-identity-x/api/mutations/add-external-user-id.js
@@ -1,0 +1,14 @@
+const gql = require('graphql-tag');
+const userFragment = require('../fragments/active-user');
+
+module.exports = gql`
+
+mutation AddExternalUserId($input: SetAppUserExternalIdMutationInput!) {
+  addAppUserExternalId(input: $input) {
+    ...ActiveUserFragment
+  }
+
+  ${userFragment}
+}
+
+`;

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -6,16 +6,24 @@ const validHooks = ['onAuthenticationSuccess'];
 class IdentityXConfiguration {
   /**
    *
-   * @param {object|string} options When a string, assumes an `appId`, else options object.
-   * @param {array} [options.requiredServerFields] Required fields, server enforced.
-   * @param {array} [options.requiredClientFields] Required fields, client-side only.
+   * @param {object} options
+   * @param {string} options.appId The application ID to use.
+   * @param {string[]} [options.requiredServerFields] Required fields, server enforced.
+   * @param {string[]} [options.requiredClientFields] Required fields, client-side only.
    */
-  constructor(options) {
-    // BC check for when the constructor only had a single `appId` argument.
-    const appId = typeof options === 'string' ? options : get(options, 'appId');
+  constructor({
+    appId,
+    requiredServerFields = [],
+    requiredClientFields = [],
+    ...rest
+  } = {}) {
     if (!appId) throw new Error('Unable to configure IdentityX: no Application ID was provided.');
     this.appId = appId;
-    this.options = options && typeof options === 'object' ? options : {};
+    this.options = {
+      requiredServerFields,
+      requiredClientFields,
+      ...rest,
+    };
 
     this.endpointTypes = ['authenticate', 'login', 'logout', 'register', 'profile'];
     this.hooks = {

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -8,17 +8,20 @@ class IdentityXConfiguration {
    *
    * @param {object} options
    * @param {string} options.appId The application ID to use.
+   * @param {string} [options.apiToken] An API token to use. Only required when doing write ops.
    * @param {string[]} [options.requiredServerFields] Required fields, server enforced.
    * @param {string[]} [options.requiredClientFields] Required fields, client-side only.
    */
   constructor({
     appId,
+    apiToken,
     requiredServerFields = [],
     requiredClientFields = [],
     ...rest
   } = {}) {
     if (!appId) throw new Error('Unable to configure IdentityX: no Application ID was provided.');
     this.appId = appId;
+    this.apiToken = apiToken;
     this.options = {
       requiredServerFields,
       requiredClientFields,
@@ -48,6 +51,10 @@ class IdentityXConfiguration {
 
   getAppId() {
     return this.appId;
+  }
+
+  getApiToken() {
+    return this.apiToken;
   }
 
   getEndpointFor(type) {

--- a/packages/marko-web-identity-x/package.json
+++ b/packages/marko-web-identity-x/package.json
@@ -15,6 +15,7 @@
     "@parameter1/base-cms-utils": "^2.4.2",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",
+    "apollo-link-context": "^1.0.20",
     "apollo-link-http": "^1.5.17",
     "body-parser": "^1.19.0",
     "cookie": "0.3.1",

--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -31,7 +31,7 @@ module.exports = asyncRoute(async (req, res) => {
   const { token: authToken, user } = data.loginAppUser;
 
   // call authentication hooks
-  await callHooksFor(identityX, 'onAuthenticationSuccess', { user, authToken });
+  await callHooksFor(identityX, 'onAuthenticationSuccess', { req, user, authToken });
   tokenCookie.setTo(res, authToken.value);
   res.json({ ok: true, user });
 });

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -23,6 +23,11 @@ class IdentityX {
     });
   }
 
+  /**
+   * Loads the current application, user, and team context.
+   *
+   * @returns {Promise<object>}
+   */
   async loadActiveContext() {
     if (!this.activeContextQuery) {
       this.activeContextQuery = this.client.query({ query: getActiveContext });
@@ -31,6 +36,12 @@ class IdentityX {
     return data.activeAppContext || {};
   }
 
+  /**
+   * Checks whether the current user can access the given content.
+   *
+   * @param {object} input
+   * @returns {Promise<object>}
+   */
   async checkContentAccess(input) {
     const variables = { input };
     const { data = {} } = await this.client.query({ query: checkContentAccess, variables });

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -1,6 +1,7 @@
 const createClient = require('./utils/create-client');
 const getActiveContext = require('./api/queries/get-active-context');
 const checkContentAccess = require('./api/queries/check-content-access');
+const addExternalUserId = require('./api/mutations/add-external-user-id');
 const tokenCookie = require('./utils/token-cookie');
 
 const isEmpty = v => v == null || v === '';
@@ -75,6 +76,28 @@ class IdentityX {
       }
     }
     return access;
+  }
+
+  /**
+   *
+   * @param {object} params
+   * @returns {Promise<object>}
+   */
+  async addExternalUserId({
+    userId,
+    identifier = {},
+    namespace = {},
+  } = {}) {
+    const input = { userId, identifier, namespace };
+    const apiToken = this.config.getApiToken();
+    if (!apiToken) throw new Error('Unable to add external ID: No API token has been configured.');
+    const variables = { input };
+    const { data } = await this.client.mutate({
+      mutation: addExternalUserId,
+      variables,
+      context: { apiToken },
+    });
+    return data.addAppUserExternalId;
   }
 }
 

--- a/packages/marko-web-identity-x/utils/create-client.js
+++ b/packages/marko-web-identity-x/utils/create-client.js
@@ -28,7 +28,7 @@ module.exports = ({
 
   const httpLink = createHttpLink({
     ...linkConfig,
-    uri: process.env.IDENTITYX_GRAPHQL_URI || 'https://identity-x.io/graphql',
+    uri: process.env.IDENTITYX_GRAPHQL_URI || 'https://identity-x.parameter1.com/graphql',
     fetch,
     headers,
   });

--- a/packages/marko-web-identity-x/utils/create-client.js
+++ b/packages/marko-web-identity-x/utils/create-client.js
@@ -2,6 +2,7 @@ const fetch = require('node-fetch');
 const { ApolloClient } = require('apollo-client');
 const { InMemoryCache } = require('apollo-cache-inmemory');
 const { createHttpLink } = require('apollo-link-http');
+const { setContext } = require('apollo-link-context');
 
 const rootConfig = {
   connectToDevTools: false,
@@ -25,15 +26,20 @@ module.exports = ({
   };
   if (token) headers.authorization = `AppUser ${token}`;
 
+  const httpLink = createHttpLink({
+    ...linkConfig,
+    uri: process.env.IDENTITYX_GRAPHQL_URI || 'https://identity-x.io/graphql',
+    fetch,
+    headers,
+  });
+  const contextLink = setContext((_, { apiToken }) => ({
+    headers: { ...(apiToken && { authorization: `OrgUserApiToken ${apiToken}` }) },
+  }));
+
   return new ApolloClient({
     ...config,
     ...rootConfig,
-    link: createHttpLink({
-      ...linkConfig,
-      uri: process.env.IDENTITYX_GRAPHQL_URI || 'https://identity-x.io/graphql',
-      fetch,
-      headers,
-    }),
+    link: contextLink.concat(httpLink),
     cache: new InMemoryCache(),
   });
 };


### PR DESCRIPTION
An `addExternalUserId` method was added to the core IdentityX service for adding external IDs to a user. In order to use this method, the `apiToken` must be set when the service's configuration is constructed.