### PR TITLE
Add beginning & ending inputs to websiteScheduledContent query

### DIFF
--- a/packages/web-common/src/block-loaders/website-scheduled-content.js
+++ b/packages/web-common/src/block-loaders/website-scheduled-content.js
@@ -1,10 +1,16 @@
 const buildQuery = require('../gql/query-factories/block-website-scheduled-content');
 
+const date = v => (v instanceof Date ? v.valueOf() : v);
+
 /**
  * @param {ApolloClient} apolloClient The Apollo GraphQL client that will perform the query.
  * @param {object} params
  * @param {number} [params.sectionId] The section ID.
  * @param {number} [params.sectionAlias] The section alias.
+ * @param {date} params.beginningAfter The date to include content by
+ * @param {date} params.beginningBefore The date to include content by
+ * @param {date} params.endingAfter The date to include content by
+ * @param {date} params.endingBefore The date to include content by
  * @param {number} [params.limit] The number of results to return.
  * @param {string} [params.after] The cursor to start returning results from.
  * @param {object} [params.sort] The sort parameters (field and order) to apply to the query.
@@ -30,6 +36,10 @@ module.exports = async (apolloClient, {
   sectionAlias,
   optionId,
   optionName,
+  beginningAfter,
+  beginningBefore,
+  endingAfter,
+  endingBefore,
 
   excludeContentIds,
   excludeContentTypes,
@@ -54,6 +64,8 @@ module.exports = async (apolloClient, {
     sectionId,
     optionId,
     optionName,
+    beginning: { after: date(beginningAfter), before: date(beginningBefore) },
+    ending: { after: date(endingAfter), before: date(endingBefore) },
     ...(sort && { sort }),
   };
   const query = buildQuery({ queryFragment, queryName, sectionFragment });

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -553,6 +553,10 @@ input WebsiteScheduledContentQueryInput {
   sort: ContentSortInput = { field: null }
   after: Date
   since: Date
+  "For types with a startDate field: Limit results to items with a startDate matching the criteria."
+  beginning: ContentBeginningInput = {}
+  "For types with a endDate field: Limit results to items with a endDate matching the criteria."
+  ending: ContentEndingInput = {}
 }
 
 input RelatedPublishedContentQueryInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1180,6 +1180,8 @@ module.exports = {
         pagination,
         since,
         after,
+        beginning,
+        ending,
       } = input;
 
       if (sectionId && sectionAlias) throw new UserInputError('You cannot provide both sectionId and sectionAlias as input.');
@@ -1250,6 +1252,11 @@ module.exports = {
       if (excludeContentIds.length) {
         query._id = { $nin: excludeContentIds };
       }
+
+      if (beginning.before) query.$and.push({ startDate: { $lte: beginning.before } });
+      if (beginning.after) query.$and.push({ startDate: { $gte: beginning.after } });
+      if (ending.before) query.$and.push({ endDate: { $lte: ending.before } });
+      if (ending.after) query.$and.push({ endDate: { $gte: ending.after } });
 
       const projection = connectionProjection(info);
       const sort = input.sort.field ? input.sort : { field: 'sectionQuery.0.start', order: 'desc' };


### PR DESCRIPTION
Similar to allPublishedContent query I added support for passing beginning & ending support to return content with an beginning and ending date field to return only result based on if those dates are before or after the beginning or ending dates passed.  

<img width="1203" alt="Screen Shot 2021-07-21 at 2 59 47 PM" src="https://user-images.githubusercontent.com/3845869/126552657-40c344a0-c7af-410d-a856-b19c7feca9d5.png">
<img width="1194" alt="Screen Shot 2021-07-21 at 2 59 58 PM" src="https://user-images.githubusercontent.com/3845869/126552663-d820438a-7443-4574-8af1-ac6ee97a9bf5.png">
