### PR TITLE
Add support for pseudo-SSR of Vue components

### DIFF
--- a/packages/marko-web/browser/index.js
+++ b/packages/marko-web/browser/index.js
@@ -16,6 +16,7 @@ const load = async ({
   name,
   props,
   on,
+  hydrate,
 } = {}) => {
   if (!el || !name) throw new Error('A Vue component name and element must be provided.');
   const Component = components[name];
@@ -25,12 +26,12 @@ const load = async ({
     const { default: provider } = await apollo();
     apolloProvider = provider;
   }
-  new Vue({
+  const component = new Vue({
     provide: providers[name],
-    el,
     apolloProvider,
     render: h => h(Component, { props, on: { ...on, ...listeners[name] } }),
   });
+  component.$mount(el, hydrate);
 };
 
 const register = async (name, Component, { provide, withApollo, on } = {}) => {

--- a/packages/marko-web/components/browser-component.marko
+++ b/packages/marko-web/components/browser-component.marko
@@ -1,12 +1,13 @@
-import { randomElementId } from '@parameter1/base-cms-utils';
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { randomElementId } from "@parameter1/base-cms-utils";
 
 $ const id = randomElementId({ prefix: 'vue' });
+$ const tag = defaultValue(input.tag, "div");
+$ const hydrate = defaultValue(input.hydrate, false);
 $ const props = JSON.stringify(input.props || {});
-$ const contents = `<script>CMSBrowserComponents.loadComponent('#${id}', '${input.name}', ${props});</script>`;
+$ const contents = `CMSBrowserComponents.load({ el: '#${id}', name: '${input.name}', props: ${props}, hydrate: ${hydrate} });`;
 
-<div id=id>
-  <if(input.renderBody)>
-    <${input.renderBody} />
-  </if>
-  $!{contents}
-</div>
+<${tag} ...input.attrs id=id class=input.class>
+  <${input.renderBody} />
+</>
+<script>$!{contents}</script>

--- a/packages/marko-web/components/marko.json
+++ b/packages/marko-web/components/marko.json
@@ -15,6 +15,10 @@
       "type": "string",
       "required": true
     },
+    "@hydrate": "boolean",
+    "@tag": "string",
+    "@class": "string",
+    "@attrs": "object",
     "@props": "object"
   }
 }


### PR DESCRIPTION
The resulting HTML from `<marko-web-browser-component>` can now be customized. The HTML tag, the class, and any other element attributes can be passed to change the rendered output. In addition, if the `hydrate` prop is set to the `true`, the Vue instance will hydrate the component instead of replacing it. For this to work, the HTML rendered on the server must match the expected HTML of the Vue component, otherwise Vue will throw a warning. This allows for "pseudo" server-side rendering of Vue components, whereby hydration results in _attaching_ the Vue instance to the existing DOM elements instead of _recreating_ them. This is handy for visual elements where a "flicker" would be detrimental, such as navigation buttons.

While this isn't true SSR, it will serve as a stop-gap until further SRR features can be evaluated.