### PR TITLE
Update to elements that appear on the leaders page

### DIFF
--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -5,7 +5,10 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-group">
-          <form-label id="inquiry-form.first-name" :required="true">
+          <form-label v-if="labels.firstName" id="inquiry-form.first-name" :required="true">
+            {{ labels.firstName }}
+          </form-label>
+          <form-label v-else id="inquiry-form.first-name" :required="true">
             First Name
           </form-label>
           <input
@@ -20,7 +23,10 @@
       </div>
       <div class="col-md-6">
         <div class="form-group">
-          <form-label id="inquiry-form.last-name" :required="true">
+          <form-label v-if="labels.lastName" id="inquiry-form.last-name" :required="true">
+            {{ labels.lastName }}
+          </form-label>
+          <form-label v-else id="inquiry-form.last-name" :required="true">
             Last Name
           </form-label>
           <input
@@ -37,7 +43,10 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-group">
-          <form-label id="inquiry-form.email" :required="true">
+          <form-label v-if="labels.email" id="inquiry-form.email" :required="true">
+            {{ labels.email }}
+          </form-label>
+          <form-label v-else id="inquiry-form.email" :required="true">
             Email Address
           </form-label>
           <input
@@ -52,7 +61,10 @@
       </div>
       <div class="col-md-6">
         <div class="form-group">
-          <form-label id="inquiry-form.phone">
+          <form-label v-if="labels.phone" id="inquiry-form.phone">
+            {{ labels.phone }}
+          </form-label>
+          <form-label v-else id="inquiry-form.phone">
             Phone Number
           </form-label>
           <input
@@ -68,7 +80,10 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-group">
-          <form-label id="inquiry-form.company">
+          <form-label v-if="labels.company" id="inquiry-form.company">
+            {{ labels.company }}
+          </form-label>
+          <form-label v-else id="inquiry-form.company">
             Company Name
           </form-label>
           <input
@@ -82,7 +97,10 @@
       </div>
       <div class="col-md-6">
         <div class="form-group">
-          <form-label id="inquiry-form.job-title" :required="true">
+          <form-label v-if="labels.jobTitle" id="inquiry-form.job-title" :required="true">
+            {{ labels.jobTitle }}
+          </form-label>
+          <form-label v-else id="inquiry-form.job-title" :required="true">
             Job Title
           </form-label>
           <input
@@ -98,11 +116,19 @@
     </div>
     <div class="row">
       <div class="col-md-6">
-        <country-field v-model="country" :required="true" />
+        <country-field
+          v-model="country"
+          :required="true"
+          :label="labels.country"
+          :place-holder="labels.countryPlaceholder"
+        />
       </div>
       <div class="col-md-6">
         <div class="form-group">
-          <form-label id="inquiry-form.postal-code">
+          <form-label v-if="labels.zip" id="inquiry-form.postal-code">
+            {{ labels.zip }}
+          </form-label>
+          <form-label v-else id="inquiry-form.postal-code">
             ZIP/Postal Code
           </form-label>
           <input
@@ -118,7 +144,10 @@
     <div class="row">
       <div class="col-12">
         <div class="form-group">
-          <form-label id="inquiry-form.comments">
+          <form-label v-if="labels.comments" id="inquiry-form.comments">
+            {{ labels.comments }}
+          </form-label>
+          <form-label v-else id="inquiry-form.comments">
             Comments
           </form-label>
           <textarea
@@ -139,7 +168,20 @@
       @verify="onVerify"
       @expired="onExpired"
     />
-    <button type="submit" class="btn btn-primary" :disabled="loading">
+    <button
+      v-if="labels.submit"
+      type="submit"
+      class="btn btn-primary"
+      :disabled="loading"
+    >
+      {{ labels.submit }}
+    </button>
+    <button
+      v-else
+      type="submit"
+      class="btn btn-primary"
+      :disabled="loading"
+    >
       Submit
     </button>
   </form>
