### PR TITLE
Add missing lock file dependencies and freeze on build/deploy

### DIFF
--- a/services/google-data-api/Dockerfile
+++ b/services/google-data-api/Dockerfile
@@ -3,7 +3,7 @@ ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms
 
-RUN yarn --production
+RUN yarn --production --frozen-lockfile
 
 WORKDIR /base-cms/services/google-data-api
 ENTRYPOINT [ "node", "src/index.js" ]

--- a/services/graphql-server/Dockerfile
+++ b/services/graphql-server/Dockerfile
@@ -3,7 +3,7 @@ ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms
 
-RUN yarn --production
+RUN yarn --production --frozen-lockfile
 
 WORKDIR /base-cms/services/graphql-server
 ENTRYPOINT [ "node", "src/index.js" ]

--- a/services/hooks/Dockerfile
+++ b/services/hooks/Dockerfile
@@ -3,7 +3,7 @@ ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms
 
-RUN yarn --production
+RUN yarn --production --frozen-lockfile
 
 WORKDIR /base-cms/services/hooks
 ENTRYPOINT [ "node", "src/index.js" ]

--- a/services/oembed/Dockerfile
+++ b/services/oembed/Dockerfile
@@ -3,7 +3,7 @@ ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms
 
-RUN yarn --production
+RUN yarn --production --frozen-lockfile
 
 WORKDIR /base-cms/services/oembed
 ENTRYPOINT [ "node", "src/index.js" ]

--- a/services/omail-link-processor/Dockerfile
+++ b/services/omail-link-processor/Dockerfile
@@ -3,7 +3,7 @@ ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms
 
-RUN yarn --production --pure-lockfile
+RUN yarn --production --frozen-lockfile
 
 WORKDIR /base-cms/services/omail-link-processor
 ENTRYPOINT [ "node", "src/index.js" ]

--- a/services/rss/Dockerfile
+++ b/services/rss/Dockerfile
@@ -3,7 +3,7 @@ ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms
 
-RUN yarn --production
+RUN yarn --production --frozen-lockfile
 
 WORKDIR /base-cms/services/rss
 ENTRYPOINT [ "node", "src/index.js" ]

--- a/services/sitemaps/Dockerfile
+++ b/services/sitemaps/Dockerfile
@@ -3,7 +3,7 @@ ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms
 
-RUN yarn --production
+RUN yarn --production --frozen-lockfile
 
 WORKDIR /base-cms/services/sitemaps
 ENTRYPOINT [ "node", "src/index.js" ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9093,6 +9093,13 @@ graphql-subscriptions@^1.0.0:
   dependencies:
     iterall "^1.2.1"
 
+graphql-tag@^2.10.1:
+  version "2.12.4"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.4.tgz#d34066688a4f09e72d6f4663c74211e9b4b7c4bf"
+  integrity sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==
+  dependencies:
+    tslib "^2.1.0"
+
 graphql-tag@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
@@ -9161,7 +9168,7 @@ graphql@^14.5.3:
   dependencies:
     iterall "^1.2.2"
 
-graphql@^14.7.0:
+graphql@^14.5.4, graphql@^14.7.0:
   version "14.7.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
   integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
@@ -17326,6 +17333,11 @@ tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslib@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
At some point, some added dependencies were not install properly, triggering a Yarn lockfile update. The Dockerfiles for all services were updated to freeze the lock file in order to trigger an error if this happens again.