### PR TITLE
Enable ability to disable card flyouts on leaders.

### DIFF
--- a/packages/leaders-program/src/components/containers/section-wrapper.vue
+++ b/packages/leaders-program/src/components/containers/section-wrapper.vue
@@ -27,6 +27,7 @@
             :promotion-limit="promotionLimit"
             :video-limit="videoLimit"
             :featured-product-label="featuredProductLabel"
+            :allow-fly-out="allowFlyOut"
             @action="emitAction"
           />
         </leaders-columns>
@@ -109,6 +110,10 @@ export default {
     featuredProductLabel: {
       type: String,
       default: 'Featured Products',
+    },
+    allowFlyOut: {
+      type: Boolean,
+      default: true,
     },
   },
 

--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -32,7 +32,7 @@
             :has-videos="item.videos.edges.length > 0"
           />
         </template>
-        <template #dropdown="{ item, isActive }">
+        <template v-if="allowFlyOut" #dropdown="{ item, isActive }">
           <card
             :company="item"
             :is-active="isActive"
@@ -107,6 +107,10 @@ export default {
     featuredProductLabel: {
       type: String,
       default: 'Featured Products',
+    },
+    allowFlyOut: {
+      type: Boolean,
+      default: true,
     },
   },
 

--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -28,6 +28,7 @@
         :promotion-limit="promotionLimit"
         :video-limit="videoLimit"
         :featured-product-label="featuredProductLabel"
+        :allow-fly-out="allowFlyOut"
         @action="emitAction"
       />
     </div>
@@ -155,6 +156,10 @@ export default {
     featuredProductLabel: {
       type: String,
       default: 'Featured Products',
+    },
+    allowFlyOut: {
+      type: Boolean,
+      default: true,
     },
   },
 


### PR DESCRIPTION
Currently the default behavior of the leaders block to is have flyout blocks when a link is hovered over:

<img width="1920" alt="Screen Shot 2021-07-30 at 11 38 55 AM" src="https://user-images.githubusercontent.com/46794001/127684760-1e334bfe-901a-4d9c-8b28-af676db26c47.png">

This change allows for these flyout blocks to be disabled when allowFlyOut is set to false:

<img width="1920" alt="Screen Shot 2021-07-30 at 11 39 05 AM" src="https://user-images.githubusercontent.com/46794001/127684815-1b0d574f-0c75-4ea2-a3d5-daa2865c6abb.png">

This corresponds to https://github.com/parameter1/ascend-media-websites/pull/188 and the ticket attached to this PR.