### PR TITLE
Addition of noCrawl URL parameter (OPTIONAL)

### DIFF
--- a/packages/marko-web/middleware/with-website-section.js
+++ b/packages/marko-web/middleware/with-website-section.js
@@ -12,6 +12,7 @@ module.exports = ({
   context: contextFn,
 } = {}) => asyncRoute(async (req, res) => {
   const alias = isFn(aliasResolver) ? await aliasResolver(req, res) : req.params.alias;
+  const { noCrawl } = req.params;
   const { apollo, query } = req;
   const cleanedAlias = alias.replace(/\/+$/, '').replace(/^\/+/, '');
 
@@ -20,7 +21,7 @@ module.exports = ({
   if (redirectTo) {
     return res.redirect(301, applyQueryParams({ path: redirectTo, query }));
   }
-  if (redirectOnPathMismatch && canonicalPath !== req.path) {
+  if (redirectOnPathMismatch && canonicalPath !== req.path && !noCrawl) {
     return res.redirect(301, applyQueryParams({ path: canonicalPath, query }));
   }
   const pageNode = new PageNode(apollo, {
@@ -39,5 +40,7 @@ module.exports = ({
       pageNode,
     });
   }
-  return res.marko(template, { ...section, pageNode, context });
+  return res.marko(template, {
+    ...section, pageNode, context, noCrawl,
+  });
 });


### PR DESCRIPTION
This allows for an Express router route param of noCrawl to be added (ideally in front of anything else in the route ex: /:noCrawl(__):alias(foo-bar) ) which will indicate that the page is to be denoted as not to be crawled (additionally this behavior could/should be used to remove GTM and GAM from the head and ads from the pages it is to be used on as will be observed in a forthcoming PR.

EDIT: "Forthcoming PR": https://github.com/parameter1/industrial-media-websites/pull/155