### PR TITLE
Create generic Apollo SSR client factory package

### DIFF
--- a/packages/apollo-ssr/package.json
+++ b/packages/apollo-ssr/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@parameter1/base-cms-apollo-ssr",
+  "version": "2.33.0",
+  "description": "Apollo GraphQL SSR Client factory.",
+  "main": "src/index.js",
+  "repository": "https://github.com/parameter1/base-cms/tree/master/packages/apollo-ssr",
+  "author": "Jacob Bare <jacob@parameter1.com>",
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint --ext .js --max-warnings 5 ./",
+    "test": "yarn lint"
+  },
+  "dependencies": {
+    "apollo-cache-inmemory": "^1.6.6",
+    "apollo-client": "^2.6.10",
+    "apollo-link-context": "^1.0.20",
+    "apollo-link-http": "^1.5.17",
+    "node-fetch": "^2.6.1"
+  },
+  "peerDependencies": {
+    "graphql": "^14.0.0 || ^15.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/apollo-ssr/src/index.js
+++ b/packages/apollo-ssr/src/index.js
@@ -1,0 +1,42 @@
+const fetch = require('node-fetch');
+const { ApolloClient } = require('apollo-client');
+const { InMemoryCache } = require('apollo-cache-inmemory');
+const { createHttpLink } = require('apollo-link-http');
+const { setContext } = require('apollo-link-context');
+
+const rootConfig = {
+  connectToDevTools: false,
+  ssrMode: true,
+};
+
+module.exports = ({
+  uri,
+  headers,
+  contextFn,
+  config,
+  cacheConfig,
+  linkConfig,
+} = {}) => {
+  if (!uri) throw new Error('A GraphQL API URI must be provided.');
+
+  const contextLink = setContext((ctx) => {
+    if (typeof contextFn === 'function') return contextFn(ctx);
+    return undefined;
+  });
+  const httpLink = createHttpLink({
+    ...linkConfig,
+    fetch,
+    uri,
+    headers: {
+      ...headers,
+      ...(linkConfig && linkConfig.headers),
+    },
+  });
+
+  return new ApolloClient({
+    ...config,
+    ...rootConfig,
+    link: contextLink.concat(httpLink),
+    cache: new InMemoryCache(cacheConfig),
+  });
+};

--- a/packages/express-apollo/package.json
+++ b/packages/express-apollo/package.json
@@ -11,15 +11,8 @@
     "test": "yarn lint"
   },
   "dependencies": {
-    "@parameter1/base-cms-graphql-fragment-types": "^2.0.0",
-    "apollo-cache-inmemory": "^1.6.6",
-    "apollo-client": "^2.6.10",
-    "apollo-link-context": "^1.0.20",
-    "apollo-link-http": "^1.5.17",
-    "node-fetch": "^2.6.1"
-  },
-  "peerDependencies": {
-    "graphql": "^14.0.0"
+    "@parameter1/base-cms-apollo-ssr": "^2.33.0",
+    "@parameter1/base-cms-graphql-fragment-types": "^2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/express-apollo/src/create-client.js
+++ b/packages/express-apollo/src/create-client.js
@@ -1,25 +1,10 @@
-const fetch = require('node-fetch');
-const { ApolloClient } = require('apollo-client');
-const { InMemoryCache } = require('apollo-cache-inmemory');
-const { createHttpLink } = require('apollo-link-http');
-const { setContext } = require('apollo-link-context');
+const createClient = require('@parameter1/base-cms-apollo-ssr');
 const fragmentMatcher = require('@parameter1/base-cms-graphql-fragment-types/fragment-matcher');
 
-const rootConfig = {
-  connectToDevTools: false,
-  ssrMode: true,
-};
-
-module.exports = (uri, config, linkConfig, contextFn) => {
-  const contextLink = setContext((ctx) => {
-    if (typeof contextFn === 'function') return contextFn(ctx);
-    return undefined;
-  });
-  const httpLink = createHttpLink({ fetch, ...linkConfig, uri });
-  return new ApolloClient({
-    ...config,
-    ...rootConfig,
-    link: contextLink.concat(httpLink),
-    cache: new InMemoryCache({ fragmentMatcher }),
-  });
-};
+module.exports = (uri, config, linkConfig, contextFn) => createClient({
+  uri,
+  config,
+  linkConfig,
+  contextFn,
+  cacheConfig: { fragmentMatcher },
+});


### PR DESCRIPTION
Moves/consolidates the generic Apollo client factory logic to its own package so it can be used by other SSR Apollo clients.