### PR TITLE
Add ability to pass sortField & sortOrder into search query.

### DIFF
--- a/packages/marko-web-search/components/query.marko
+++ b/packages/marko-web-search/components/query.marko
@@ -11,6 +11,8 @@ $ const params = {
   limit: input.limit,
   skip: input.skip,
   searchQuery: input.searchQuery,
+  sortField: input.sortField,
+  sortOrder: input.sortOrder,
   contentTypes: input.contentTypes,
   ...(assignedToWebsiteSectionIds && assignedToWebsiteSectionIds.length
     ? { assignedToWebsiteSectionIds }


### PR DESCRIPTION
Add the ability to pass sort into marko web site search query
Added mapping logic to ensuring the content nodes keep their original sort order.