### PR TITLE
Allow forcing a deployment

### DIFF
--- a/packages/newsletter-deployment-tool/src/commands/deploy/deploy.js
+++ b/packages/newsletter-deployment-tool/src/commands/deploy/deploy.js
@@ -8,6 +8,7 @@ const {
   DOCKER_PASSWORD,
   DOCKER_USERNAME,
   TRAVIS_TAG,
+  FORCE_DEPLOYMENT,
 } = require('./env');
 const failed = require('../notify/failed');
 
@@ -93,7 +94,7 @@ module.exports = async (argv) => {
     } else {
       log('Image found, skipping build and deployment.');
       // Do not attempt to deploy if the image is already built.
-      return true;
+      if (!FORCE_DEPLOYMENT) return true;
     }
 
     const { RANCHER_CLUSTERID, RANCHER_TOKEN, RANCHER_URL } = process.env;

--- a/packages/newsletter-deployment-tool/src/commands/deploy/env.js
+++ b/packages/newsletter-deployment-tool/src/commands/deploy/env.js
@@ -1,4 +1,9 @@
-const { cleanEnv, makeValidator, url } = require('envalid');
+const {
+  cleanEnv,
+  makeValidator,
+  url,
+  bool,
+} = require('envalid');
 
 const nonemptystr = makeValidator((v) => {
   const err = new Error('Expected a non-empty string');
@@ -19,4 +24,5 @@ module.exports = cleanEnv(process.env, {
   RANCHER_TOKEN: nonemptystr({ desc: 'The Rancher credentials.' }),
   RANCHER_URL: url({ desc: 'The Rancher URL to deploy to.' }),
   TRAVIS_TAG: nonemptystr({ desc: 'The version to deploy.' }),
+  FORCE_DEPLOYMENT: bool({ desc: 'Force run a deployment when skipping build.', default: false }),
 });

--- a/packages/website-deployment-tool/src/commands/deploy/deploy.js
+++ b/packages/website-deployment-tool/src/commands/deploy/deploy.js
@@ -8,6 +8,7 @@ const {
   DOCKER_PASSWORD,
   DOCKER_USERNAME,
   TRAVIS_TAG,
+  FORCE_DEPLOYMENT,
 } = require('./env');
 const failed = require('../notify/failed');
 
@@ -93,7 +94,7 @@ module.exports = async (argv) => {
     } else {
       log('Image found, skipping build and deployment.');
       // Do not attempt to deploy if the image is already built.
-      return true;
+      if (!FORCE_DEPLOYMENT) return true;
     }
 
     const { RANCHER_CLUSTERID, RANCHER_TOKEN, RANCHER_URL } = process.env;

--- a/packages/website-deployment-tool/src/commands/deploy/env.js
+++ b/packages/website-deployment-tool/src/commands/deploy/env.js
@@ -1,4 +1,9 @@
-const { cleanEnv, makeValidator, url } = require('envalid');
+const {
+  cleanEnv,
+  makeValidator,
+  url,
+  bool,
+} = require('envalid');
 
 const nonemptystr = makeValidator((v) => {
   const err = new Error('Expected a non-empty string');
@@ -19,4 +24,5 @@ module.exports = cleanEnv(process.env, {
   RANCHER_TOKEN: nonemptystr({ desc: 'The Rancher credentials.' }),
   RANCHER_URL: url({ desc: 'The Rancher URL to deploy to.' }),
   TRAVIS_TAG: nonemptystr({ desc: 'The version to deploy.' }),
+  FORCE_DEPLOYMENT: bool({ desc: 'Force run a deployment when skipping build.', default: false }),
 });


### PR DESCRIPTION
Allows images to be deployed even if the docker build is skipped. This accounts for the following scenario:
- A repository has a staging and production build pipeline
- The staging pipeline is run before (or finishes before) the production pipeline for a production tag (v1.0.0)
- The production pipeline then sees the image as already built and (currently) bails.

This flag allows such behavior to be overwritten by adding the `FORCE_DEPLOYMENT=1` env to the Travis build. This should be rolled out in two parts for each utilizing repository:
- Ensure that the staging pipeline is executed in series **after** the production pipeline.
- Add the `FORCE_DEPLOYMENT=1` env to the staging pipeline config

Future deployments to the staging environments would therefore always cause an image deployment/upgrade, but without the need to attempt to rebuild the image.