### PR TITLE
Add mutation to create a website schedule

### DIFF
--- a/services/graphql-server/src/graphql/definitions/website/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/website/schedule.js
@@ -18,6 +18,7 @@ extend type Query {
 }
 
 extend type Mutation {
+  createWebsiteSchedule(input: CreateWebsiteScheduleMutationInput!): WebsiteSchedule! @requiresAuth
   quickCreateWebsiteSchedules(input: QuickCreateWebsiteSchedulesMutationInput!): [WebsiteSchedule!]!
   updateWebsiteSchedule(input: UpdateWebsiteScheduleMutationInput!): WebsiteSchedule!
   deleteWebsiteSchedule(input: DeleteWebsiteScheduleMutationInput!): String!
@@ -96,6 +97,14 @@ input WebsiteScheduleSectionInput {
 
 input WebsiteScheduleOptionInput {
   status: ModelStatus = active
+}
+
+input CreateWebsiteScheduleMutationInput {
+  contentId: Int!
+  sectionId: Int!
+  optionId: Int
+  startDate: Date
+  endDate: Date
 }
 
 input QuickCreateWebsiteSchedulesMutationInput {

--- a/services/graphql-server/src/graphql/resolvers/website/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/website/schedule.js
@@ -5,6 +5,7 @@ const { UserInputError } = require('apollo-server-express');
 
 const validateRest = require('../../utils/validate-rest');
 const getProjection = require('../../utils/get-projection');
+const buildProjection = require('../../utils/build-projection');
 
 const { ObjectID } = MongoDB;
 
@@ -163,11 +164,9 @@ module.exports = {
       if (input.endDate) body.set('endDate', input.endDate);
 
       const response = await base4rest.insertOne({ model: 'website/schedule', body });
-      const id = BaseDB.coerceID(response.data.id);
-
-      const { fieldNodes, schema, fragments } = info;
-      const projection = getProjection(schema, schema.getType('WebsiteSchedule'), fieldNodes[0].selectionSet, fragments);
-      return basedb.findOne('website.Schedule', { _id: id }, { projection });
+      const { id } = response.data;
+      const projection = buildProjection({ info, type: 'WebsiteSchedule' });
+      return basedb.findById('website.Schedule', id, { projection });
     },
   },
 };

--- a/services/graphql-server/src/graphql/resolvers/website/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/website/schedule.js
@@ -138,10 +138,9 @@ module.exports = {
 
       const { contentId, sectionId } = input;
       const [content, section] = await Promise.all([
-        load('platformContent', contentId, { status: 1, published: 1, type: 1 }),
+        load('platformContent', contentId, { published: 1, type: 1 }),
         basedb.strictFindOne('website.Section', { _id: sectionId }, { projection: { site: 1 } }),
       ]);
-      if (content.status !== 1) throw new UserInputError('The content status must be published.');
 
       const startDate = input.startDate || content.published || new Date();
       const siteId = BaseDB.extractRefId(section.site);


### PR DESCRIPTION
The logic for this is largely the same as the `quickCreateWebsiteSchedules` with three notable exceptions:
- Supports setting additional fields (custom optionId, startDate, & endDate)
- Only allows a single schedule to be created at once
- Now requires GraphQL authentication

This mutation is being added to support Allured's external publishing tool. Due to the backwards incompatible changes to authentication, this mutation is being created alongside `quickCreateWebsiteSchedules`, rather than replacing it.

![image](https://user-images.githubusercontent.com/1778222/126382660-1feae439-79fe-431d-a3b2-649a50221f45.png)
