### PR TITLE
Add Base Browse GraphQL middleware

### DIFF
--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@godaddy/terminus": "^4.5.0",
+    "@parameter1/base-cms-apollo-ssr": "^2.33.0",
     "@parameter1/base-cms-embedded-media": "^2.8.1",
     "@parameter1/base-cms-express-apollo": "^2.3.0",
     "@parameter1/base-cms-graphql-fragment-types": "^2.0.0",

--- a/packages/marko-web/start-server.js
+++ b/packages/marko-web/start-server.js
@@ -38,6 +38,9 @@ module.exports = async ({
   redirectHandler,
   sitemapsHeaders,
 
+  // Base browse (optional)
+  baseBrowseGraphqlUri = env.BASE_BROWSE_GRAPHQL_URI,
+
   // Cache settings.
   gqlCacheResponses = parseBooleanHeader(env.CACHE_GQL_RESPONSES),
   gqlCacheSiteContext = parseBooleanHeader(env.CACHE_GQL_SITE_CONTEXT),
@@ -78,6 +81,7 @@ module.exports = async ({
     sitemapsHeaders,
     gqlCacheResponses,
     gqlCacheSiteContext,
+    baseBrowseGraphqlUri,
   });
 
   // Await required services here...
@@ -135,6 +139,7 @@ module.exports = async ({
             name: sitePackage.name,
             siteId,
             graphqlUri,
+            baseBrowseGraphqlUri,
             location: `http://${exposedHost}:${exposedPort}`,
           });
         }

--- a/packages/web-cli/src/gulp/server.js
+++ b/packages/web-cli/src/gulp/server.js
@@ -15,7 +15,10 @@ module.exports = (file) => {
     node = await spawn('node', [file], { stdio: ['inherit', 'inherit', 'inherit', 'ipc'] });
     node.on('message', (msg) => {
       if (msg.event === 'ready') {
-        log(`${magenta(msg.name)} website ${green('ready')} on ${yellow(msg.location)} (Site ID: ${gray(msg.siteId)}) (API: ${gray(msg.graphqlUri)})`);
+        const { baseBrowseGraphqlUri } = msg;
+        let message = `${magenta(msg.name)} website ${green('ready')} on ${yellow(msg.location)} (Site ID: ${gray(msg.siteId)}) (API: ${gray(msg.graphqlUri)})`;
+        if (baseBrowseGraphqlUri) message = `${message} (Base Browse API: ${gray(baseBrowseGraphqlUri)})`;
+        log(message);
         livereload.changed('/');
       }
     });


### PR DESCRIPTION
Sets the Base Browse Apollo client to the `$baseBrowse` property on all request and reponse objects. This is _optional_ and only applies if the `baseBrowseGraphqlUri` is provided to `startServer`. This value can either passed directly or inferred via the `BASE_BROWSE_GRAPHQL_URI` environment variable.