### PR TITLE
Add database support for setting `noindex` on content pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
       EXPOSED_PORT: 10101
     depends_on:
       - mongodb
+      - redis
       - google-data-api
     ports:
       - "10101:80"
@@ -160,6 +161,7 @@ services:
       EXPOSED_PORT: 10102
     depends_on:
       - mongodb
+      - redis
       - google-data-api
     ports:
       - "10102:80"

--- a/packages/marko-web/components/page/metadata/components/common.marko
+++ b/packages/marko-web/components/page/metadata/components/common.marko
@@ -5,6 +5,7 @@ $ const {
   canonicalUrl,
   imageSrc,
   description,
+  noIndex,
 } = input;
 $ const fallbackImage = config.fallbackImage();
 $ const image = imageSrc || fallbackImage;
@@ -13,6 +14,11 @@ $ const image = imageSrc || fallbackImage;
 <marko-web-page-title value=title />
 <marko-web-page-description value=description />
 <marko-web-page-rel-canonical path=canonicalPath url=canonicalUrl />
+
+<!-- No Index Directive -->
+<if(noIndex)>
+  <meta name="robots" content="noindex">
+</if>
 
 <!-- Name/Title (OpenGrah, and Schema.org respectively) -->
 <if(title)>

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -13,6 +13,7 @@ fragment ContentPageMetadataFragment on Content {
   siteContext {
     path
     canonicalUrl
+    noIndex
   }
   published
   updated
@@ -59,6 +60,7 @@ fragment ContentPageMetadataFragment on Content {
       description: get(node, "metadata.description"),
       canonicalPath: get(node, "siteContext.path"),
       canonicalUrl: get(node, "siteContext.canonicalUrl"),
+      noIndex: get(node, "siteContext.noIndex"),
       imageSrc: get(node, "metadata.image.src"),
     };
     $ const publishedDate = get(node, "metadata.publishedDate");

--- a/packages/marko-web/components/page/metadata/dynamic-page.marko
+++ b/packages/marko-web/components/page/metadata/dynamic-page.marko
@@ -11,6 +11,7 @@ fragment DynamicPageMetadataFragment on ContentPage {
   siteContext {
     path
     canonicalUrl
+    noIndex
   }
   metadata {
     title
@@ -25,6 +26,7 @@ fragment DynamicPageMetadataFragment on ContentPage {
       title: get(node, "metadata.title"),
       description: get(node, "metadata.description"),
       canonicalPath: get(node, "siteContext.path"),
+      noIndex: get(node, "siteContext.noIndex"),
     };
     <common ...metadata />
     <meta property="og:type" content="website" />

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -193,6 +193,7 @@ type ContentSiteContext {
   url: String!
   canonicalUrl: String!
   path: String!
+  noIndex: Boolean!
 }
 
 type ContentStubLocation {

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -71,7 +71,7 @@ interface Content @requiresProject(fields: ["type"]) {
   websiteUrl: String! @deprecated(reason: "Use \`siteContext.url\` instead.") @projection(localField: "_id", needs: ["type", "linkUrl", "mutations.Website.slug", "mutations.Website.primarySection", "mutations.Website.primaryCategory", "mutations.Website.alias"])
 
   # Fields that require site context
-  siteContext(input: ContentSiteContextInput = {}): ContentSiteContext! @projection(localField: "_id", needs: ["type", "linkUrl", "mutations.Website.slug", "mutations.Website.primarySection", "mutations.Website.primaryCategory", "mutations.Website.alias", "mutations.Website.canonicalUrl"])
+  siteContext(input: ContentSiteContextInput = {}): ContentSiteContext! @projection(localField: "_id", needs: ["type", "linkUrl", "mutations.Website.slug", "mutations.Website.primarySection", "mutations.Website.primaryCategory", "mutations.Website.alias", "mutations.Website.canonicalUrl", "mutations.Website.noIndex"])
 
   # Determines if this content item should redirect to another location.
   redirectTo: String @projection(localField: "type", needs: ["linkUrl"])

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -296,6 +296,7 @@ module.exports = {
           const origin = `https://${owningSite.host}`;
           return `${origin}/${cleanPath(canonicalPath)}`;
         },
+        noIndex: () => Boolean(get(content, 'mutations.Website.noIndex')),
       };
     },
 


### PR DESCRIPTION
Setting `mutations.Website.noIndex` to `true` on a content object will add the `<meta name="robots" content="noindex">` element to the corresponding content page.