### PR TITLE
Allow null values for Youtube components

### DIFF
--- a/services/graphql-server/src/graphql/definitions/google-data-api/youtube.js
+++ b/services/graphql-server/src/graphql/definitions/google-data-api/youtube.js
@@ -1,11 +1,13 @@
 const gql = require('graphql-tag');
 
 module.exports = gql`
+
 extend type Query {
   validateYoutubePlaylistId(input: ValidateYoutubePlaylistIdQueryInput!): Boolean!
   validateYoutubeChannelId(input: ValidateYoutubeChannelIdQueryInput!): Boolean!
   validateYoutubeUsername(input: ValidateYoutubeUsernameQueryInput!): Boolean!
 }
+
 enum YoutubeThumbnailSizes {
   default
   medium
@@ -13,18 +15,22 @@ enum YoutubeThumbnailSizes {
   standard
   maxres
 }
+
 input YoutubeThumbnailInput {
   size: YoutubeThumbnailSizes = default
 }
+
 type YoutubePlaylistConnection {
   totalCount: Int!
   edges: [YoutubePlaylistEdge]!
   pageInfo: PageInfo!
 }
+
 type YoutubePlaylistEdge {
   node: YoutubeVideo!
   cursor: String!
 }
+
 type YoutubeVideo {
   id: String!
   url: String!
@@ -33,13 +39,17 @@ type YoutubeVideo {
   title: String!
   description: String
 }
+
 input ValidateYoutubePlaylistIdQueryInput {
   playlistId: String!
 }
+
 input ValidateYoutubeChannelIdQueryInput {
   channelId: String!
 }
+
 input ValidateYoutubeUsernameQueryInput {
   username: String!
 }
+
 `;

--- a/services/graphql-server/src/graphql/definitions/google-data-api/youtube.js
+++ b/services/graphql-server/src/graphql/definitions/google-data-api/youtube.js
@@ -21,22 +21,22 @@ input YoutubeThumbnailInput {
 }
 
 type YoutubePlaylistConnection {
-  totalCount: Int!
-  edges: [YoutubePlaylistEdge]!
-  pageInfo: PageInfo!
+  totalCount: Int
+  edges: [YoutubePlaylistEdge]
+  pageInfo: PageInfo
 }
 
 type YoutubePlaylistEdge {
-  node: YoutubeVideo!
-  cursor: String!
+  node: YoutubeVideo
+  cursor: String
 }
 
 type YoutubeVideo {
-  id: String!
-  url: String!
-  published: Date!
-  thumbnail(input: YoutubeThumbnailInput): String!
-  title: String!
+  id: String
+  url: String
+  published: Date
+  thumbnail(input: YoutubeThumbnailInput): String
+  title: String
   description: String
 }
 

--- a/services/graphql-server/src/graphql/definitions/google-data-api/youtube.js
+++ b/services/graphql-server/src/graphql/definitions/google-data-api/youtube.js
@@ -1,13 +1,11 @@
 const gql = require('graphql-tag');
 
 module.exports = gql`
-
 extend type Query {
   validateYoutubePlaylistId(input: ValidateYoutubePlaylistIdQueryInput!): Boolean!
   validateYoutubeChannelId(input: ValidateYoutubeChannelIdQueryInput!): Boolean!
   validateYoutubeUsername(input: ValidateYoutubeUsernameQueryInput!): Boolean!
 }
-
 enum YoutubeThumbnailSizes {
   default
   medium
@@ -15,41 +13,33 @@ enum YoutubeThumbnailSizes {
   standard
   maxres
 }
-
 input YoutubeThumbnailInput {
   size: YoutubeThumbnailSizes = default
 }
-
 type YoutubePlaylistConnection {
-  totalCount: Int
-  edges: [YoutubePlaylistEdge]
-  pageInfo: PageInfo
+  totalCount: Int!
+  edges: [YoutubePlaylistEdge]!
+  pageInfo: PageInfo!
 }
-
 type YoutubePlaylistEdge {
-  node: YoutubeVideo
-  cursor: String
+  node: YoutubeVideo!
+  cursor: String!
 }
-
 type YoutubeVideo {
-  id: String
-  url: String
-  published: Date
-  thumbnail(input: YoutubeThumbnailInput): String
-  title: String
+  id: String!
+  url: String!
+  published: Date!
+  thumbnail(input: YoutubeThumbnailInput): String!
+  title: String!
   description: String
 }
-
 input ValidateYoutubePlaylistIdQueryInput {
   playlistId: String!
 }
-
 input ValidateYoutubeChannelIdQueryInput {
   channelId: String!
 }
-
 input ValidateYoutubeUsernameQueryInput {
   username: String!
 }
-
 `;

--- a/services/graphql-server/src/graphql/resolvers/google-data-api/youtube.js
+++ b/services/graphql-server/src/graphql/resolvers/google-data-api/youtube.js
@@ -8,26 +8,26 @@ module.exports = {
   YoutubePlaylistConnection: {
     totalCount: response => get(response, 'pageInfo.totalResults', 0),
     pageInfo: response => ({
-      hasNextPage: Boolean(get(response, 'nextPageToken')),
-      endCursor: get(response, 'nextPageToken'),
+      hasNextPage: Boolean(get(response, 'nextPageToken')) || false,
+      endCursor: get(response, 'nextPageToken') || '',
     }),
-    edges: response => getAsArray(response, 'items'),
+    edges: response => getAsArray(response, 'items') || [],
   },
   /**
    *
    */
   YoutubePlaylistEdge: {
-    node: edge => getAsObject(edge, 'snippet'),
-    cursor: edge => get(edge, 'id'),
+    node: edge => getAsObject(edge, 'snippet') || {},
+    cursor: edge => get(edge, 'id') || '',
   },
   /**
    *
    */
   YoutubeVideo: {
-    id: snippet => get(snippet, 'resourceId.videoId'),
-    url: snippet => `https://youtu.be/${get(snippet, 'resourceId.videoId')}`,
-    published: snippet => new Date(get(snippet, 'publishedAt')),
-    thumbnail: (snippet, { input = {} }) => get(snippet, `thumbnails.${input.size}.url`, get(snippet, 'thumbnails.default.url')),
+    id: snippet => get(snippet, 'resourceId.videoId') || '',
+    url: snippet => `https://youtu.be/${get(snippet, 'resourceId.videoId')}` || '',
+    published: snippet => new Date(get(snippet, 'publishedAt')) || new Date(),
+    thumbnail: (snippet, { input = {} }) => get(snippet, `thumbnails.${input.size}.url`, get(snippet, 'thumbnails.default.url')) || '',
   },
   /**
    *


### PR DESCRIPTION
It appears when a 400 level error response is returned by the Youtube API the GraphQL fragment isn't allowing the error to fall off and is displaying it's own error in the response as found here: https://parameter1.atlassian.net/browse/HELP-129 .

The easiest solution is to allow for null values to be set at the Graph level. I took into account how these were being rendered and it would appear those are all requiring the data to be set on them anyway so it won't cause an issue in which invalid data is being set as the data won't be there to be passed anyway. I made a test company to get an idea of what returns when bad data is passed (including a private playlist which was my primary testing point).

Potentially we should check if a particular field is present on the video items to validate if the object is properly defined or not, because even though Vue will continue to work passed "erroring" required properties we should avoid that whenever possible.

<img width="1192" alt="Screen Shot 2021-08-13 at 12 57 37 PM" src="https://user-images.githubusercontent.com/46794001/129401299-a7a0f16c-e8b5-415c-8627-aadfbb17440a.png">
