### PR TITLE
Create `SidebarEnabledInterface` and corresponding web component

### DIFF
--- a/packages/marko-web/components/element/content/marko.json
+++ b/packages/marko-web/components/element/content/marko.json
@@ -135,6 +135,16 @@
     "@modifiers": "string",
     "@attrs": "object"
   },
+  "<marko-web-content-sidebar-stubs>": {
+    "template": "./sidebar-stubs.marko",
+    "<embed-options>": {},
+    "@block-name": "string",
+    "@obj": "object",
+    "@tag": "string",
+    "@class": "string",
+    "@modifiers": "string",
+    "@attrs": "object"
+  },
   "<marko-web-content-images>": {
     "template": "./images.marko",
     "@block-name": "string",

--- a/packages/marko-web/components/element/content/sidebar-stubs.marko
+++ b/packages/marko-web/components/element/content/sidebar-stubs.marko
@@ -1,0 +1,23 @@
+import extractRender from "../extract-render";
+
+$ const { parseEmbeddedMedia, res } = out.global;
+$ const embedOptions = getAsObject(input, "embedOptions")
+
+<marko-web-obj-array|{ value }|
+  type="content"
+  block-name=input.blockName
+  obj=input.obj
+  field="sidebarStubs"
+  tag=input.tag
+  class=input.class
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+  $ const { body } = value;
+  $ const v = body == null ? "" : `${body}`.trim();
+  $ const obj = {
+    ...value,
+    body: parseEmbeddedMedia(v, res, embedOptions),
+  };
+  <${input.renderBody} sidebar=value />
+</marko-web-obj-array>

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -171,6 +171,13 @@ enum RelatedContentQueryType {
   company
 }
 
+type ContentStubSidebar {
+  body: String
+  name: String
+  label: String
+  sequence: Int!
+}
+
 type ContentGating {
   requiredRole: GateableUserRole
   surveyType: GateableSurveyProvider

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/index.js
@@ -7,6 +7,7 @@ const inquirable = require('./inquirable');
 const media = require('./media');
 const organizationContactable = require('./organization-contactable');
 const primaryCategory = require('./primary-category');
+const sidebarEnabled = require('./sidebar-enabled');
 const socialLinkable = require('./social-linkable');
 
 module.exports = gql`
@@ -19,6 +20,7 @@ ${inquirable}
 ${media}
 ${organizationContactable}
 ${primaryCategory}
+${sidebarEnabled}
 ${socialLinkable}
 
 `;

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/sidebar-enabled.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/sidebar-enabled.js
@@ -1,0 +1,23 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+interface SidebarEnabledInterface {
+  sidebarStubs(input: ContentSidebarStubsInput = {}): [ContentStubSidebar!]! @projection(localField: "sidebars")
+}
+
+enum ContentSidebarSortField {
+  name
+  sequence
+}
+
+input ContentSidebarStubsInput {
+  sort: ContentSidebarSortInput = {}
+}
+
+input ContentSidebarSortInput {
+  field: ContentSidebarSortField = sequence
+  order: SortOrder = asc
+}
+
+`;

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/sidebar-enabled.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/sidebar-enabled.js
@@ -12,6 +12,8 @@ enum ContentSidebarSortField {
 }
 
 input ContentSidebarStubsInput {
+  "Filters the sidebars by one or more labels. An empty value will return all sidebars"
+  labels: [String!] = []
   sort: ContentSidebarSortInput = {}
 }
 

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/article.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/article.js
@@ -6,9 +6,9 @@ extend type Query {
   contentArticle(input: ContentArticleQueryInput!): ContentArticle @findOne(model: "platform.Content", using: { id: "_id" }, criteria: "contentArticle")
 }
 
-type ContentArticle implements Content & Authorable @applyInterfaceFields {
+type ContentArticle implements Content & Authorable & SidebarEnabledInterface @applyInterfaceFields {
   # fields directly on platform.model::Content\Article
-  sidebars: [String]! @projection
+  sidebars: [String]! @deprecated(reason: "Sidebars now support multiple fields. Use \`ContentArticle.sidebarStubs\` instead.") @projection
 }
 
 type ContentArticleConnection {

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/news.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/news.js
@@ -6,7 +6,7 @@ extend type Query {
   contentNews(input: ContentNewsQueryInput!): ContentNews @findOne(model: "platform.Content", using: { id: "_id" }, criteria: "contentNews")
 }
 
-type ContentNews implements Content & Authorable @applyInterfaceFields {
+type ContentNews implements Content & Authorable & SidebarEnabledInterface @applyInterfaceFields {
   # fields directly on platform.model::Content\News
   source: String @projection
   byline: String @projection

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/product.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/product.js
@@ -6,7 +6,7 @@ extend type Query {
   contentProduct(input: ContentProductQueryInput!): ContentProduct @findOne(model: "platform.Content", using: { id: "_id" }, criteria: "contentProduct")
 }
 
-type ContentProduct implements Content & PrimaryCategory & Inquirable @applyInterfaceFields {
+type ContentProduct implements Content & PrimaryCategory & Inquirable & SidebarEnabledInterface @applyInterfaceFields {
   # fields directly on platform.model::Content\Product
   bodyOriginal: String @projection
   productUrl: String @projection

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -208,6 +208,23 @@ module.exports = {
   /**
    *
    */
+  SidebarEnabledInterface: {
+    __resolveType: resolveType,
+    sidebarStubs: (content, { input }) => {
+      const { field, order } = input.sort;
+      const sidebars = getAsArray(content, 'sidebars');
+      return sidebars.sort((a, b) => {
+        const direction = order === 'asc' ? 1 : -1;
+        if (a[field] > b[field]) return direction;
+        if (a[field] < b[field]) return direction * -1;
+        return 0;
+      });
+    },
+  },
+
+  /**
+   *
+   */
   Contactable: {
     __resolveType: resolveType,
     website: ({ website }) => {
@@ -718,6 +735,31 @@ module.exports = {
     },
     caption: image => sitemap.escape(createCaptionFor(image.caption)),
     title: image => sitemap.escape(image.name),
+  },
+
+  ContentStubSidebar: {
+    body: async ({ body }, _, { site, basedb }) => {
+      if (!body) return null;
+      let value = body.trim();
+      if (!value) return null;
+
+      const imageHost = site.get('imageHost', defaults.imageHost);
+      const imageTags = await getEmbeddedImageTags(value, { imageHost, basedb });
+      imageTags.forEach((tag) => {
+        const replacement = tag.isValid() ? tag.build() : '';
+        value = value.replace(tag.getRegExp(), replacement);
+      });
+      return value;
+    },
+    name: ({ name }) => {
+      if (!name) return null;
+      return name.trim() || null;
+    },
+    label: ({ label }) => {
+      if (!label) return null;
+      return label.trim() || null;
+    },
+    sequence: ({ sequence }) => (sequence == null ? 0 : sequence),
   },
 
   /**

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -211,9 +211,13 @@ module.exports = {
   SidebarEnabledInterface: {
     __resolveType: resolveType,
     sidebarStubs: (content, { input }) => {
-      const { field, order } = input.sort;
+      const { labels, sort } = input;
+      const { field, order } = sort;
       const sidebars = getAsArray(content, 'sidebars');
-      return sidebars.sort((a, b) => {
+      return sidebars.filter((sidebar) => {
+        if (!labels.length) return true;
+        return labels.includes(sidebar.label);
+      }).sort((a, b) => {
         const direction = order === 'asc' ? 1 : -1;
         if (a[field] > b[field]) return direction;
         if (a[field] < b[field]) return direction * -1;


### PR DESCRIPTION
Adds the `sidebarStubs` field to the `ContentArticle`, `ContentNews` and `ContentProduct` types. The `sidebars` field was _not_ used as it was previously only resolving to the sidebar `body` on Articles - which is now deprecated. The `sidebarStubs` field supports sorting by sidebar `name` or `sequence` and can also be filtered by one or more sidebar `label` values.

A corresponding `<marko-web-content-sidebar-stubs>` component was also created. This will return the sidebars as formatted objects with parsed embedded images. Example:

```marko
<!-- pass the content object with sidebars as the `obj` input -->
<marko-web-content-sidebar-stubs|{ sidebar }|
  obj=content
>
  <!-- render / display each processed sidebar object in the array -->
  <p>${sidebar.name}</p>
  <div>$!{sidebar.body}</div>
</marko-web-content-sidebar-stubs>
``` 