### PR TITLE
Do not allow/require `.marko` file extensions on import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     'import'
   ],
   rules: {
-    'no-underscore-dangle': [ 'error', { allow: ['_id'] } ],
+    'import/extensions': ['error', 'ignorePackages', { js: 'never', marko: 'never', json: 'always' } ],
+    'no-underscore-dangle': ['error', { allow: ['_id'] }],
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     'import'
   ],
   rules: {
-    'import/extensions': ['error', 'ignorePackages', { js: 'never', marko: 'never', json: 'always' } ],
+    'import/extensions': ['error', 'ignorePackages', { js: 'never', marko: 'never', json: 'always' }],
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
   },
 };

--- a/packages/export-framework/admin/routes.js
+++ b/packages/export-framework/admin/routes.js
@@ -1,5 +1,5 @@
 const { asyncRoute } = require('@parameter1/base-cms-utils');
-const template = require('./templates/index.marko');
+const template = require('./templates/index');
 
 const getSite = (arr, site) => {
   if (arr.find(({ name }) => name === site)) {

--- a/packages/marko-newsletters/admin/routes/home.js
+++ b/packages/marko-newsletters/admin/routes/home.js
@@ -1,6 +1,6 @@
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const mapTemplates = require('../../utils/map-templates');
-const template = require('../templates/index.marko');
+const template = require('../templates/index');
 
 module.exports = (router, { templates }) => {
   router.get('/', asyncRoute(async (req, res) => {

--- a/packages/marko-web-html-sitemap/routes/index.js
+++ b/packages/marko-web-html-sitemap/routes/index.js
@@ -3,8 +3,8 @@ const { getAsArray } = require('@parameter1/base-cms-object-path');
 const moment = require('moment');
 const gql = require('graphql-tag');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
-const dateListTemplate = require('../templates/date-list.marko');
-const dayTemplate = require('../templates/day.marko');
+const dateListTemplate = require('../templates/date-list');
+const dayTemplate = require('../templates/day');
 
 const FORMAT = 'YYYY-MM-DD';
 const dateNotFound = () => {

--- a/packages/marko-web/express/error-handlers.js
+++ b/packages/marko-web/express/error-handlers.js
@@ -1,6 +1,6 @@
 const { STATUS_CODES } = require('http');
 const createError = require('http-errors');
-const errorTemplate = require('../components/document/components/error.marko');
+const errorTemplate = require('../components/document/components/error');
 const getRedirect = require('./get-redirect');
 const findContentAlias = require('./find-content-alias');
 const applyQueryParams = require('../utils/apply-query-params');

--- a/packages/marko-web/express/load-document.js
+++ b/packages/marko-web/express/load-document.js
@@ -1,3 +1,3 @@
-const defaultDocument = require('../components/document/index.marko');
+const defaultDocument = require('../components/document');
 
 module.exports = document => document || defaultDocument;

--- a/packages/marko-web/middleware/with-load-more.js
+++ b/packages/marko-web/middleware/with-load-more.js
@@ -1,5 +1,5 @@
 const { asyncRoute } = require('@parameter1/base-cms-utils');
-const LoadMore = require('../components/load-more/index.marko');
+const LoadMore = require('../components/load-more');
 
 module.exports = () => asyncRoute(async (req, res) => {
   const { method, query, body } = req;

--- a/packages/marko-web/utils/embedded-media/oembed.js
+++ b/packages/marko-web/utils/embedded-media/oembed.js
@@ -1,4 +1,4 @@
-const BrowserComponent = require('../../components/browser-component.marko');
+const BrowserComponent = require('../../components/browser-component');
 const facebook = require('./facebook-oembed');
 const instagram = require('./instagram-oembed');
 

--- a/packages/web-cli/src/generator/templates/bootstrap/server/routes/load-more.js
+++ b/packages/web-cli/src/generator/templates/bootstrap/server/routes/load-more.js
@@ -1,5 +1,5 @@
 const { withLoadMore } = require('@parameter1/base-cms-marko-web/middleware');
-const contentSubPageA = require('../components/content-sub-page-a.marko');
+const contentSubPageA = require('../components/content-sub-page-a');
 
 // Register blocks that support load more...
 const blocks = {

--- a/packages/web-cli/src/generator/templates/core/.eslintrc.js
+++ b/packages/web-cli/src/generator/templates/core/.eslintrc.js
@@ -10,4 +10,7 @@ module.exports = {
       },
     },
   },
+  rules: {
+    'import/extensions': ['error', 'ignorePackages', { js: 'never', marko: 'never', json: 'always' } ],
+  },
 };

--- a/packages/web-cli/src/generator/templates/core/.eslintrc.js
+++ b/packages/web-cli/src/generator/templates/core/.eslintrc.js
@@ -11,6 +11,6 @@ module.exports = {
     },
   },
   rules: {
-    'import/extensions': ['error', 'ignorePackages', { js: 'never', marko: 'never', json: 'always' } ],
+    'import/extensions': ['error', 'ignorePackages', { js: 'never', marko: 'never', json: 'always' }],
   },
 };

--- a/packages/web-cli/src/generator/templates/core/server/routes/content.js
+++ b/packages/web-cli/src/generator/templates/core/server/routes/content.js
@@ -1,6 +1,6 @@
 const gql = require('graphql-tag');
 const { withContent } = require('@parameter1/base-cms-marko-web/middleware');
-const content = require('../templates/content/index.marko');
+const content = require('../templates/content');
 
 module.exports = (app) => {
   app.get('/:prefix(*):id(\\d{8}):suffix(*)', withContent({

--- a/packages/web-cli/src/generator/templates/core/server/routes/dynamic-page.js
+++ b/packages/web-cli/src/generator/templates/core/server/routes/dynamic-page.js
@@ -1,5 +1,5 @@
 const { withDynamicPage } = require('@parameter1/base-cms-marko-web/middleware');
-const page = require('../templates/dynamic-page/index.marko');
+const page = require('../templates/dynamic-page');
 
 module.exports = (app) => {
   app.get('/page/:alias', withDynamicPage({

--- a/packages/web-cli/src/generator/templates/core/server/routes/index.js
+++ b/packages/web-cli/src/generator/templates/core/server/routes/index.js
@@ -1,6 +1,6 @@
 const contentTypes = require('./content');
 const dynamicPages = require('./dynamic-page');
-const index = require('../templates/index.marko');
+const index = require('../templates/index');
 const loadMore = require('./load-more');
 const websiteSections = require('./website-section');
 

--- a/packages/web-cli/src/generator/templates/core/server/routes/website-section.js
+++ b/packages/web-cli/src/generator/templates/core/server/routes/website-section.js
@@ -1,5 +1,5 @@
 const { withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
-const section = require('../templates/website-section/index.marko');
+const section = require('../templates/website-section');
 
 module.exports = (app) => {
   app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({


### PR DESCRIPTION
Note: if lint errors similar to `Missing file extension "marko" for "../templates/dynamic-page"  import/extensions` are being reported in your newsletter or site repositories, you must added the following rule to the `.eslintrc.js` file in the root of the site/newsletter project: `'import/extensions': ['error', 'ignorePackages', { js: 'never', marko: 'never', json: 'always' } ],`

The resulting `.eslintrc.js` file will then look something like the below:
```js
module.exports = {
  extends: 'airbnb-base',
  plugins: [
    'import'
  ],
  settings: {
    'import/resolver': {
      node: {
        extensions: ['.js', '.marko'],
      },
    },
  },
  rules: {
    'import/extensions': ['error', 'ignorePackages', { js: 'never', marko: 'never', json: 'always' }],
  },
};

```