@@ -168,6 +210,11 @@ export default {
     sitekey: {
       type: String,
       required: true,
+    },
+    labels: {
+      type: Object,
+      required: false,
+      default: null,
     },
   },
   data: () => ({

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -5,11 +5,8 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-group">
-          <form-label v-if="labels.firstName" id="inquiry-form.first-name" :required="true">
+          <form-label id="inquiry-form.first-name" :required="true">
             {{ labels.firstName }}
-          </form-label>
-          <form-label v-else id="inquiry-form.first-name" :required="true">
-            First Name
           </form-label>
           <input
             id="inquiry-form.first-name"
@@ -23,11 +20,8 @@
       </div>
       <div class="col-md-6">
         <div class="form-group">
-          <form-label v-if="labels.lastName" id="inquiry-form.last-name" :required="true">
+          <form-label id="inquiry-form.last-name" :required="true">
             {{ labels.lastName }}
-          </form-label>
-          <form-label v-else id="inquiry-form.last-name" :required="true">
-            Last Name
           </form-label>
           <input
             id="inquiry-form.last-name"
@@ -43,11 +37,8 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-group">
-          <form-label v-if="labels.email" id="inquiry-form.email" :required="true">
+          <form-label id="inquiry-form.email" :required="true">
             {{ labels.email }}
-          </form-label>
-          <form-label v-else id="inquiry-form.email" :required="true">
-            Email Address
           </form-label>
           <input
             id="inquiry-form.email"
@@ -61,11 +52,8 @@
       </div>
       <div class="col-md-6">
         <div class="form-group">
-          <form-label v-if="labels.phone" id="inquiry-form.phone">
+          <form-label id="inquiry-form.phone">
             {{ labels.phone }}
-          </form-label>
-          <form-label v-else id="inquiry-form.phone">
-            Phone Number
           </form-label>
           <input
             id="inquiry-form.phone"
@@ -80,11 +68,8 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-group">
-          <form-label v-if="labels.company" id="inquiry-form.company">
+          <form-label id="inquiry-form.company">
             {{ labels.company }}
-          </form-label>
-          <form-label v-else id="inquiry-form.company">
-            Company Name
           </form-label>
           <input
             id="inquiry-form.company"
@@ -97,11 +82,8 @@
       </div>
       <div class="col-md-6">
         <div class="form-group">
-          <form-label v-if="labels.jobTitle" id="inquiry-form.job-title" :required="true">
+          <form-label id="inquiry-form.job-title" :required="true">
             {{ labels.jobTitle }}
-          </form-label>
-          <form-label v-else id="inquiry-form.job-title" :required="true">
-            Job Title
           </form-label>
           <input
             id="inquiry-form.job-title"
@@ -125,11 +107,8 @@
       </div>
       <div class="col-md-6">
         <div class="form-group">
-          <form-label v-if="labels.zip" id="inquiry-form.postal-code">
+          <form-label id="inquiry-form.postal-code">
             {{ labels.zip }}
-          </form-label>
-          <form-label v-else id="inquiry-form.postal-code">
-            ZIP/Postal Code
           </form-label>
           <input
             id="inquiry-form.postal-code"
@@ -144,11 +123,8 @@
     <div class="row">
       <div class="col-12">
         <div class="form-group">
-          <form-label v-if="labels.comments" id="inquiry-form.comments">
+          <form-label  id="inquiry-form.comments">
             {{ labels.comments }}
-          </form-label>
-          <form-label v-else id="inquiry-form.comments">
-            Comments
           </form-label>
           <textarea
             id="inquiry-form.comments"
@@ -169,20 +145,11 @@
       @expired="onExpired"
     />
     <button
-      v-if="labels.submit"
       type="submit"
       class="btn btn-primary"
       :disabled="loading"
     >
       {{ labels.submit }}
-    </button>
-    <button
-      v-else
-      type="submit"
-      class="btn btn-primary"
-      :disabled="loading"
-    >
-      Submit
     </button>
   </form>
   <div v-else>
@@ -214,7 +181,7 @@ export default {
     labels: {
       type: Object,
       required: false,
-      default: null,
+      default: this.setDefaultLabels(),
     },
   },
   data: () => ({
@@ -270,6 +237,21 @@ export default {
 
       await this.$submit(payload);
       this.EventBus.$emit('inquiry-form-submit', { contentId, contentType, payload });
+    },
+    setDefaultLabels() {
+      return {
+        firstName: 'First Name',
+        lastName: 'Last Name',
+        email: 'Email Address',
+        phone: 'Phone Number',
+        company: 'Company Name',
+        jobTitle: 'Job Title',
+        country: 'Country',
+        countryPlaceholder: 'Select country...',
+        postalCode: 'ZIP/Postal Code',
+        comments: 'Comments',
+        submit: 'Submit',
+      };
     },
   },
 };

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -123,7 +123,7 @@
     <div class="row">
       <div class="col-12">
         <div class="form-group">
-          <form-label  id="inquiry-form.comments">
+          <form-label id="inquiry-form.comments">
             {{ labels.comments }}
           </form-label>
           <textarea

--- a/packages/marko-web-inquiry/browser/fields/country.vue
+++ b/packages/marko-web-inquiry/browser/fields/country.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="form-group">
     <form-label id="inquiry-form.country" :required="required">
-      Country
+      {{ label }}
     </form-label>
     <select
       id="inquiry-form.country"
@@ -13,7 +13,7 @@
       @change="$emit('input', $event.target.value)"
     >
       <option disabled="disabled" value="">
-        Select country...
+        {{ placeHolder }}
       </option>
       <option value="US">
         United States of America 🇺🇸
@@ -783,6 +783,14 @@ export default {
     required: {
       type: Boolean,
       default: false,
+    },
+    label: {
+      type: String,
+      default: 'Country',
+    },
+    placeHolder: {
+      type: String,
+      default: 'Select country...',
     },
   },
 };

--- a/packages/marko-web-inquiry/components/form.marko
+++ b/packages/marko-web-inquiry/components/form.marko
@@ -10,6 +10,7 @@ $ const withDescription = defaultValue(input.withDescription, true);
 
 $ const blockName = "inquiry-form";
 $ const { RECAPTCHA_SITE_KEY } = require('../env');
+$ const props = getAsObject(input, "props")
 
 <if(inquiry.enabled)>
   <marko-web-block name=blockName modifiers=input.modifiers>
@@ -37,7 +38,8 @@ $ const { RECAPTCHA_SITE_KEY } = require('../env');
       formClass: `${blockName}__form`,
       contentId: content.id,
       contentType: content.type,
-      sitekey: RECAPTCHA_SITE_KEY
+      sitekey: RECAPTCHA_SITE_KEY,
+      labels: props
     } />
   </marko-web-block>
 </if>

