### PR TITLE
Do not attempt deploys if images are already built

### DIFF
--- a/packages/newsletter-deployment-tool/src/commands/deploy/deploy.js
+++ b/packages/newsletter-deployment-tool/src/commands/deploy/deploy.js
@@ -91,7 +91,9 @@ module.exports = async (argv) => {
       await build();
       log('Build complete.');
     } else {
-      log('Image found, skipping build.');
+      log('Image found, skipping build and deployment.');
+      // Do not attempt to deploy if the image is already built.
+      return true;
     }
 
     const { RANCHER_CLUSTERID, RANCHER_TOKEN, RANCHER_URL } = process.env;

--- a/packages/website-deployment-tool/src/commands/deploy/deploy.js
+++ b/packages/website-deployment-tool/src/commands/deploy/deploy.js
@@ -91,7 +91,9 @@ module.exports = async (argv) => {
       await build();
       log('Build complete.');
     } else {
-      log('Image found, skipping build.');
+      log('Image found, skipping build and deployment.');
+      // Do not attempt to deploy if the image is already built.
+      return true;
     }
 
     const { RANCHER_CLUSTERID, RANCHER_TOKEN, RANCHER_URL } = process.env;

--- a/packages/website-deployment-tool/src/commands/deploy/service.js
+++ b/packages/website-deployment-tool/src/commands/deploy/service.js
@@ -93,7 +93,9 @@ module.exports = async (argv) => {
       await build();
       log('Build complete.');
     } else {
-      log('Image found, skipping build.');
+      log('Image found, skipping build and deployment.');
+      // Do not attempt to deploy if the image is already built.
+      return true;
     }
 
     const { RANCHER_CLUSTERID, RANCHER_TOKEN, RANCHER_URL } = process.env;


### PR DESCRIPTION
Prevents an older tag from being deployed when the Github > Travis webhook catchup happens (aka the 2am rollback to last weeks release).

If the image has already been built, assume it no longer needs to be deployed and pass the build without attempting to upgrade any containers.

This will remove the ability to rollback to an older version via Travis, but normal rollbacks within Rancher will be unaffected.