### PR TITLE
Create contentPublishing mutation

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -364,7 +364,7 @@ input ContentContactFieldsMutationInput {
 
 input ContentPublishingMutationInput {
   id: Int!
-  status: ModelStatus
+  status: ModelStatus!
   published: Date
   unpublished: Date
 }

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -53,6 +53,7 @@ extend type Mutation {
   contentAddressFields(input: ContentAddressFieldsMutationInput!): Content! @requiresAuth
   "Updates contact fields on Content items"
   contentContactFields(input: ContentContactFieldsMutationInput!): Content! @requiresAuth
+  contentPublishing(input: ContentPublishingMutationInput!): Content! @requiresAuth
 }
 
 enum GateableUserRole {
@@ -359,6 +360,13 @@ input ContentContactFieldsMutationInput {
   title: String
   "The public email address"
   publicEmail: String
+}
+
+input ContentPublishingMutationInput {
+  id: Int!
+  status: ModelStatus
+  published: Date
+  unpublished: Date
 }
 
 input AllPublishedContentQueryInput {

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -48,11 +48,13 @@ extend type Query {
 }
 
 extend type Mutation {
+  "Creates a new Content item"
   createContent(input: CreateContentMutationInput!): Content! @requiresAuth
-  "Updates address fields on Content items"
+  "Updates address fields on a Content item"
   contentAddressFields(input: ContentAddressFieldsMutationInput!): Content! @requiresAuth
-  "Updates contact fields on Content items"
+  "Updates contact fields on a Content item"
   contentContactFields(input: ContentContactFieldsMutationInput!): Content! @requiresAuth
+  "Changes the publishing state of a Content item"
   contentPublishing(input: ContentPublishingMutationInput!): Content! @requiresAuth
 }
 
@@ -313,8 +315,11 @@ input ContentSitemapNewsUrlsQueryInput {
 }
 
 input CreateContentMutationInput {
+  "The type of content to create"
   type: ContentType!
+  "The name of the content"
   name: String!
+  "The primary section of this content item"
   primarySectionId: Int!
 }
 
@@ -363,9 +368,13 @@ input ContentContactFieldsMutationInput {
 }
 
 input ContentPublishingMutationInput {
+  "The content ID"
   id: Int!
+  "The status to change the content to"
   status: ModelStatus!
+  "The date the content should become available"
   published: Date
+  "The date the content should become unavailable"
   unpublished: Date
 }
 

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1381,6 +1381,56 @@ module.exports = {
       const projection = buildProjection({ info, type: 'Content' });
       return basedb.findById('platform.Content', id, { projection });
     },
+    contentPublishing: async (_, { input }, { base4rest, basedb }, info) => {
+      validateRest(base4rest);
+      const { id, ...payload } = input;
+      const fields = { published: 1, unpublished: 1, type: 1 };
+      const doc = await basedb.strictFindById('platform.Content', id, { projection: fields });
+      const type = `platform/content/${dasherize(doc.type)}`;
+      const now = new Date();
+      const body = new Base4RestPayload({ type });
+
+      if (!payload.status && !payload.published) {
+        throw new UserInputError('You must provide a status or published input.');
+      }
+
+      // We're publishing, set the status, published date, and unpublished as needed.
+      if (payload.status === 'active' || payload.published) {
+        body.set('status', 1);
+        if (doc.published && doc.published > now) {
+          // The content is already scheduled, set to the new date.
+          body.set('published', payload.published || now);
+        } else {
+          // Use the payload date, the content date, or the current date.
+          body.set('published', payload.published || doc.published || now);
+        }
+        if (doc.unpublished && doc.unpublished < now) {
+          // The content is already expired, set or remove the unpublished date.
+          body.set('unpublished', payload.unpublished || null);
+        } else if (payload.unpublished) {
+          body.set('unpublished', payload.unpublished);
+        }
+      } else {
+        switch (payload.status) {
+          case 'draft':
+            body.set('status', 2);
+            body.set('published', null);
+            body.set('unpublished', null);
+            break;
+          case 'deleted':
+            body.set('status', 0);
+            body.set('published', null);
+            body.set('unpublished', null);
+            break;
+          default:
+            throw new UserInputError(`The ModelStatus value '${payload.status}' is not valid for publishing.`);
+        }
+      }
+      body.set('id', id);
+      await base4rest.updateOne({ model: type, id, body });
+      const projection = buildProjection({ info, type: 'Content' });
+      return basedb.findOne('platform.Content', { _id: parseInt(id, 10) }, { projection });
+    },
     /**
      *
      */

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1402,7 +1402,7 @@ module.exports = {
           if (doc.unpublished && doc.unpublished < now) {
             // The content is already expired, set or remove the unpublished date.
             body.set('unpublished', payload.unpublished || null);
-          } else if (Object.hasOwnProperty.call(payload, 'unpublished')) {
+          } else if (typeof payload.unpublished !== 'undefined') {
             // Set the unpublished date, if specified.
             body.set('unpublished', payload.unpublished);
           }


### PR DESCRIPTION
Adds a mutation to handle publishing content (status, published, and unpublished fields).

This mutation enforces the following rules:
- If given a model status `active` the content will be published immediately, unless a future `published` date is provided.
  - If the content already has published or unpublished dates set, modify them as necessary based on the payload.
- If given a `draft` or `deleted` model status the content will be unpublished immediately.

Example queries:
```graphql
mutation PublishContentStatusOld {
  contentPublishing(input: {
    id: 21576960
    status: active
    # 2018-09-30
    published: 1538338400000
    # 2021-04-13
    unpublished: 1618338400000
  }) {
    id
    status
    statusText
    publishedDate
    unpublishedDate
  }
}
```
```json
{
  "data": {
    "contentPublishing": {
      "id": 21576960,
      "status": 1,
      "statusText": "Expired",
      "publishedDate": "Sep 30th, 2018",
      "unpublishedDate": "Apr 13th, 2021"
    }
  }
}
```
---
```graphql
mutation PublishContentStatus {
  contentPublishing(input: { id: 21576960, status: active }) {
    id
    status
    statusText
    publishedDate
    unpublishedDate
  }
}
```
```json
{
  "data": {
    "contentPublishing": {
      "id": 21576960,
      "status": 1,
      "statusText": "Published",
      "publishedDate": "Sep 30th, 2018",
      "unpublishedDate": null
    }
  }
}
```
---
```graphql
mutation PublishContentScheduled {
  contentPublishing(
    input: {
      id: 21576960
      status: active
      # 2021-12-01
      published: 1638338400000
      # 2021-12-03
      unpublished: 1638538400000
    }
  ) {
    id
    status
    statusText
    publishedDate
    unpublishedDate
  }
}
```
```json
{
  "data": {
    "contentPublishing": {
      "id": 21576960,
      "status": 1,
      "statusText": "Scheduled",
      "publishedDate": "Dec 1st, 2021",
      "unpublishedDate": "Dec 3rd, 2021"
    }
  }
}
```
---
```graphql
mutation PublishContentDraft {
  contentPublishing(input: { id: 21576960, status: draft }) {
    id
    status
    statusText
    publishedDate
    unpublishedDate
  }
}
```
```json
{
  "data": {
    "contentPublishing": {
      "id": 21576960,
      "status": 2,
      "statusText": "Draft",
      "publishedDate": null,
      "unpublishedDate": null
    }
  }
}
```
---
```graphql
mutation PublishContentDelete {
  contentPublishing(input: { id: 21576960, status: deleted }) {
    id
    status
    statusText
    publishedDate
    unpublishedDate
  }
}
```
```json
{
  "data": {
    "contentPublishing": {
      "id": 21576960,
      "status": 0,
      "statusText": "Deleted",
      "publishedDate": null,
      "unpublishedDate": null
    }
  }
}
```
---
```graphql
mutation PublishContentError {
  contentPublishing(input: { id: 21576960, status: any }) {
    id
  }
}
```
```json
{
  "errors": [
    {
      "message": "The ModelStatus value 'any' is not valid for publishing.",
      "locations": [
        {
          "line": 52,
          "column": 3
        }
      ],
      "path": [
        "contentPublishing"
      ],
      "extensions": {
        "code": "BAD_USER_INPUT"
      }
    }
  ],
  "data": null
}
```