### PR TITLE
Add ability to pass customMetadata to google structured data ld_json tag

### DIFF
--- a/packages/marko-web/components/page/layouts/content.marko
+++ b/packages/marko-web/components/page/layouts/content.marko
@@ -7,7 +7,11 @@ $ const { document } = out.global;
   foot=input.foot
 >
   <@head>
-    <marko-web-content-page-metadata id=id structured-data-query-fragment=structuredDataQueryFragment build-structured-data=buildStructuredData />
+    <marko-web-content-page-metadata
+      id=id
+      structured-data-query-fragment=structuredDataQueryFragment
+      build-structured-data=buildStructuredData
+    />
     <${input.head} />
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->

--- a/packages/marko-web/components/page/layouts/content.marko
+++ b/packages/marko-web/components/page/layouts/content.marko
@@ -1,4 +1,4 @@
-$ const { id, type } = input;
+$ const { customMetadata, id, type } = input;
 $ const { document } = out.global;
 
 <${document}
@@ -7,7 +7,7 @@ $ const { document } = out.global;
   foot=input.foot
 >
   <@head>
-    <marko-web-content-page-metadata id=id />
+    <marko-web-content-page-metadata id=id custom-metadata=customMetadata/>
     <${input.head} />
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->

--- a/packages/marko-web/components/page/layouts/content.marko
+++ b/packages/marko-web/components/page/layouts/content.marko
@@ -1,4 +1,4 @@
-$ const { customMetadata, id, type } = input;
+$ const { structuredDataQueryFragment, buildStructuredData, id, type } = input;
 $ const { document } = out.global;
 
 <${document}
@@ -7,7 +7,7 @@ $ const { document } = out.global;
   foot=input.foot
 >
   <@head>
-    <marko-web-content-page-metadata id=id custom-metadata=customMetadata/>
+    <marko-web-content-page-metadata id=id structured-data-query-fragment=structuredDataQueryFragment build-structured-data=buildStructuredData />
     <${input.head} />
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->

--- a/packages/marko-web/components/page/layouts/marko.json
+++ b/packages/marko-web/components/page/layouts/marko.json
@@ -40,6 +40,7 @@
     "<page>": {},
     "<above-page>": {},
     "<below-page>": {},
+    "@custom-metadata": {},
     "@id": "number",
     "@type": "string",
     "@attrs": "object"

--- a/packages/marko-web/components/page/layouts/marko.json
+++ b/packages/marko-web/components/page/layouts/marko.json
@@ -41,7 +41,7 @@
     "<above-page>": {},
     "<below-page>": {},
     "@structured-data-query-fragment": "string",
-    "@build-structured-data": "string",
+    "@build-structured-data": "function",
     "@id": "number",
     "@type": "string",
     "@attrs": "object"

--- a/packages/marko-web/components/page/layouts/marko.json
+++ b/packages/marko-web/components/page/layouts/marko.json
@@ -40,7 +40,8 @@
     "<page>": {},
     "<above-page>": {},
     "<below-page>": {},
-    "@custom-metadata": {},
+    "@structured-data-query-fragment": "string",
+    "@build-structured-data": "string",
     "@id": "number",
     "@type": "string",
     "@attrs": "object"

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -5,7 +5,7 @@ import buildStructuredData from "./google-structured-data/content";
 
 <!-- @todo This data should generated and saved to the content object as flat data, so no relationships are required. -->
 
-$ const { id } = input;
+$ const { customMetadata, id } = input;
 $ const queryFragment = gql`
 fragment ContentPageMetadataFragment on Content {
   id
@@ -87,7 +87,7 @@ fragment ContentPageMetadataFragment on Content {
       </if>
     </else>
 
-    $ const structuredData = buildStructuredData(node);
+    $ const structuredData = buildStructuredData(node, customMetadata);
     <if(structuredData)>
       <script type="application/ld+json">
         ${structuredData}

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -81,7 +81,7 @@ fragment ContentPageMetadataFragment on Content {
 ${processedFragment}
 `;
 
