### PR TITLE
Add ability to query for images that are approved for web and/or print

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -517,6 +517,8 @@ input ContentCompanyInput {
 }
 
 input ContentImagesInput {
+  approvedForWeb: Boolean = true
+  approvedForPrint: Boolean
   sort: AssetImageSortInput = { order: values }
   pagination: PaginationInput = {}
 }

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -42,7 +42,7 @@ interface Content @requiresProject(fields: ["type"]) {
 
   # fields from platform.trait::MediaRelatable
   primaryImage: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
-  images(input: ContentImagesInput = {}): AssetImageConnection! @projection @refMany(model: "platform.Asset", criteria: "assetImage")
+  images(input: ContentImagesInput = {}): AssetImageConnection! @projection @refMany(model: "platform.Asset", criteria: "assetImage", refQueryBuilder: "contentAssetImages")
 
   # fields from platform.model::Content mutations
   # schedules: PlatformContentSchedules! @passThru

--- a/services/graphql-server/src/graphql/ref-query-builders/content-asset-images.js
+++ b/services/graphql-server/src/graphql/ref-query-builders/content-asset-images.js
@@ -1,0 +1,7 @@
+module.exports = (doc, { query }, { input }) => {
+  const q = { ...query };
+  const { approvedForWeb, approvedForPrint } = input;
+  if (approvedForWeb != null) q['mutations.Website.approved'] = approvedForWeb;
+  if (approvedForPrint != null) q['mutations.Magazine.approved'] = approvedForPrint;
+  return { query: q };
+};

--- a/services/graphql-server/src/graphql/ref-query-builders/index.js
+++ b/services/graphql-server/src/graphql/ref-query-builders/index.js
@@ -1,6 +1,7 @@
 const brevityCollectionIssues = require('./brevity-collection-issues');
 const emailNewsletterCampaigns = require('./email-newsletter-campaigns');
 const websiteSiteSections = require('./website-site-sections');
+const contentAssetImages = require('./content-asset-images');
 
 /**
  * Each function will receive the following args:
@@ -18,6 +19,7 @@ const builders = {
   brevityCollectionIssues,
   emailNewsletterCampaigns,
   websiteSiteSections,
+  contentAssetImages,
 };
 
 module.exports = async (key, {


### PR DESCRIPTION
Add the ability to query for content images that approved for web and print.  By default it will only return images that are approvedForWeb