### PR TITLE
Show video icon if item has videos

### DIFF
--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -29,7 +29,6 @@
           <link-contents
             :title="item.name"
             :is-active="isActive"
-            :youtube="item.youtube"
             :has-videos="item.videos.edges.length > 0"
           />
         </template>

--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -30,6 +30,7 @@
             :title="item.name"
             :is-active="isActive"
             :youtube="item.youtube"
+            :has-videos="item.videos.edges.length > 0"
           />
         </template>
         <template #dropdown="{ item, isActive }">

--- a/packages/leaders-program/src/components/list/nav/contents.vue
+++ b/packages/leaders-program/src/components/list/nav/contents.vue
@@ -29,13 +29,17 @@ export default {
       type: Object,
       default: null,
     },
+    hasVideos: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   computed: {
     showVideoIcon() {
       const { youtube } = this;
       if (!youtube) return false;
-      return Boolean(youtube.username || youtube.channelId);
+      return Boolean(youtube.username || youtube.channelId || this.hasVideos);
     },
     iconModifiers() {
       const mods = [];

--- a/packages/leaders-program/src/components/list/nav/contents.vue
+++ b/packages/leaders-program/src/components/list/nav/contents.vue
@@ -3,7 +3,7 @@
     <filter-none-icon :modifiers="iconModifiers" />
     <span class="leaders-nav-link-contents__container">
       <span class="leaders-nav-link-contents__title">{{ title }}</span>
-      <videocam-icon v-if="showVideoIcon" :modifiers="iconModifiers" />
+      <videocam-icon v-if="hasVideos" :modifiers="iconModifiers" />
     </span>
   </span>
 </template>
@@ -25,10 +25,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    youtube: {
-      type: Object,
-      default: null,
-    },
     hasVideos: {
       type: Boolean,
       default: false,
@@ -36,11 +32,6 @@ export default {
   },
 
   computed: {
-    showVideoIcon() {
-      const { youtube } = this;
-      if (!youtube) return false;
-      return Boolean(this.hasVideos);
-    },
     iconModifiers() {
       const mods = [];
       if (this.isActive) mods.push('active');

--- a/packages/leaders-program/src/components/list/nav/contents.vue
+++ b/packages/leaders-program/src/components/list/nav/contents.vue
@@ -39,7 +39,7 @@ export default {
     showVideoIcon() {
       const { youtube } = this;
       if (!youtube) return false;
-      return Boolean(youtube.username || youtube.channelId || this.hasVideos);
+      return Boolean(this.hasVideos);
     },
     iconModifiers() {
       const mods = [];


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-07-23 at 11 05 49 AM" src="https://user-images.githubusercontent.com/46794001/126810752-dc38031d-3dfb-4bb1-b9df-6790daa0e4da.png">


Gormann-Rupp Pumps only had a playlistId on it but was previously not displaying the video icon.