### PR TITLE
Set default fallback value for lang if not set

### DIFF
--- a/packages/marko-web-inquiry/components/form.marko
+++ b/packages/marko-web-inquiry/components/form.marko
@@ -11,7 +11,7 @@ $ const withDescription = defaultValue(input.withDescription, true);
 
 $ const blockName = "inquiry-form";
 $ const { RECAPTCHA_SITE_KEY } = require('../env');
-$ const lang = defaultValue(input.lang, "en")
+$ const lang = defaultValue(input.lang, "en");
 
 <if(inquiry.enabled)>
   <marko-web-block name=blockName modifiers=input.modifiers>

--- a/packages/marko-web-inquiry/components/form.marko
+++ b/packages/marko-web-inquiry/components/form.marko
@@ -11,7 +11,7 @@ $ const withDescription = defaultValue(input.withDescription, true);
 
 $ const blockName = "inquiry-form";
 $ const { RECAPTCHA_SITE_KEY } = require('../env');
-$ const lang = input.lang;
+$ const lang = defaultValue(input.lang, "en")
 
 <if(inquiry.enabled)>
   <marko-web-block name=blockName modifiers=input.modifiers>


### PR DESCRIPTION
See https://github.com/parameter1/pmmi-media-group-websites/pull/228 . This creates a default fallback value if language is not set on the shared-inquiry-form component.