### PR TITLE
Add mutations for setting content body and teaser fields

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -58,6 +58,8 @@ extend type Mutation {
   contentPublishing(input: ContentPublishingMutationInput!): Content! @requiresAuth
   "Sets the Content body"
   contentBody(input: ContentBodyMutationInput!): Content! @requiresAuth
+  "Sets the Content teaser"
+  contentTeaser(input: ContentTeaserMutationInput!): Content! @requiresAuth
 }
 
 enum GateableUserRole {
@@ -385,6 +387,13 @@ input ContentBodyMutationInput {
   id: Int!
   "The body text for the content"
   body: String
+}
+
+input ContentTeaserMutationInput {
+  "The content ID"
+  id: Int!
+  "The teaser/intro text for the content"
+  teaser: String
 }
 
 input AllPublishedContentQueryInput {

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -56,6 +56,8 @@ extend type Mutation {
   contentContactFields(input: ContentContactFieldsMutationInput!): Content! @requiresAuth
   "Changes the publishing state of a Content item"
   contentPublishing(input: ContentPublishingMutationInput!): Content! @requiresAuth
+  "Sets the Content body"
+  contentBody(input: ContentBodyMutationInput!): Content! @requiresAuth
 }
 
 enum GateableUserRole {
@@ -376,6 +378,13 @@ input ContentPublishingMutationInput {
   published: Date
   "The date the content should become unavailable"
   unpublished: Date
+}
+
+input ContentBodyMutationInput {
+  "The content ID"
+  id: Int!
+  "The body text for the content"
+  body: String
 }
 
 input AllPublishedContentQueryInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1372,6 +1372,11 @@ module.exports = {
     /**
      *
      */
+    contentTeaser: updateContentMutationHandler,
+
+    /**
+     *
+     */
     contentAddressFields: updateContentMutationHandler,
 
     /**

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1367,6 +1367,11 @@ module.exports = {
     /**
      *
      */
+    contentBody: updateContentMutationHandler,
+
+    /**
+     *
+     */
     contentAddressFields: updateContentMutationHandler,
 
     /**

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -157,6 +157,19 @@ const loadSitemapImages = ({ content, basedb }) => {
   return basedb.find('platform.Asset', query, { projection });
 };
 
+const updateContentMutationHandler = async (_, { input }, { basedb, base4rest }, info) => {
+  validateRest(base4rest);
+  const { id, ...payload } = input;
+  const doc = await basedb.strictFindById('platform.Content', id, { projection: { type: 1 } });
+  const type = `platform/content/${dasherize(doc.type)}`;
+  const body = new Base4RestPayload({ type });
+  Object.keys(payload).forEach(k => body.set(k, payload[k]));
+  body.set('id', id);
+  await base4rest.updateOne({ model: type, id, body });
+  const projection = buildProjection({ info, type: 'Content' });
+  return basedb.findById('platform.Content', id, { projection });
+};
+
 module.exports = {
   /**
    *
@@ -1354,33 +1367,16 @@ module.exports = {
     /**
      *
      */
-    contentAddressFields: async (_, { input }, { base4rest, basedb }, info) => {
-      validateRest(base4rest);
-      const { id, ...payload } = input;
-      const doc = await basedb.strictFindById('platform.Content', id, { projection: { type: 1 } });
-      const type = `platform/content/${dasherize(doc.type)}`;
-      const body = new Base4RestPayload({ type });
-      Object.keys(payload).forEach(k => body.set(k, payload[k]));
-      body.set('id', id);
-      await base4rest.updateOne({ model: type, id, body });
-      const projection = buildProjection({ info, type: 'Content' });
-      return basedb.findById('platform.Content', id, { projection });
-    },
+    contentAddressFields: updateContentMutationHandler,
+
     /**
      *
      */
-    contentContactFields: async (_, { input }, { base4rest, basedb }, info) => {
-      validateRest(base4rest);
-      const { id, ...payload } = input;
-      const doc = await basedb.strictFindById('platform.Content', id, { projection: { type: 1 } });
-      const type = `platform/content/${dasherize(doc.type)}`;
-      const body = new Base4RestPayload({ type });
-      Object.keys(payload).forEach(k => body.set(k, payload[k]));
-      body.set('id', id);
-      await base4rest.updateOne({ model: type, id, body });
-      const projection = buildProjection({ info, type: 'Content' });
-      return basedb.findById('platform.Content', id, { projection });
-    },
+    contentContactFields: updateContentMutationHandler,
+
+    /**
+     *
+     */
     contentPublishing: async (_, { input }, { base4rest, basedb }, info) => {
       validateRest(base4rest);
       const { id, ...payload } = input;
@@ -1426,6 +1422,7 @@ module.exports = {
       const projection = buildProjection({ info, type: 'Content' });
       return basedb.findOne('platform.Content', { _id: parseInt(id, 10) }, { projection });
     },
+
     /**
      *
      */


### PR DESCRIPTION
- Unifies `id, ...payload` resolvers into a single handler for flat fields
- Adds mutation to set the teaser
- Adds mutation to set the body

![image](https://user-images.githubusercontent.com/1778222/126538166-5b541b94-1e0d-4bd2-a2eb-066c1746df77.png)
