### PR TITLE
Override deferred script loading via `out.global.$deferScripts`

### DIFF
--- a/packages/marko-web-deferred-script-loader/components/register.marko
+++ b/packages/marko-web-deferred-script-loader/components/register.marko
@@ -1,12 +1,24 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsObject } from "@parameter1/base-cms-object-path";
+import getRegisterConfig from "../get-register-config";
 
-$ const on = defaultValue(input.on, "ready");
+$ const {
+  on,
+  requestFrame,
+  targetTag,
+} = getRegisterConfig({
+  name: input.name,
+  globalConfig: out.global.$deferScripts,
+  inputConfig: {
+    on: defaultValue(input.on, "ready"),
+    requestFrame: Boolean(input.requestFrame),
+    targetTag: defaultValue(input.targetTag, "body"),
+  },
+});
+
 $ const init = `function() { ${input.init || ''} }`;
 $ const onScriptBuild = `function(script) { ${input.onScriptBuild || ''} }`;
 $ const onScriptLoaded = `function() { ${input.onScriptLoaded || ''} }`;
 $ const attrs = JSON.stringify(getAsObject(input, "attrs"));
-$ const requestFrame = Boolean(input.requestFrame);
-$ const targetTag = defaultValue(input.targetTag, "body");
 
 <script>deferScript('register', { name: '${input.name}', src: '${input.src}', on: '${on}', requestFrame: ${requestFrame}, targetTag: '${targetTag}', init: ${init}, onScriptBuild: ${onScriptBuild}, onScriptLoaded: ${onScriptLoaded}, attrs: ${attrs} });</script>

--- a/packages/marko-web-deferred-script-loader/get-register-config.js
+++ b/packages/marko-web-deferred-script-loader/get-register-config.js
@@ -1,0 +1,17 @@
+const { getAsObject } = require('@parameter1/base-cms-object-path');
+
+module.exports = (params = {}) => {
+  const { name } = params;
+  const inputConfig = getAsObject(params, 'inputConfig');
+  const globalConfig = getAsObject(params, 'globalConfig');
+
+  return ['on', 'requestFrame', 'targetTag'].reduce((o, prop) => {
+    // check for specific value for the provided script name, e.g. `{ googletag.on: 'load' }`
+    const namedProp = `${name}.${prop}`;
+    if (globalConfig[namedProp] != null) return { ...o, [prop]: globalConfig[namedProp] };
+    // then check for a global (all scripts) prop, e.g. `{ on: 'never' }`
+    if (globalConfig[prop] != null) return { ...o, [prop]: globalConfig[prop] };
+    // otherwise, return the local/specific config value.
+    return { ...o, [prop]: inputConfig[prop] };
+  }, {});
+};


### PR DESCRIPTION
The `on`, `requestFrame` and `targetTag` deferred script configuration values can now be overridden by setting them to the `out.global.$deferScripts` object. This is useful, for example, on a "stealth" link where all deferred/tracking scripts should be disabled (but enabled on all other routes):

```js
const template = require('../templates/stealth-link.marko');

module.exports = (app) => {
  app.get('/__about-us', (_, res) => {
    // disable all deferred scripts (P1 events, GTM/GA, GAM, etc)
    res.locals.$deferScripts = { on: 'never' };
    res.marko(template);
  });
};
```