### PR TITLE
Use "now" for `unpublished` date criteria

### DIFF
--- a/packages/utils/src/get-published-content-criteria.js
+++ b/packages/utils/src/get-published-content-criteria.js
@@ -10,7 +10,8 @@ module.exports = ({
   after,
   primarySite,
 } = {}) => {
-  const date = since || new Date();
+  const now = new Date();
+  const date = since || now;
   const types = isArray(contentTypes) && contentTypes.length
     ? contentTypes : getDefaultContentTypes();
 
@@ -30,7 +31,7 @@ module.exports = ({
     $and: [
       {
         $or: [
-          { unpublished: { $gt: date } },
+          { unpublished: { $gt: now } },
           { unpublished: { $exists: false } },
         ],
       },


### PR DESCRIPTION
It was using since if set, but it should always use now. Content can be queried with publishedDate between two dates, but unpublished should always be before now.