### PR TITLE
Allow copyright to be toggled off per site.

### DIFF
--- a/packages/marko-web-theme-default/components/site-footer/index.marko
+++ b/packages/marko-web-theme-default/components/site-footer/index.marko
@@ -1,7 +1,9 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
 $ const { config, site } = out.global;
 
 $ const blockName = input.blockName || "site-footer";
-$ const showCopyright = input.showCopyright !== undefined ? input.showCopyright : true;
+$ const showCopyright = defaultValue(input.showCopyright, true)
 
 <marko-web-block
   name=blockName

--- a/packages/marko-web-theme-default/components/site-footer/index.marko
+++ b/packages/marko-web-theme-default/components/site-footer/index.marko
@@ -1,6 +1,7 @@
 $ const { config, site } = out.global;
 
 $ const blockName = input.blockName || "site-footer";
+$ const showCopyright = input.showCopyright !== undefined ? input.showCopyright : true;
 
 <marko-web-block
   name=blockName
@@ -32,9 +33,11 @@ $ const blockName = input.blockName || "site-footer";
       reg-enabled=input.regEnabled
       has-user=input.hasUser
     />
-    <default-theme-site-footer-copyright
-      company=site.get("company")
-      notice=site.get("copyrightNotice")
-    />
+    <if(showCopyright)>
+      <default-theme-site-footer-copyright
+        company=site.get("company")
+        notice=site.get("copyrightNotice")
+      />
+    </if>
   </default-theme-site-footer-container>
 </marko-web-block>


### PR DESCRIPTION
BEFORE:
<img width="1920" alt="Screen Shot 2021-10-04 at 8 47 08 AM" src="https://user-images.githubusercontent.com/46794001/135862822-c0f9ae3c-74ad-41b4-b410-7e330ec9ac65.png">

AFTER:
<img width="1920" alt="Screen Shot 2021-10-04 at 8 43 38 AM" src="https://user-images.githubusercontent.com/46794001/135862830-13730761-f3e5-4394-ae4b-6f9225aa5c19.png">

This will have a corresponding change in the Ascend websites repo in order to pass this parameter to this component for the provided example.

EDIT: PR for that change https://github.com/parameter1/ascend-media-websites/pull/240