### PR TITLE
Use `mutations.Website.redirectTo` in `redirectTo` resolver

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -74,7 +74,7 @@ interface Content @requiresProject(fields: ["type"]) {
   siteContext(input: ContentSiteContextInput = {}): ContentSiteContext! @projection(localField: "_id", needs: ["type", "linkUrl", "mutations.Website.slug", "mutations.Website.primarySection", "mutations.Website.primaryCategory", "mutations.Website.alias", "mutations.Website.canonicalUrl", "mutations.Website.noIndex"])
 
   # Determines if this content item should redirect to another location.
-  redirectTo: String @projection(localField: "type", needs: ["linkUrl"])
+  redirectTo: String @projection(localField: "type", needs: ["linkUrl", "mutations.Website.redirectTo"])
   # Returns related, published content based on input flags
   relatedContent(input: ContentRelatedContentInput = {}): ContentConnection! @projection(localField: "_id", needs: ["relatedTo", "mutations.Website.primarySection"])
   userRegistration: ContentUserRegistration! @projection(localField: "mutations.Website.requiresAccessLevels", needs: ["mutations.Website.requiresRegistration"])

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -471,6 +471,8 @@ module.exports = {
 
     redirectTo: (content) => {
       const { type, linkUrl } = content;
+      const redirectTo = get(content, 'mutations.Website.redirectTo');
+      if (redirectTo) return redirectTo;
 
       const types = ['Promotion', 'TextAd'];
       if (!types.includes(type)) return null;


### PR DESCRIPTION
If the `mutations.Website.redirectTo` field is present, use it to resolve the `Content.redirectTo` value, otherwise resolve as normal.