-$ const buildStructuredData = input.buildStructuredData || defaultBuildStructuredData;
+$ const buildStructuredData = isFunction(input.buildStructuredData) ? input.buildStructuredData : defaultBuildStructuredData;
 
 <if(id)>
   <marko-web-query|{ node }| name="content" params={ id, queryFragment }>

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -11,6 +11,7 @@ fragment ContentPageMetadataFragment on Content {
   id
   type
   siteContext {
+    url
     path
     canonicalUrl
     noIndex
@@ -31,6 +32,10 @@ fragment ContentPageMetadataFragment on Content {
   ... on ContentVideo {
     embedSrc
   }
+  ... on ContentPodcast {
+    fileSrc
+    fileName
+  }
   ... on Authorable {
     authors {
       edges {
@@ -40,6 +45,26 @@ fragment ContentPageMetadataFragment on Content {
         }
       }
     }
+  }
+  ... on Addressable {
+    address1
+    address2
+    city
+    state
+    zip
+    country
+  }
+  ... on Contactable {
+    phone
+    tollfree
+    fax
+    website
+    title
+    mobile
+    publicEmail
+  }
+  ... on ContentCompany {
+    email
   }
   images(input:{ pagination: { limit: 0 }, sort: { order: values } }) {
     edges {

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -1,12 +1,14 @@
 import gql from "graphql-tag";
 import { get } from "@parameter1/base-cms-object-path";
 import { warn } from "@parameter1/base-cms-utils";
+import { extractFragmentData } from "@parameter1/base-cms-web-common/src/utils";
 import defaultBuildStructuredData from "./google-structured-data/content";
 
 <!-- @todo This data should generated and saved to the content object as flat data, so no relationships are required. -->
 
-$ const { id } = input;
-$ const defaultQueryFragment = gql`
+$ const { id, structuredDataQueryFragment } = input;
+$ const { spreadFragmentName, processedFragment } = extractFragmentData(structuredDataQueryFragment);
+$ const queryFragment = gql`
 fragment ContentPageMetadataFragment on Content {
   id
   type
@@ -74,10 +76,11 @@ fragment ContentPageMetadataFragment on Content {
       }
     }
   }
+  ${spreadFragmentName}
 }
+${processedFragment}
 `;
 
-$ const queryFragment = input.structuredDataQueryFragment || defaultQueryFragment;
 $ const buildStructuredData = input.buildStructuredData || defaultBuildStructuredData;
 
 <if(id)>

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 import { get } from "@parameter1/base-cms-object-path";
-import { warn } from "@parameter1/base-cms-utils";
+import { warn, isFunction } from "@parameter1/base-cms-utils";
 import { extractFragmentData } from "@parameter1/base-cms-web-common/src/utils";
 import defaultBuildStructuredData from "./google-structured-data/content";
 

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -1,12 +1,12 @@
 import gql from "graphql-tag";
 import { get } from "@parameter1/base-cms-object-path";
 import { warn } from "@parameter1/base-cms-utils";
-import buildStructuredData from "./google-structured-data/content";
+import defaultBuildStructuredData from "./google-structured-data/content";
 
 <!-- @todo This data should generated and saved to the content object as flat data, so no relationships are required. -->
 
-$ const { customMetadata, id } = input;
-$ const queryFragment = gql`
+$ const { id } = input;
+$ const defaultQueryFragment = gql`
 fragment ContentPageMetadataFragment on Content {
   id
   type
@@ -52,6 +52,9 @@ fragment ContentPageMetadataFragment on Content {
 }
 `;
 
+$ const queryFragment = input.structuredDataQueryFragment || defaultQueryFragment;
+$ const buildStructuredData = input.buildStructuredData || defaultBuildStructuredData;
+
 <if(id)>
   <marko-web-query|{ node }| name="content" params={ id, queryFragment }>
     $ const metadata = {
@@ -87,7 +90,7 @@ fragment ContentPageMetadataFragment on Content {
       </if>
     </else>
 
-    $ const structuredData = buildStructuredData(node, customMetadata);
+    $ const structuredData = buildStructuredData(node);
     <if(structuredData)>
       <script type="application/ld+json">
         ${structuredData}

--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -108,5 +108,5 @@ module.exports = (node) => {
     });
   }
 
-  return JSON.stringify(defaultStruturedData);
+  return undefined;
 };

--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -71,6 +71,7 @@ module.exports = (node, customMetadata = {}) => {
       dateModified: updatedISOString,
       author: getAuthor(node),
       description: get(node, 'metadata.description'),
+      ...customMetadata,
     });
     return structuredData;
   }

