### PR TITLE
Remove default `{ field: null }` from `WebsiteScheduledContentQueryInput.sort`

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -630,7 +630,7 @@ input WebsiteScheduledContentQueryInput {
   useOptionFallback: Boolean = false
   sectionBubbling: Boolean = true
   pagination: PaginationInput = {}
-  sort: ContentSortInput = { field: null }
+  sort: ContentSortInput = {}
   after: Date
   since: Date
   "For types with a startDate field: Limit results to items with a startDate matching the criteria."


### PR DESCRIPTION
I'm not sure where in the resolving this causes the results to be limited to 1 but removing it resolves the issue documented in https://github.com/parameter1/base-cms/issues/185

<img width="1792" alt="Screen Shot 2021-11-12 at 11 51 29 AM" src="https://user-images.githubusercontent.com/46794001/141512233-ebfbbdc9-1d54-4b64-bffb-b29077663c20.png">
