### PR TITLE
Update load-more to include role main, add labels.

### DIFF
--- a/packages/marko-web/components/load-more/index.marko
+++ b/packages/marko-web/components/load-more/index.marko
@@ -18,6 +18,7 @@ $ const queryParams = {
         tag="section"
         ...input.pageInput
         modifiers=["load-more", `page-${pageNumber}`, ...getAsArray(input, "pageInput.modifiers")]
+        attrs={"aria-label": `load-more-page-${pageNumber}`, "role": "main"}
       >
         <!-- Fire generic `load-more-in-view` event (other services can attach to this, e.g. GTM) -->
         <marko-web-browser-component name="TriggerInViewEvent" props={ eventName: "load-more-in-view", data: { page_number: pageNumber + 1 } } />

--- a/packages/marko-web/components/load-more/index.marko
+++ b/packages/marko-web/components/load-more/index.marko
@@ -18,7 +18,7 @@ $ const queryParams = {
         tag="section"
         ...input.pageInput
         modifiers=["load-more", `page-${pageNumber}`, ...getAsArray(input, "pageInput.modifiers")]
-        attrs={ "aria-label": `load-more-page-${pageNumber}`, "role": "main" }
+        attrs=input.attrs
       >
         <!-- Fire generic `load-more-in-view` event (other services can attach to this, e.g. GTM) -->
         <marko-web-browser-component name="TriggerInViewEvent" props={ eventName: "load-more-in-view", data: { page_number: pageNumber + 1 } } />

--- a/packages/marko-web/components/load-more/index.marko
+++ b/packages/marko-web/components/load-more/index.marko
@@ -18,7 +18,7 @@ $ const queryParams = {
         tag="section"
         ...input.pageInput
         modifiers=["load-more", `page-${pageNumber}`, ...getAsArray(input, "pageInput.modifiers")]
-        attrs={"aria-label": `load-more-page-${pageNumber}`, "role": "main"}
+        attrs={ "aria-label": `load-more-page-${pageNumber}`, "role": "main" }
       >
         <!-- Fire generic `load-more-in-view` event (other services can attach to this, e.g. GTM) -->
         <marko-web-browser-component name="TriggerInViewEvent" props={ eventName: "load-more-in-view", data: { page_number: pageNumber + 1 } } />

--- a/packages/marko-web/components/load-more/marko.json
+++ b/packages/marko-web/components/load-more/marko.json
@@ -12,7 +12,8 @@
     "@fragment-name": "string",
     "@page-input": "object",
     "@header": "string",
-    "@trigger-input": "object"
+    "@trigger-input": "object",
+    "@attrs": "object"
   },
   "<marko-web-load-more-trigger>": {
     "template": "./trigger.marko",

--- a/packages/marko-web/components/page/layouts/content.marko
+++ b/packages/marko-web/components/page/layouts/content.marko
@@ -12,7 +12,7 @@ $ const { document } = out.global;
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->
   <@container abovePage=input.abovePage belowPage=input.belowPage>
-    <@page for="content" tag="article" id=id type=type>
+    <@page for="content" tag="article" id=id type=type attrs=input.attrs>
       <${input.page} />
     </@page>
   </@container>

--- a/packages/marko-web/components/page/layouts/default.marko
+++ b/packages/marko-web/components/page/layouts/default.marko
@@ -13,7 +13,7 @@ $ const { document } = out.global;
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->
   <@container abovePage=input.abovePage belowPage=input.belowPage>
-    <@page for=type>
+    <@page for=type attrs=input.attrs>
       <${input.page} />
     </@page>
   </@container>

--- a/packages/marko-web/components/page/layouts/dynamic-page.marko
+++ b/packages/marko-web/components/page/layouts/dynamic-page.marko
@@ -12,7 +12,7 @@ $ const { document } = out.global;
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->
   <@container abovePage=input.abovePage belowPage=input.belowPage>
-    <@page for="dynamic-page" id=id>
+    <@page for="dynamic-page" id=id attrs=input.attrs>
       <${input.page} />
     </@page>
   </@container>

--- a/packages/marko-web/components/page/layouts/magazine-issue.marko
+++ b/packages/marko-web/components/page/layouts/magazine-issue.marko
@@ -12,7 +12,7 @@ $ const { document } = out.global;
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->
   <@container abovePage=input.abovePage belowPage=input.belowPage>
-    <@page for="magazine-issue" id=id>
+    <@page for="magazine-issue" id=id attrs=input.attrs>
       <${input.page} />
     </@page>
   </@container>

--- a/packages/marko-web/components/page/layouts/magazine-publication.marko
+++ b/packages/marko-web/components/page/layouts/magazine-publication.marko
@@ -12,7 +12,7 @@ $ const { document } = out.global;
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->
   <@container abovePage=input.abovePage belowPage=input.belowPage>
-    <@page for="magazine-publication" id=id>
+    <@page for="magazine-publication" id=id attrs=input.attrs>
       <${input.page} />
     </@page>
   </@container>

--- a/packages/marko-web/components/page/layouts/marko.json
+++ b/packages/marko-web/components/page/layouts/marko.json
@@ -27,7 +27,8 @@
     "@with-rss": {
       "type": "boolean",
       "default-value": true
-    }
+    },
+    "@attrs": "object"
   },
   "<marko-web-content-page-layout>": {
     "template": "./content.marko",

--- a/packages/marko-web/components/page/layouts/marko.json
+++ b/packages/marko-web/components/page/layouts/marko.json
@@ -10,7 +10,8 @@
     "<below-page>": {},
     "@type": "string",
     "@title": "string",
-    "@description": "string"
+    "@description": "string",
+    "@attrs": "object"
   },
   "<marko-web-website-section-page-layout>": {
     "template": "./website-section.marko",
@@ -40,7 +41,8 @@
     "<above-page>": {},
     "<below-page>": {},
     "@id": "number",
-    "@type": "string"
+    "@type": "string",
+    "@attrs": "object"
   },
   "<marko-web-dynamic-page-layout>": {
     "template": "./dynamic-page.marko",
@@ -52,7 +54,8 @@
     "<above-page>": {},
     "<below-page>": {},
     "@id": "string",
-    "@alias": "string"
+    "@alias": "string",
+    "@attrs": "object"
   },
   "<marko-web-magazine-issue-page-layout>": {
     "template": "./magazine-issue.marko",
@@ -63,7 +66,8 @@
     "<page>": {},
     "<above-page>": {},
     "<below-page>": {},
-    "@id": "number"
+    "@id": "number",
+    "@attrs": "object"
   },
   "<marko-web-magazine-publication-page-layout>": {
     "template": "./magazine-publication.marko",
@@ -74,6 +78,7 @@
     "<page>": {},
     "<above-page>": {},
     "<below-page>": {},
-    "@id": "number"
+    "@id": "number",
+    "@attrs": "object"
   }
 }