--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -26,6 +26,10 @@ module.exports = (node) => {
   const defaultStruturedData = {
     '@context': 'https://schema.org',
     '@type': 'Article',
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': get(node, 'siteContext.canonicalUrl'),
+    },
     headline: get(node, 'metadata.title'),
     name: get(node, 'metadata.title'),
     ...(get(node, 'metadata.description') && { description: get(node, 'metadata.description') }),

--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -20,58 +20,89 @@ const getImages = (node) => {
 module.exports = (node) => {
   const publishedISOString = node.published ? (new Date(node.published)).toISOString() : undefined;
   const updatedISOString = node.updated ? (new Date(node.updated)).toISOString() : undefined;
+  const siteUrl = get(node, 'siteContext.url');
+  const canonicalUrl = get(node, 'siteContext.canonicalUrl');
+
+  const defaultStruturedData = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: get(node, 'metadata.title'),
+    name: get(node, 'metadata.title'),
+    ...(get(node, 'metadata.description') && { description: get(node, 'metadata.description') }),
+    ...(get(node, 'metadata.image.src') && { thumbnailUrl: get(node, 'metadata.image.src') }),
+    ...(getImages(node) && { image: getImages(node) }),
+    datePublished: publishedISOString,
+    dateModified: updatedISOString,
+    url: canonicalUrl,
+    ...(siteUrl !== canonicalUrl && { url: siteUrl, isBasedOn: canonicalUrl }),
+    ...(getAuthor(node) && { author: getAuthor(node) }),
+  };
+
   if (node.type === 'video') {
-    const structuredData = JSON.stringify({
-      '@context': 'https://schema.org',
+    return JSON.stringify({
+      ...defaultStruturedData,
       '@type': 'VideoObject',
-      name: get(node, 'metadata.title'),
-      description: get(node, 'metadata.description'),
-      thumbnailUrl: get(node, 'metadata.image.src'),
       uploadDate: publishedISOString,
       contentUrl: get(node, 'siteContext.canonicalUrl'),
-      author: getAuthor(node),
       embedUrl: get(node, 'embedSrc'),
     });
-    return structuredData;
   }
 
-  const newsArticleTypes = ['article', 'news'];
-  if (newsArticleTypes.includes(node.type)) {
-    const structuredData = JSON.stringify({
-      '@context': 'https://schema.org',
+  if (node.type === 'podcast') {
+    // Set associatedMedia if audio file is present
+    const associatedMedia = (get(node, 'fileName') && get(node, 'fileSrc'))
+      ? {
+        '@type': 'AudioObject',
+        contentUrl: get(node, 'fileSrc'),
+        name: get(node, 'fileName'),
+      }
+      : undefined;
+    return JSON.stringify({
+      ...defaultStruturedData,
+      '@type': 'PodcastEpisode',
+      headline: get(node, 'metadata.title'),
+      ...(associatedMedia && { associatedMedia }),
+    });
+  }
+
+  if (node.type === 'company') {
+    // Concat address1 && address2 if present
+    const streetAddresses = [];
+    if (get(node, 'address1')) streetAddresses.push(get(node, 'address1'));
+    if (get(node, 'address2')) streetAddresses.push(get(node, 'address2'));
+    const streetAddress = streetAddresses.join(' ');
+    // Display and set address info if present
+    const showAddress = (streetAddress || get(node, 'city') || get(node, 'state') || get(node, 'zip'));
+    const address = (showAddress)
+      ? {
+        '@type': 'PostalAddress',
+        ...(get(node, 'city') && { addressLocality: get(node, 'city') }),
+        ...(get(node, 'state') && { addressLocality: get(node, 'state') }),
+        ...(get(node, 'zip') && { postalCode: get(node, 'zip') }),
+        ...(streetAddress && { streetAddress }),
+      }
+      : undefined;
+    // Set tollfree || phone if present
+    const telephone = get(node, 'tollfree') || get(node, 'phone');
+
+    return JSON.stringify({
+      ...defaultStruturedData,
+      '@type': 'Organization',
+      address,
+      ...(telephone && { telephone }),
+      ...(get(node, 'metadata.image.src') && { logo: get(node, 'metadata.image.src') }),
+      ...(get(node, 'email') && { email: get(node, 'email') }),
+      ...(get(node, 'fax') && { faxNumber: get(node, 'fax') }),
+    });
+  }
+
+  if (['article', 'news'].includes(node.type)) {
+    return JSON.stringify({
+      ...defaultStruturedData,
       '@type': 'NewsArticle',
-      mainEntityOfPage: {
-        '@type': 'WebPage',
-        '@id': get(node, 'siteContext.canonicalUrl'),
-      },
       headline: get(node, 'metadata.title'),
-      image: getImages(node),
-      datePublished: publishedISOString,
-      dateModified: updatedISOString,
-      author: getAuthor(node),
-      description: get(node, 'metadata.description'),
     });
-    return structuredData;
   }
 
-  const standardArticleTypes = ['product', 'blog'];
-  if (standardArticleTypes.includes(node.type)) {
-    const structuredData = JSON.stringify({
-      '@context': 'https://schema.org',
-      '@type': 'Article',
-      mainEntityOfPage: {
-        '@type': 'WebPage',
-        '@id': get(node, 'siteContext.canonicalUrl'),
-      },
-      headline: get(node, 'metadata.title'),
-      image: getImages(node),
-      datePublished: publishedISOString,
-      dateModified: updatedISOString,
-      author: getAuthor(node),
-      description: get(node, 'metadata.description'),
-    });
-    return structuredData;
-  }
-
-  return undefined;
+  return JSON.stringify(defaultStruturedData);
 };

--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -17,7 +17,7 @@ const getImages = (node) => {
   return images.length ? images : undefined;
 };
 
-module.exports = (node) => {
+module.exports = (node, customMetadata = {}) => {
   const publishedISOString = node.published ? (new Date(node.published)).toISOString() : undefined;
   const updatedISOString = node.updated ? (new Date(node.updated)).toISOString() : undefined;
   if (node.type === 'video') {
@@ -31,6 +31,7 @@ module.exports = (node) => {
       contentUrl: get(node, 'siteContext.canonicalUrl'),
       author: getAuthor(node),
       embedUrl: get(node, 'embedSrc'),
+      ...customMetadata,
     });
     return structuredData;
   }
@@ -50,6 +51,7 @@ module.exports = (node) => {
       dateModified: updatedISOString,
       author: getAuthor(node),
       description: get(node, 'metadata.description'),
+      ...customMetadata,
     });
     return structuredData;
   }

--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -17,7 +17,7 @@ const getImages = (node) => {
   return images.length ? images : undefined;
 };
 
-module.exports = (node, customMetadata = {}) => {
+module.exports = (node) => {
   const publishedISOString = node.published ? (new Date(node.published)).toISOString() : undefined;
   const updatedISOString = node.updated ? (new Date(node.updated)).toISOString() : undefined;
   if (node.type === 'video') {
@@ -31,7 +31,6 @@ module.exports = (node, customMetadata = {}) => {
       contentUrl: get(node, 'siteContext.canonicalUrl'),
       author: getAuthor(node),
       embedUrl: get(node, 'embedSrc'),
-      ...customMetadata,
     });
     return structuredData;
   }
@@ -51,7 +50,6 @@ module.exports = (node, customMetadata = {}) => {
       dateModified: updatedISOString,
       author: getAuthor(node),
       description: get(node, 'metadata.description'),
-      ...customMetadata,
     });
     return structuredData;
   }
@@ -71,7 +69,6 @@ module.exports = (node, customMetadata = {}) => {
       dateModified: updatedISOString,
       author: getAuthor(node),
       description: get(node, 'metadata.description'),
-      ...customMetadata,
     });
     return structuredData;
   }

--- a/packages/marko-web/components/page/metadata/marko.json
+++ b/packages/marko-web/components/page/metadata/marko.json
@@ -8,7 +8,8 @@
   },
   "<marko-web-content-page-metadata>": {
     "template": "./content.marko",
-    "@id": "number"
+    "@id": "number",
+    "@custom-metadata": {}
   },
   "<marko-web-website-section-page-metadata>": {
     "template": "./website-section.marko",

--- a/packages/marko-web/components/page/metadata/marko.json
+++ b/packages/marko-web/components/page/metadata/marko.json
@@ -9,7 +9,8 @@
   "<marko-web-content-page-metadata>": {
     "template": "./content.marko",
     "@id": "number",
-    "@custom-metadata": {}
+    "@structured-data-query-fragment": "string",
+    "@build-structured-data": "string"
   },
   "<marko-web-website-section-page-metadata>": {
     "template": "./website-section.marko",

--- a/packages/marko-web/components/page/metadata/marko.json
+++ b/packages/marko-web/components/page/metadata/marko.json
@@ -10,7 +10,7 @@
     "template": "./content.marko",
     "@id": "number",
     "@structured-data-query-fragment": "string",
-    "@build-structured-data": "string"
+    "@build-structured-data": "function"
   },
   "<marko-web-website-section-page-metadata>": {
     "template": "./website-section.marko",


### PR DESCRIPTION
In the case of FCP they are adding  articleSection: primarySection, creators: [author.name] & keywords: [taxonomy.name].

**FCP Company:**
<img width="877" alt="Screen Shot 2021-06-28 at 11 30 07 AM" src="https://user-images.githubusercontent.com/3845869/123671787-455b1d00-d804-11eb-9242-403f0d67d8cf.png">
**FCP Article**
<img width="1058" alt="Screen Shot 2021-06-28 at 11 30 26 AM" src="https://user-images.githubusercontent.com/3845869/123671790-45f3b380-d804-11eb-8045-52883a17d6a9.png">
**Standard Article**
<img width="1067" alt="Screen Shot 2021-06-28 at 11 35 02 AM" src="https://user-images.githubusercontent.com/3845869/123672457-f19d0380-d804-11eb-9f63-f4532b8dc69d.png">
