### PR TITLE
Do not destructure p1events from window object

### DIFF
--- a/packages/marko-web-p1-events/browser/track-content-body-links.vue
+++ b/packages/marko-web-p1-events/browser/track-content-body-links.vue
@@ -28,9 +28,8 @@ export default {
   },
 
   created() {
-    const { p1events } = window;
-    if (!p1events) return;
-    p1events('trackLinks', {
+    if (!window.p1events) return;
+    window.p1events('trackLinks', {
       ancestor: this.selector,
       linkType: this.linkType,
       handler: ({ element }) => {

--- a/packages/marko-web-p1-events/browser/track-inquiry-submission.vue
+++ b/packages/marko-web-p1-events/browser/track-inquiry-submission.vue
@@ -18,13 +18,12 @@ export default {
   },
 
   created() {
-    const { p1events } = window;
-    if (!p1events) return;
+    if (!window.p1events) return;
 
     this.EventBus.$on(this.eventName, ({ payload } = {}) => {
       const props = { ...payload };
       delete props.token;
-      p1events('track', {
+      window.p1events('track', {
         category: 'Inquiry',
         action: 'Submit',
         entity: this.entity,


### PR DESCRIPTION
I'm guessing this is causing issues with the deferred script loading -- the events are likely still being pushed to the previous accumulator after the p1events library initializes, and never actually fire.

With this change, the events are actually sent as expected.