--- a/packages/marko-web/components/page/layouts/website-section.marko
+++ b/packages/marko-web/components/page/layouts/website-section.marko
@@ -18,7 +18,7 @@ $ const withRss = input.withRss != null ? input.withRss : true;
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->
   <@container abovePage=input.abovePage belowPage=input.belowPage>
-    <@page for="website-section" id=id attrs={ "aria-label": `website-section-${id}` }>
+    <@page for="website-section" id=id attrs=input.attrs>
       <${input.page} />
     </@page>
   </@container>

--- a/packages/marko-web/components/page/layouts/website-section.marko
+++ b/packages/marko-web/components/page/layouts/website-section.marko
@@ -18,7 +18,7 @@ $ const withRss = input.withRss != null ? input.withRss : true;
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->
   <@container abovePage=input.abovePage belowPage=input.belowPage>
-    <@page for="website-section" id=id attrs={"aria-label": `website-section-${id}`}>
+    <@page for="website-section" id=id attrs={ "aria-label": `website-section-${id}` }>
       <${input.page} />
     </@page>
   </@container>

--- a/packages/marko-web/components/page/layouts/website-section.marko
+++ b/packages/marko-web/components/page/layouts/website-section.marko
@@ -18,7 +18,7 @@ $ const withRss = input.withRss != null ? input.withRss : true;
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->
   <@container abovePage=input.abovePage belowPage=input.belowPage>
-    <@page for="website-section" id=id>
+    <@page for="website-section" id=id attrs={"aria-label": `website-section-${id}`}>
       <${input.page} />
     </@page>
   </@container>


### PR DESCRIPTION
<img width="1331" alt="Screen Shot 2021-09-07 at 9 11 50 AM" src="https://user-images.githubusercontent.com/46794001/132360635-8e83c0a1-405c-450e-81df-dfedc071e8c4.png">

Consulted:
https://www.w3.org/TR/wai-aria-practices/examples/landmarks/main.html (Either the ARIA or HTML tab both seem to indicate essentially the same thing) 
https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html (defaulting labeling practices by tag, hence why a unique label per section would need to be provided regardless of role)

This will be used in conjunction with a forthcoming PR for Ascend's websites: https://github.com/parameter1/ascend-media-websites/pull/227