--- a/packages/marko-web-leaders/browser/company-social-link.vue
+++ b/packages/marko-web-leaders/browser/company-social-link.vue
@@ -47,6 +47,11 @@ export default {
       type: String,
       required: true,
     },
+    socialMediaLabel: {
+      type: String,
+      required: false,
+      default: 'Visit us on',
+    },
   },
   data: () => ({
     modifiers: ['dark', 'lg'],
@@ -56,7 +61,7 @@ export default {
       return `icon-${this.provider}`;
     },
     title() {
-      return `Visit us on ${this.provider.charAt(0).toUpperCase()}${this.provider.slice(1)}`;
+      return `${this.socialMediaLabel} ${this.provider.charAt(0).toUpperCase()}${this.provider.slice(1)}`;
     },
   },
   methods: {

--- a/packages/marko-web-leaders/browser/company-website-link.vue
+++ b/packages/marko-web-leaders/browser/company-website-link.vue
@@ -7,7 +7,7 @@
     rel="nofollow"
     @click="emitAction"
   >
-    Visit Site
+    {{ label }}
   </a>
 </template>
 
@@ -25,6 +25,11 @@ export default {
     href: {
       type: String,
       required: true,
+    },
+    label: {
+      type: String,
+      required: false,
+      default: 'Visit Site',
     },
   },
   methods: {

--- a/packages/marko-web-leaders/components/company-social-link.marko
+++ b/packages/marko-web-leaders/components/company-social-link.marko
@@ -2,11 +2,13 @@ import { get, getAsObject } from "@parameter1/base-cms-object-path";
 
 $ const { id, name } = getAsObject(input, "company");
 $ const { url: href, label, provider } = getAsObject(input, "item");
+$ const socialMediaLabel = (input, 'label')
 $ const props = {
   companyId: id,
   companyName: name,
   href,
   provider,
+  socialMediaLabel
 };
 
 <marko-web-browser-component name="LeadersCompanySocialLink" props=props />

--- a/packages/marko-web-leaders/components/company-website-link.marko
+++ b/packages/marko-web-leaders/components/company-website-link.marko
@@ -2,7 +2,8 @@ import { get, getAsObject } from "@parameter1/base-cms-object-path";
 
 $ const { id, name } = getAsObject(input, "company");
 $ const href = get(input, "company.website");
-$ const props = { companyId: id, companyName: name, href };
+$ const label = get(input, "label")
+$ const props = { companyId: id, companyName: name, href, label };
 
 <if(href)>
   <marko-web-browser-component name="LeadersCompanyWebsiteLink" props=props />

--- a/packages/marko-web-leaders/components/marko.json
+++ b/packages/marko-web-leaders/components/marko.json
@@ -5,11 +5,13 @@
   "<marko-web-leaders-company-social-link>": {
     "template": "./company-social-link.marko",
     "@company": "object",
-    "@item": "object"
+    "@item": "object",
+    "@label": "string"
   },
   "<marko-web-leaders-company-website-link>": {
     "template": "./company-website-link.marko",
-    "@company": "object"
+    "@company": "object",
+    "@label": "string"
   },
   "<marko-web-leaders-dropdown-portal>": {
     "template": "./dropdown-portal.marko"

--- a/packages/marko-web-theme-default/components/content/contact-details/index.marko
+++ b/packages/marko-web-theme-default/components/content/contact-details/index.marko
@@ -19,6 +19,8 @@ $ const showFields = fields.some(k => content[k]);
 $ const websiteLinkAttrs = getAsObject(input, "websiteLinkAttrs");
 $ const socialLinkAttrs = getAsObject(input, "socialLinkAttrs");
 
+$ const labels = getAsObject(input, "labels")
+
 <default-theme-page-contact-details|{ blockName }|
   tag=input.tag
   class=input.class
@@ -64,19 +66,34 @@ $ const socialLinkAttrs = getAsObject(input, "socialLinkAttrs");
     <default-theme-content-contact-details-section block-name=blockName>
       <if(content.phone)>
         <div class=`${blockName}__field`>
-          <span class=`${blockName}__label`>Phone:</span>
+          <if(labels.phone)>
+            <span class=`${blockName}__label`>${labels.phone}:</span>
+          </if>
+          <else>
+            <span class=`${blockName}__label`>Phone:</span>
+          </else>
           <marko-web-content-phone block-name=blockName obj=content />
         </div>
       </if>
       <if(content.mobile)>
         <div class=`${blockName}__field`>
-          <span class=`${blockName}__label`>Mobile:</span>
+          <if (labels.mobile)>
+            <span class=`${blockName}__label`>${labels.mobile}:</span>
+          </if>
+          <else>
+            <span class=`${blockName}__label`>Mobile:</span>
+          </else>
           <marko-web-content-mobile block-name=blockName obj=content />
         </div>
       </if>
       <if(content.tollfree)>
         <div class=`${blockName}__field`>
+          <if (labels.tollFree)>
+            <span class=`${blockName}__label`>${labels.tollFree}:</span>
+          </if>
+          <else>
           <span class=`${blockName}__label`>Toll Free:</span>
+          </else>
           <marko-web-content-tollfree block-name=blockName obj=content />
         </div>
       </if>

--- a/packages/marko-web-theme-default/components/content/contact-details/index.marko
+++ b/packages/marko-web-theme-default/components/content/contact-details/index.marko
@@ -19,7 +19,14 @@ $ const showFields = fields.some(k => content[k]);
 $ const websiteLinkAttrs = getAsObject(input, "websiteLinkAttrs");
 $ const socialLinkAttrs = getAsObject(input, "socialLinkAttrs");
 
-$ const labels = getAsObject(input, "labels")
+$ const labels = {
+  phone: "Phone",
+  mobile: "Mobile",
+  tollFree: "Toll Free",
+  fax: "Fax",
+  ...input.labels,
+}
+
 
 <default-theme-page-contact-details|{ blockName }|
   tag=input.tag
@@ -66,40 +73,25 @@ $ const labels = getAsObject(input, "labels")
     <default-theme-content-contact-details-section block-name=blockName>
       <if(content.phone)>
         <div class=`${blockName}__field`>
-          <if(labels.phone)>
             <span class=`${blockName}__label`>${labels.phone}:</span>
-          </if>
-          <else>
-            <span class=`${blockName}__label`>Phone:</span>
-          </else>
           <marko-web-content-phone block-name=blockName obj=content />
         </div>
       </if>
       <if(content.mobile)>
         <div class=`${blockName}__field`>
-          <if (labels.mobile)>
             <span class=`${blockName}__label`>${labels.mobile}:</span>
-          </if>
-          <else>
-            <span class=`${blockName}__label`>Mobile:</span>
-          </else>
           <marko-web-content-mobile block-name=blockName obj=content />
         </div>
       </if>
       <if(content.tollfree)>
         <div class=`${blockName}__field`>
-          <if (labels.tollFree)>
-            <span class=`${blockName}__label`>${labels.tollFree}:</span>
-          </if>
-          <else>
-          <span class=`${blockName}__label`>Toll Free:</span>
-          </else>
+          <span class=`${blockName}__label`>${labels.tollFree}:</span>
           <marko-web-content-tollfree block-name=blockName obj=content />
         </div>
       </if>
       <if(content.fax)>
         <div class=`${blockName}__field`>
-          <span class=`${blockName}__label`>Fax:</span>
+          <span class=`${blockName}__label`>${labels.fax}:</span>
           <marko-web-content-fax block-name=blockName obj=content />
         </div>
       </if>

--- a/packages/marko-web-theme-default/components/content/contact-details/marko.json
+++ b/packages/marko-web-theme-default/components/content/contact-details/marko.json
@@ -14,7 +14,8 @@
     "@modifiers": "array",
     "@attrs": "object",
     "@website-link-attrs": "object",
-    "@social-link-attrs": "object"
+    "@social-link-attrs": "object",
+    "@labels": "object"
   },
   "<default-theme-content-contact-details-section>": {
     "template": "./section.marko",


### PR DESCRIPTION

<img width="1920" alt="Screen Shot 2021-05-20 at 10 21 53 AM" src="https://user-images.githubusercontent.com/46794001/119005728-54bd8f80-b955-11eb-89b1-76131137b3cb.png">

This is done in order to properly translate all elements on the leaders/companies page(s) in Mundo.