### PR TITLE
Add `siteQueryOperator` to `WebsiteRedirectQueryInput`

### DIFF
--- a/services/graphql-server/src/graphql/definitions/website/redirect.js
+++ b/services/graphql-server/src/graphql/definitions/website/redirect.js
@@ -45,11 +45,18 @@ enum WebsiteRedirectSortField {
   from
 }
 
+enum WebsiteRedirectSiteQueryOperatorEnum {
+  equal
+  notEqual
+}
+
 input WebsiteRedirectQueryInput {
   id: ObjectID
   siteId: ObjectID
   from: String
   params: JSON
+  "Determines whether to check for a redirect on the _current_ site or from a site _other_ than the current site."
+  siteQueryOperator: WebsiteRedirectSiteQueryOperatorEnum = equal
 }
 
 input WebsiteRedirectsQueryInput {

--- a/services/graphql-server/src/graphql/resolvers/website/redirect.js
+++ b/services/graphql-server/src/graphql/resolvers/website/redirect.js
@@ -37,17 +37,20 @@ module.exports = {
      *
      */
     websiteRedirect: async (_, { input }, { basedb, site }) => {
-      const { from, params } = input;
+      const { from, params, siteQueryOperator } = input;
       if (input.id) return basedb.findOne('website.Redirects', { _id: input.id });
       if (!from) throw new UserInputError('An id or from must be provided via input.');
       const siteId = input.siteId || site.id();
       if (!siteId) throw new UserInputError('A siteId must be provided via input or context.');
 
       const queryParams = new URLSearchParams(asObject(params));
+
+      const siteOps = { equal: '$eq', notEqual: '$ne' };
+      const siteOp = siteOps[siteQueryOperator];
       const query = {
         $or: [
-          { siteId, from },
-          { siteId, from: from.toLowerCase() },
+          { siteId: { [siteOp]: siteId }, from },
+          { siteId: { [siteOp]: siteId }, from: from.toLowerCase() },
         ],
       };
       const redirect = await basedb.findOne('website.Redirects', query);


### PR DESCRIPTION
When the `siteQueryOperator` input is set to `notEqual` the query when attempt to return a redirect that matches the `from` value from _any_ site other than the current site. This is _not_ the default behavior, and must be specifically set in the query input.