### PR TITLE
Facebook family oembed handlers

### DIFF
--- a/packages/marko-web/utils/embedded-media/facebook-oembed.js
+++ b/packages/marko-web/utils/embedded-media/facebook-oembed.js
@@ -1,0 +1,51 @@
+const { URL } = require('url');
+
+const buildFacebookElement = ({
+  href,
+  lazy = true,
+  width,
+  showText,
+}) => {
+  const params = {
+    href: decodeURIComponent(href),
+    ...(lazy && { lazy: true }),
+    ...(width && { width }),
+    ...(showText && { 'show-text': true }),
+  };
+  const data = Object.keys(params).map(key => `data-${key}="${params[key]}"`);
+  return `<div class="fb-post" ${data.join(' ')}></div><script async defer src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>`;
+};
+
+const facebook = (url) => {
+  const pattern = /facebook\.com/i;
+  if (!pattern.test(url)) return null; // not a facebook URL.
+
+  const { href, host, searchParams } = new URL(url);
+
+  if (/facebook\.com\/plugins\//i.test(url)) {
+    // matches a plugin url, e.g. plugins/video.php plugins/post.php, etc
+    if (!searchParams.has('href')) return '<div></div>'; // no `href` query param found. remove.
+    // return facebook div element
+    return buildFacebookElement({
+      href: searchParams.get('href'),
+      showText: searchParams.get('show_text') === 'true',
+      // @todo determine if the requested width should be preserved
+      // width: searchParams.get('width'),
+    });
+  }
+  // after checking for facebook plugin URLs, treat all other facebook URLs as posts.
+  if (!pattern.test(host)) return null; // facebook.com appears somewhere else in the URL.
+  // return facebook div element
+  return buildFacebookElement({ href, showText: true });
+};
+
+
+/**
+ *
+ */
+module.exports = (url) => {
+  // convert embeds, as they no longer support oembed without auth
+  const fbPost = facebook(url);
+  if (fbPost) return fbPost;
+  return null;
+};

--- a/packages/marko-web/utils/embedded-media/instagram-oembed.js
+++ b/packages/marko-web/utils/embedded-media/instagram-oembed.js
@@ -17,21 +17,21 @@ const buildInstagramElement = ({
   }
   return `
   <iframe class="instagram-media instagram-media-rendered"
-  ${data.join(' ')}
-  allowtransparency="true"
-  frameborder="0"
-  height="700px"
-  scrolling="no"
-  style="
-  background: rgb(255, 255, 255);
-  border: 1px solid rgb(219, 219, 219);
-  margin: 0px 0px 0px; max-width: 700px;
-  width: calc(100% - 2px);
-  border-radius: 4px;
-  box-shadow: none;
-  display: block;
-  padding: 0px;">
-  </iframe>
+    ${data.join(' ')}
+    allowtransparency="true"
+    frameborder="0"
+    height="700px"
+    scrolling="no"
+    style="
+    background: rgb(255, 255, 255);
+    border: 1px solid rgb(219, 219, 219);
+    margin: 0px 0px 0px; max-width: 700px;
+    width: calc(100% - 2px);
+    border-radius: 4px;
+    box-shadow: none;
+    display: block;
+    padding: 0px;">
+    </iframe>
   <script async="" defer="" src="//platform.instagram.com/en_US/embeds.js"></script>`;
 };
 

--- a/packages/marko-web/utils/embedded-media/instagram-oembed.js
+++ b/packages/marko-web/utils/embedded-media/instagram-oembed.js
@@ -1,0 +1,57 @@
+const { URL } = require('url');
+
+const buildInstagramElement = ({
+  href,
+  lazy = true,
+  width,
+}) => {
+  const src = `${href.replace(/\/+$/g, '')}/embed/?cr=1`;
+  const params = {
+    src,
+    ...(lazy && { lazy: true }),
+    ...(width && { width }),
+  };
+  const data = Object.keys(params).map(key => `${key}="${params[key]}"`);
+  if (data.lazy) {
+    data.loading = 'lazy';
+  }
+  return `
+  <iframe class="instagram-media instagram-media-rendered"
+  ${data.join(' ')}
+  allowtransparency="true"
+  frameborder="0"
+  height="700px"
+  scrolling="no"
+  style="
+  background: rgb(255, 255, 255);
+  border: 1px solid rgb(219, 219, 219);
+  margin: 0px 0px 0px; max-width: 700px;
+  width: calc(100% - 2px);
+  border-radius: 4px;
+  box-shadow: none;
+  display: block;
+  padding: 0px;">
+  </iframe>
+  <script async="" defer="" src="//platform.instagram.com/en_US/embeds.js"></script>`;
+};
+
+const instagram = (url) => {
+  const pattern = /instagram\.com/i;
+  if (!pattern.test(url)) return null; // not a instagram URL.
+
+  const { href, host } = new URL(url);
+  // after checking for instagram URLs, treat all other instagram URLs as posts.
+  if (!pattern.test(host)) return null; // instagram.com appears somewhere else in the URL.
+  // return instagram div element
+  return buildInstagramElement({ href });
+};
+
+/**
+ *
+ */
+module.exports = (url) => {
+  // convert embeds, as they no longer support oembed without auth
+  const igPost = instagram(url);
+  if (igPost) return igPost;
+  return null;
+};

--- a/packages/marko-web/utils/embedded-media/oembed.js
+++ b/packages/marko-web/utils/embedded-media/oembed.js
@@ -1,8 +1,18 @@
 const BrowserComponent = require('../../components/browser-component');
+const facebook = require('./facebook-oembed');
+const instagram = require('./instagram-oembed');
 
 module.exports = (tag, $global) => {
   const { config } = $global;
   const url = tag.id;
+  const facebookPost = facebook(url);
+  const instagramPost = instagram(url);
   const props = { mountPoint: config.oembedMountPoint(), url, attrs: tag.attrs };
+  if (facebookPost) {
+    return facebookPost;
+  }
+  if (instagramPost) {
+    return instagramPost;
+  }
   return BrowserComponent.renderToString({ $global, name: 'OEmbed', props });
 };


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2021-08-31 at 2 39 28 PM" src="https://user-images.githubusercontent.com/46794001/131565750-ae4f9228-38c1-4358-8a41-cca2d4bf52c3.png">
<img width="1920" alt="Screen Shot 2021-08-31 at 2 39 53 PM" src="https://user-images.githubusercontent.com/46794001/131565759-2d38e290-6255-44ec-811a-97b3f5a29f7b.png">
<img width="1920" alt="Screen Shot 2021-08-31 at 2 40 15 PM" src="https://user-images.githubusercontent.com/46794001/131565769-35aca385-956c-4bfd-b903-d6cf8f502476.png">

Screenshots taken from examples provided in attached Trello card, this effectively replaces: https://github.com/parameter1/bizbash-media-websites/pull/59 and any custom oEmbed handlers for Instagram or Facebook already existing in other locations.

EDIT: The Facebook handler is a copy of the one found here: https://github.com/parameter1/randall-reilly-websites/blob/master/packages/global/oembed-handler.js . The return logic is slightly modified to fall back to the "default" handler given the Facebook one being moved to this location.

EDIT 2: Random Facebook Post from RR using handler- 
<img width="1920" alt="Screen Shot 2021-08-31 at 2 55 50 PM" src="https://user-images.githubusercontent.com/46794001/131567556-b08ae9d5-6746-401b-abce-b1dd986dc358.png">
