### PR TITLE
Add style to account for conversion of h6 => p.footnote content body element change

### DIFF
--- a/packages/marko-web-theme-default/scss/components/_page-contents.scss
+++ b/packages/marko-web-theme-default/scss/components/_page-contents.scss
@@ -50,6 +50,17 @@
         line-height: .8;
       }
     }
+
+    p.footnote {
+      @include theme-apply-fonts(
+        $font-family: $theme-content-heading-h6-font-family,
+        $font-size-sm: $theme-content-heading-h6-font-size-sm,
+        $font-size: $theme-content-heading-h6-font-size,
+        $font-weight: $theme-content-heading-h6-font-weight,
+        $line-height-sm: $theme-content-heading-h6-line-height-sm,
+        $line-height: $theme-content-heading-h6-line-height
+      );
+    }
   }
 
   &__content-sidebar {


### PR DESCRIPTION
We are converting h3 to h2, h6 to p tags with a class of footnote & h4 & h5 tags to h3 tags.

This style is to specifically to apply the h6 style to the content body p tag with the footnote class. 

