### PR TITLE
Add `ContentVideo.embedSrc` field

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/types/video.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/video.js
@@ -14,6 +14,9 @@ type ContentVideo implements Content & Authorable & Media @applyInterfaceFields 
   embedCode: String @projection
   sourceId: String @projection
   sourceThumbnail: String @projection
+
+  # graphql only fields
+  embedSrc: String @projection(localField: "embedCode")
 }
 
 type ContentVideoConnection {


### PR DESCRIPTION
Attempts to parse the `embedCode` HTML for an embeddable video `src` value. Will first generically handle the presence of an `iframe` and then fall back to parsing Brightcove videos.