### PR TITLE
Allow fetch to be overwritten by linkConfig

### DIFF
--- a/packages/apollo-ssr/src/index.js
+++ b/packages/apollo-ssr/src/index.js
@@ -24,8 +24,8 @@ module.exports = ({
     return undefined;
   });
   const httpLink = createHttpLink({
-    ...linkConfig,
     fetch,
+    ...linkConfig,
     uri,
     headers: {
       ...headers,


### PR DESCRIPTION
Restores previous functionality removed in #131 allowing headers to be set dynamically based on the request.