### PR TITLE
Provide faux EventBus when rendering server-side

### DIFF
--- a/packages/marko-web/utils/render-ssr-component.js
+++ b/packages/marko-web/utils/render-ssr-component.js
@@ -3,11 +3,12 @@ const Vue = require('vue');
 const VueServerRenderer = require('vue-server-renderer');
 
 const renderer = VueServerRenderer.createRenderer();
+const EventBus = new Vue();
 
 module.exports = async (Component, { id, props } = {}) => {
   if (get(Component, 'props.id')) throw new Error('The provided component has an `id` prop which is incompatible with SSR rendering.');
   const app = new Vue({
-    provide: { EventBus: new Vue() },
+    provide: { EventBus },
     render: h => h(Component, { attrs: { id }, props }),
   });
   return renderer.renderToString(app);

--- a/packages/marko-web/utils/render-ssr-component.js
+++ b/packages/marko-web/utils/render-ssr-component.js
@@ -7,7 +7,7 @@ const renderer = VueServerRenderer.createRenderer();
 module.exports = async (Component, { id, props } = {}) => {
   if (get(Component, 'props.id')) throw new Error('The provided component has an `id` prop which is incompatible with SSR rendering.');
   const app = new Vue({
-    provide: { EventBus: {} },
+    provide: { EventBus: new Vue() },
     render: h => h(Component, { attrs: { id }, props }),
   });
   return renderer.renderToString(app);

--- a/packages/marko-web/utils/render-ssr-component.js
+++ b/packages/marko-web/utils/render-ssr-component.js
@@ -7,6 +7,7 @@ const renderer = VueServerRenderer.createRenderer();
 module.exports = async (Component, { id, props } = {}) => {
   if (get(Component, 'props.id')) throw new Error('The provided component has an `id` prop which is incompatible with SSR rendering.');
   const app = new Vue({
+    provide: { EventBus: {} },
     render: h => h(Component, { attrs: { id }, props }),
   });
   return renderer.renderToString(app);


### PR DESCRIPTION
Events aren’t actually used on the server, but this prevents build warnings when SSR components use the EventBus on the client.