### PR TITLE
Display image in native or cropped aspect ratio

### DIFF
--- a/packages/marko-web-photoswipe/components/images.marko
+++ b/packages/marko-web-photoswipe/components/images.marko
@@ -36,7 +36,8 @@ $ const items = images.map((image) => {
   const defaultOptions = {
     w: maxSize,
     h: round(maxSize / (16 / 9)), // default 16:9 height
-    fit: "crop",
+    fit: "fill",
+    fill: "solid",
   };
 
   const imageOptions = {


### PR DESCRIPTION
Change the fit from crop to fill and add fill=solid.  This makes it display the image based on height or width filling space first and fills the remainder with transparency.  Is logo causes it to fill with white instead of transparent.

native 16x9 || isLogo
Cropped Portrait || native portrait 

<img width="2971" alt="Screen Shot 2021-06-17 at 1 29 34 PM" src="https://user-images.githubusercontent.com/3845869/122455946-94868f80-cf72-11eb-9ee8-262d249f5e7a.png">
