### PR TITLE
Add support for findOne vs strictFindOne on loadSection call.

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -601,41 +601,45 @@ module.exports = {
       if (optionId.length && optionName.length) throw new UserInputError('You cannot provide both optionId and optionName as input.');
 
       const siteId = input.siteId || site.id();
-      const [section, options] = await Promise.all([
-        loadSection({
-          basedb,
-          siteId,
-          id: sectionId,
-          alias: sectionAlias,
-        }),
-        loadOptions({
-          basedb,
-          siteId,
-          ids: optionId,
-          names: optionName.length ? optionName : ['Standard'],
-        }),
-      ]);
+      try {
+        const [section, options] = await Promise.all([
+          loadSection({
+            basedb,
+            siteId,
+            id: sectionId,
+            alias: sectionAlias,
+          }),
+          loadOptions({
+            basedb,
+            siteId,
+            ids: optionId,
+            names: optionName.length ? optionName : ['Standard'],
+          }),
+        ]);
 
-      const descendantIds = sectionBubbling ? await getDescendantIds(section._id, basedb) : [];
+        const descendantIds = sectionBubbling ? await getDescendantIds(section._id, basedb) : [];
 
-      const now = new Date();
-      const $elemMatch = {
-        sectionId: descendantIds.length ? { $in: descendantIds } : section._id,
-        optionId: { $in: options.map(opt => opt._id) },
-        start: { $lte: now },
-        $and: [
-          {
-            $or: [
-              { end: { $gt: now } },
-              { end: { $exists: false } },
-            ],
-          },
-        ],
-      };
+        const now = new Date();
+        const $elemMatch = {
+          sectionId: descendantIds.length ? { $in: descendantIds } : section._id,
+          optionId: { $in: options.map(opt => opt._id) },
+          start: { $lte: now },
+          $and: [
+            {
+              $or: [
+                { end: { $gt: now } },
+                { end: { $exists: false } },
+              ],
+            },
+          ],
+        };
 
-      const query = { _id: doc._id, sectionQuery: { $elemMatch } };
-      const matched = await basedb.findOne('platform.Content', query, { projection: { _id: 1 } });
-      return Boolean(matched);
+        const query = { _id: doc._id, sectionQuery: { $elemMatch } };
+        const matched = await basedb.findOne('platform.Content', query, { projection: { _id: 1 } });
+        return Boolean(matched);
+      } catch (e) {
+        return false;
+      }
     },
   },
 


### PR DESCRIPTION
Add ability to pass strict to load section.  Allowing the look up to use findOne vs strictFindOne.  

Example with invalid alias lookup:

<img width="1791" alt="Screen Shot 2021-10-28 at 2 21 51 PM" src="https://user-images.githubusercontent.com/3845869/139322517-d5b77c37-fc11-40d4-ac26-83a60e476d6a.png">

With valid alias look up:

<img width="1792" alt="Screen Shot 2021-10-28 at 2 22 04 PM" src="https://user-images.githubusercontent.com/3845869/139322648-4f52450d-483a-43d2-a42b-7157fac04f81.png">


