### PR TITLE
Embedded image attribute handling

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -175,7 +175,7 @@ enum RelatedContentQueryType {
 }
 
 type ContentStubSidebar {
-  body: String
+  body(input: ContentStubSidebarBodyInput = {}): String
   name: String
   label: String
   sequence: Int!
@@ -302,6 +302,15 @@ type QueryMostPopularContentConnection {
 
 type QueryMostPopularContentEdge {
   node: MostPopularContent!
+}
+
+input ContentStubSidebarBodyInput {
+  "Embedded image defaults to apply to inline images"
+  imageAttrs: EmbeddedImageAttrsInput = {
+    w: 1280,
+    fit: "max",
+    auto: "format,compress"
+  }
 }
 
 input ContentQueryInput {

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -665,6 +665,20 @@ input ContentTeaserInput {
 
 input ContentBodyInput {
   mutation: ContentMutation = Website
+  imageAttrs: EmbeddedImageAttrsInput = {
+    w: 1280,
+    fit: "max",
+    auto: "format,compress"
+  }
+}
+
+input EmbeddedImageAttrsInput {
+  "The (max) width of the embedded image"
+  w: Int
+  "The Imgix 'fit' parameter"
+  fit: String
+  "The Imgix 'auto' parameter"
+  auto: String
 }
 
 input ContentTaxonomyInput {

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -682,7 +682,7 @@ input ContentBodyInput {
 }
 
 input EmbeddedImageAttrsInput {
-  "The (max) width of the embedded image"
+  "The width of the embedded image"
   w: Int
   "The Imgix 'fit' parameter"
   fit: String

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/sidebar-enabled.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/sidebar-enabled.js
@@ -15,6 +15,12 @@ input ContentSidebarStubsInput {
   "Filters the sidebars by one or more labels. An empty value will return all sidebars"
   labels: [String!] = []
   sort: ContentSidebarSortInput = {}
+  "Embedded image defaults to apply to inline images"
+  imageAttrs: EmbeddedImageAttrsInput = {
+    w: 1280,
+    fit: "max",
+    auto: "format,compress"
+  }
 }
 
 input ContentSidebarSortInput {

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/sidebar-enabled.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/sidebar-enabled.js
@@ -15,12 +15,6 @@ input ContentSidebarStubsInput {
   "Filters the sidebars by one or more labels. An empty value will return all sidebars"
   labels: [String!] = []
   sort: ContentSidebarSortInput = {}
-  "Embedded image defaults to apply to inline images"
-  imageAttrs: EmbeddedImageAttrsInput = {
-    w: 1280,
-    fit: "max",
-    auto: "format,compress"
-  }
 }
 
 input ContentSidebarSortInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -472,7 +472,7 @@ module.exports = {
     taxonomyIds: content => getAsArray(content, 'taxonomy').map(t => parseInt(t.oid, 10)).filter(id => id),
 
     body: async (content, { input }, { site, basedb }) => {
-      const { mutation } = input;
+      const { mutation, imageAttrs } = input;
       const { body } = content;
       const mutated = get(content, `mutations.${mutation}.body`);
 
@@ -482,7 +482,7 @@ module.exports = {
       // Convert image tags to include image attributes (src, alt, caption, credit).
       // Convert document tags to include href and file extension.
       const [imageTags, documentTags] = await Promise.all([
-        getEmbeddedImageTags(value, { imageHost, basedb }),
+        getEmbeddedImageTags(value, { imageHost, imageAttrs, basedb }),
         getEmbeddedDocumentTags(value, { imageHost, basedb }),
       ]);
 

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -785,7 +785,9 @@ module.exports = {
   },
 
   ContentStubSidebar: {
-    body: async ({ body }, _, { site, imageAttrs, basedb }) => {
+    body: async ({ body }, { input }, { site, basedb }) => {
+      const { imageAttrs } = input;
+      console.log('imageAttrs', imageAttrs);
       const value = await prepareSidebarBody(body, { site, imageAttrs, basedb });
       return value;
     },

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -787,7 +787,6 @@ module.exports = {
   ContentStubSidebar: {
     body: async ({ body }, { input }, { site, basedb }) => {
       const { imageAttrs } = input;
-      console.log('imageAttrs', imageAttrs);
       const value = await prepareSidebarBody(body, { site, imageAttrs, basedb });
       return value;
     },

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -192,12 +192,12 @@ const updateContentMutationHandler = ({
   return basedb.findById('platform.Content', id, { projection: { ...projection, type: 1 } });
 };
 
-const prepareSidebarBody = async (body, { site, basedb }) => {
+const prepareSidebarBody = async (body, { site, imageAttrs, basedb }) => {
   if (!body) return null;
   let value = body.trim();
   if (!value) return null;
   const imageHost = site.get('imageHost', defaults.imageHost);
-  const imageTags = await getEmbeddedImageTags(value, { imageHost, basedb });
+  const imageTags = await getEmbeddedImageTags(value, { imageHost, imageAttrs, basedb });
   imageTags.forEach((tag) => {
     const replacement = tag.isValid() ? tag.build() : '';
     value = value.replace(tag.getRegExp(), replacement);
@@ -648,10 +648,10 @@ module.exports = {
    *
    */
   ContentArticle: {
-    sidebars: async ({ sidebars }, _, { site, basedb }) => {
+    sidebars: async ({ sidebars }, { imageAttrs }, { site, basedb }) => {
       if (!isArray(sidebars)) return [];
       const bodies = await Promise.all(sidebars.map(async ({ body } = {}) => {
-        const value = await prepareSidebarBody(body, { site, basedb });
+        const value = await prepareSidebarBody(body, { site, imageAttrs, basedb });
         return value;
       }));
       return bodies.filter(v => v);
@@ -785,8 +785,8 @@ module.exports = {
   },
 
   ContentStubSidebar: {
-    body: async ({ body }, _, { site, basedb }) => {
-      const value = await prepareSidebarBody(body, { site, basedb });
+    body: async ({ body }, _, { site, imageAttrs, basedb }) => {
+      const value = await prepareSidebarBody(body, { site, imageAttrs, basedb });
       return value;
     },
     name: ({ name }) => {

--- a/services/graphql-server/src/graphql/utils/embedded-image-tags.js
+++ b/services/graphql-server/src/graphql/utils/embedded-image-tags.js
@@ -32,11 +32,6 @@ module.exports = async (body, { imageHost, imageAttrs, basedb }) => {
       ...defaults,
       ...imageAttrs,
     }));
-    tag.set('srcSet', createSrcFor(imageHost, image, {
-      ...defaults,
-      ...imageAttrs,
-      dpr: 2,
-    }));
     tag.set('caption', createCaptionFor(image.caption));
     tag.set('credit', image.credit);
     return tag;

--- a/services/graphql-server/src/graphql/utils/embedded-image-tags.js
+++ b/services/graphql-server/src/graphql/utils/embedded-image-tags.js
@@ -29,7 +29,7 @@ module.exports = async (body, { imageHost, basedb }) => {
     tag.set('src', createSrcFor(imageHost, image, {
       w: size,
       fit: 'max',
-      auto: 'format',
+      auto: 'format,compress',
     }));
     tag.set('caption', createCaptionFor(image.caption));
     tag.set('credit', image.credit);

--- a/services/graphql-server/src/graphql/utils/embedded-image-tags.js
+++ b/services/graphql-server/src/graphql/utils/embedded-image-tags.js
@@ -1,7 +1,7 @@
 const { extractEmbeddedTags } = require('@parameter1/base-cms-embedded-media');
 const { createAltFor, createSrcFor, createCaptionFor } = require('@parameter1/base-cms-image');
 
-module.exports = async (body, { imageHost, basedb }) => {
+module.exports = async (body, { imageHost, imageAttrs, basedb }) => {
   if (!body) return [];
   const imageTags = extractEmbeddedTags(body).filter(tag => tag.type === 'image');
   return Promise.all(imageTags.map(async (tag) => {
@@ -20,16 +20,15 @@ module.exports = async (body, { imageHost, basedb }) => {
       tag.setValid(false);
       return tag;
     }
-    // const defaultSize = ['left', 'right'].includes(tag.get('align')) ? '320' : '640';
-    // const size = tag.get('size', defaultSize).replace('w', '');
-    // @todo Adjust this. Hardcoding for now to allow for crisp images until proper w/h is handled.
-    const size = '1440';
 
     tag.set('alt', createAltFor(image));
     tag.set('src', createSrcFor(imageHost, image, {
-      w: size,
+      // Set sane defaults
+      w: '1280',
       fit: 'max',
       auto: 'format,compress',
+      // Allow new values to be input
+      ...imageAttrs,
     }));
     tag.set('caption', createCaptionFor(image.caption));
     tag.set('credit', image.credit);

--- a/services/graphql-server/src/graphql/utils/embedded-image-tags.js
+++ b/services/graphql-server/src/graphql/utils/embedded-image-tags.js
@@ -1,6 +1,12 @@
 const { extractEmbeddedTags } = require('@parameter1/base-cms-embedded-media');
 const { createAltFor, createSrcFor, createCaptionFor } = require('@parameter1/base-cms-image');
 
+const defaults = {
+  w: '1280',
+  fit: 'max',
+  auto: 'format,compress',
+};
+
 module.exports = async (body, { imageHost, imageAttrs, basedb }) => {
   if (!body) return [];
   const imageTags = extractEmbeddedTags(body).filter(tag => tag.type === 'image');
@@ -23,12 +29,13 @@ module.exports = async (body, { imageHost, imageAttrs, basedb }) => {
 
     tag.set('alt', createAltFor(image));
     tag.set('src', createSrcFor(imageHost, image, {
-      // Set sane defaults
-      w: '1280',
-      fit: 'max',
-      auto: 'format,compress',
-      // Allow new values to be input
+      ...defaults,
       ...imageAttrs,
+    }));
+    tag.set('srcSet', createSrcFor(imageHost, image, {
+      ...defaults,
+      ...imageAttrs,
+      dpr: 2,
     }));
     tag.set('caption', createCaptionFor(image.caption));
     tag.set('credit', image.credit);


### PR DESCRIPTION
- Move attribute defaults for embedded images to the GraphQL definitions for the relevant `body` field
- Change default `auto` parameter to include `compress`
- Change default `w` to be `1280`px instead of `1440`
- Include `src-set` with a pre-built 2x dpr tag with the embed tag

When specified, the `w`, `fit`, and `auto` parameters can be modified from the defaults by supplying input arguments to the `body` field (content or sidebar)

![image](https://user-images.githubusercontent.com/1778222/139502124-8ca14173-5813-420b-876f-1fd7c360584c.png)
