### PR TITLE
Add `Content.taxonomyIds` field

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -85,6 +85,9 @@ interface Content @requiresProject(fields: ["type"]) {
 
   # Allows custom field values to be returned from the \`customAttributes\` model field. Currently all values are cast as strings.
   customAttribute(input: ContentCustomAttributeInput!): String @projection(localField: "customAttributes")
+
+  # Allows accessing the content's taxonomy IDs without querying the related models.
+  taxonomyIds: [Int!]! @projection(localField: "taxonomy")
 }
 
 `;

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -400,6 +400,8 @@ module.exports = {
       return contentTeaser.generateTeaser(teaser, teaserFallback, input) || null;
     },
 
+    taxonomyIds: content => getAsArray(content, 'taxonomy').map(t => parseInt(t.oid, 10)).filter(id => id),
+
     body: async (content, { input }, { site, basedb }) => {
       const { mutation } = input;
       const { body } = content;


### PR DESCRIPTION
Add support for returning a content object’s “raw” taxonomy IDs without querying the related models.