### PR TITLE
Add Ability to add days, and Labels  params to SitemapUrlsQuery

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -296,7 +296,10 @@ input ContentSitemapNewsUrlsQueryInput {
   siteId: ObjectID
   includeContentTypes: [ContentType!] = [News, PressRelease, Blog]
   excludeContentTypes: [ContentType!] = []
+  days: Int = 2
   taxonomyIds: [Int!] = []
+  includeLabels: [String!] = []
+  excludeLabels: [String!] = []
 }
 
 input AllPublishedContentQueryInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -860,15 +860,25 @@ module.exports = {
       const {
         includeContentTypes,
         excludeContentTypes,
+        days,
         taxonomyIds,
+        includeLabels,
+        excludeLabels,
       } = input;
       const query = getPublishedCriteria({
         contentTypes: includeContentTypes,
         excludeContentTypes,
       });
 
-      query.$and.push({ published: { $gte: moment().subtract(2, 'days').toDate() } });
+      query.$and.push({ published: { $gte: moment().subtract(days, 'days').toDate() } });
       if (taxonomyIds.length) query['taxonomy.$id'] = { $in: taxonomyIds };
+
+      if (includeLabels.length && excludeLabels.length) {
+        query.labels = { $in: includeLabels, $nin: excludeLabels };
+      } else {
+        if (includeLabels.length) query.labels = { $in: includeLabels };
+        if (excludeLabels.length) query.labels = { $nin: excludeLabels };
+      }
 
       const siteId = input.siteId || site.id();
       if (siteId) query['mutations.Website.primarySite'] = siteId;


### PR DESCRIPTION
Add this ability to adjust how many days it rolls back instead of being forces to 2 days.
Add the ability to exclude content with specific labels(Sponsored)

Example use is : https://github.com/parameter1/randall-reilly-websites/pull/239

<img width="1848" alt="Screen Shot 2021-06-08 at 8 35 45 AM" src="https://user-images.githubusercontent.com/3845869/121194660-90e95f00-c834-11eb-9e04-8eece9d7f7b4.png">
