### PR TITLE
Create Omeda+IdentityX Rapid Identification Router

### DIFF
--- a/packages/marko-web-omeda-identity-x/package.json
+++ b/packages/marko-web-omeda-identity-x/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@parameter1/base-cms-object-path": "^2.5.0",
+    "@parameter1/base-cms-utils": "^2.4.2",
     "graphql": "^14.7.0",
     "graphql-tag": "^2.11.0"
   },

--- a/packages/marko-web-omeda-identity-x/package.json
+++ b/packages/marko-web-omeda-identity-x/package.json
@@ -17,7 +17,9 @@
     "graphql-tag": "^2.11.0"
   },
   "peerDependencies": {
-    "@parameter1/base-cms-marko-web-identity-x": "^2.16.0"
+    "@parameter1/base-cms-marko-web": "^2.13.0",
+    "@parameter1/base-cms-marko-web-identity-x": "^2.16.0",
+    "express": "^4.17.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/marko-web-omeda-identity-x/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/rapid-identify.js
@@ -88,4 +88,5 @@ module.exports = async ({
       namespace,
     }),
   ]);
+  return { id, encryptedCustomerId };
 };

--- a/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
@@ -1,0 +1,40 @@
+const { Router } = require('express');
+const { getAsObject } = require('@parameter1/base-cms-object-path');
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const jsonErrorHandler = require('@parameter1/base-cms-marko-web/express/json-error-handler');
+const omedaRapidIdentityX = require('../rapid-identify');
+const findOmedaEncryptedId = require('../utils/find-omeda-encrypted-id');
+
+module.exports = ({ brandKey, productId } = {}) => {
+  if (!brandKey) throw new Error('An Omeda brand key is required to use this middleware.');
+  if (!productId) throw new Error('An Omeda rapid identification product ID is required to use this middleware.');
+  const router = Router();
+  router.get('/', asyncRoute(async (req, res) => {
+    const data = { encryptedId: null, source: null };
+    const { identityX } = req;
+    const context = await identityX.loadActiveContext();
+    const user = getAsObject(context, 'user');
+    if (!user.id) return res.json(data);
+    // determine if an encrypted ID already exists for this user and brand.
+    const encryptedId = findOmedaEncryptedId({ externalIds: user.externalIds, brandKey });
+    if (encryptedId) {
+      data.encryptedId = encryptedId;
+      data.source = 'existing';
+    } else {
+      // no omeda identifier found for this user, rapidly identify.
+      const { encryptedCustomerId } = await omedaRapidIdentityX({
+        brandKey,
+        productId,
+        appUser: user,
+        identityX,
+        omedaGraphQL: req.$omeda,
+      });
+      data.encryptedId = encryptedCustomerId;
+      data.source = 'new';
+    }
+    return res.json(data);
+  }));
+
+  router.use(jsonErrorHandler());
+  return router;
+};

--- a/packages/marko-web-omeda-identity-x/utils/find-omeda-encrypted-id.js
+++ b/packages/marko-web-omeda-identity-x/utils/find-omeda-encrypted-id.js
@@ -1,0 +1,13 @@
+const { asArray } = require('@parameter1/base-cms-utils');
+
+module.exports = ({ externalIds = [], brandKey } = {}) => {
+  const externalId = asArray(externalIds).find((eid) => {
+    const { namespace, identifier } = eid;
+    return namespace.provider === 'omeda'
+      && namespace.tenant === brandKey.toLowerCase()
+      && namespace.type === 'customer'
+      && identifier.type === 'encrypted'
+      && identifier.value;
+  });
+  return externalId ? externalId.identifier.value : null;
+};


### PR DESCRIPTION
Can be used by a website to mount a JSON endpoint for rapidly identifying the active IdentityX user (if present).

If the Omeda ID for the configured brand is already set on the IdentityX user, the value will simply be passed through. If not set, the "rapid identification dance" is initiated.