### PR TITLE
Consolidate Omeda, IdentityX and Omeda+IdentityX installation

### DIFF
--- a/packages/marko-web-identity-x/index.js
+++ b/packages/marko-web-identity-x/index.js
@@ -1,6 +1,11 @@
 const routes = require('./routes');
 const middleware = require('./middleware');
 
+/**
+ *
+ * @param {object} app The express app instance
+ * @param {IdentityXConfiguration} config The IdentityX config
+ */
 module.exports = (app, config) => {
   app.use(middleware(config));
   app.use('/__idx', routes);

--- a/packages/marko-web-omeda-identity-x/add-integration-hooks.js
+++ b/packages/marko-web-omeda-identity-x/add-integration-hooks.js
@@ -14,19 +14,17 @@ const {
 module.exports = ({
   idxConfig,
   brandKey,
-  productId,
-  omedaGraphQLProp = '$omeda',
+  omedaGraphQLProp = '$omedaGraphQLClient',
+  idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
 } = {}) => {
   if (!idxConfig) throw new Error('The IdentityX configuration instances is required to add Omeda+IdentityX integration hooks.');
-  if (!brandKey) throw new Error('An Omeda brand key is required to add Omeda+IdentityX integration hooks.');
-  if (!productId) throw new Error('An Omeda rapid identification product ID is required to add Omeda+IdentityX integration hooks.');
   idxConfig.addHook({
     name: 'onLoginLinkSent',
     shouldAwait: false,
     fn: async ({ req, service, user }) => onLoginLinkSent({
       brandKey,
-      productId,
       omedaGraphQLProp,
+      idxOmedaRapidIdentifyProp,
 
       req,
       service,
@@ -43,14 +41,10 @@ module.exports = ({
   idxConfig.addHook({
     name: 'onUserProfileUpdate',
     shouldAwait: false,
-    fn: async ({ user, service, req }) => onUserProfileUpdate({
-      brandKey,
-      productId,
-      omedaGraphQLProp,
-
-      user,
-      service,
+    fn: async ({ user, req }) => onUserProfileUpdate({
+      idxOmedaRapidIdentifyProp,
       req,
+      user,
     }),
   });
 

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -47,6 +47,12 @@ module.exports = (app, {
     omedaRapidIdentifyProp,
   }));
 
+  // register the rapid identify AJAX route
+  app.use('/__idx/omeda-rapid-ident', rapidIdentify({
+    brandKey,
+    idxOmedaRapidIdentifyProp,
+  }));
+
   // strip `oly_enc_id` when identity-x user is logged-in
   app.use(stripOlyticsParam());
 };

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -1,0 +1,52 @@
+const omeda = require('@parameter1/base-cms-marko-web-omeda');
+const identityX = require('@parameter1/base-cms-marko-web-identity-x');
+const addOmedaHooksToConfig = require('./add-integration-hooks');
+const stripOlyticsParam = require('./middleware/strip-olytics-param');
+const rapidIdentify = require('./middleware/rapid-identify');
+
+module.exports = (app, {
+  brandKey,
+  clientKey,
+  appId,
+  inputId,
+
+  rapidIdentProductId,
+  omedaGraphQLClientProp = '$omedaGraphQLClient',
+  omedaRapidIdentifyProp = '$omedaRapidIdentify',
+
+  idxConfig,
+  idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
+} = {}) => {
+  // install omeda middleware
+  omeda(app, {
+    brandKey,
+    clientKey,
+    appId,
+    inputId,
+    rapidIdentProductId,
+    omedaGraphQLClientProp,
+    omedaRapidIdentifyProp,
+  });
+
+  // add appropiate identity-x to omeda integration hooks
+  addOmedaHooksToConfig({
+    idxConfig,
+    brandKey,
+    productId: rapidIdentProductId,
+    omedaGraphQLProp: omedaGraphQLClientProp,
+  });
+
+  // install identity x
+  identityX(app, idxConfig);
+
+  // attach the identity-x rapid identification wrapper middleware
+  app.use(rapidIdentify({
+    brandKey,
+    productId: rapidIdentProductId,
+    prop: idxOmedaRapidIdentifyProp,
+    omedaRapidIdentifyProp,
+  }));
+
+  // strip `oly_enc_id` when identity-x user is logged-in
+  app.use(stripOlyticsParam());
+};

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -5,7 +5,7 @@ const stripOlyticsParam = require('./middleware/strip-olytics-param');
 const rapidIdentify = require('./middleware/rapid-identify');
 
 module.exports = (app, {
-  brandKey,
+  brandKey: brand,
   clientKey,
   appId,
   inputId,
@@ -17,6 +17,13 @@ module.exports = (app, {
   idxConfig,
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
 } = {}) => {
+  if (!brand) throw new Error('The Omeda `brandKey` is required.');
+  if (!appId) throw new Error('The Omeda `appId` is required.');
+  if (!rapidIdentProductId) throw new Error('The Omeda `rapidIdentProductId` is required.');
+
+  // consistently pass brand key
+  const brandKey = brand.trim().toLowerCase();
+
   // install omeda middleware
   omeda(app, {
     brandKey,

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -1,6 +1,6 @@
 const omeda = require('@parameter1/base-cms-marko-web-omeda');
 const identityX = require('@parameter1/base-cms-marko-web-identity-x');
-const addOmedaHooksToConfig = require('./add-integration-hooks');
+const addOmedaHooksToIdentityXConfig = require('./add-integration-hooks');
 const stripOlyticsParam = require('./middleware/strip-olytics-param');
 const rapidIdentify = require('./middleware/rapid-identify');
 
@@ -36,7 +36,7 @@ module.exports = (app, {
   });
 
   // add appropiate identity-x to omeda integration hooks
-  addOmedaHooksToConfig({
+  addOmedaHooksToIdentityXConfig({
     idxConfig,
     brandKey,
     productId: rapidIdentProductId,

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
@@ -136,13 +136,13 @@ module.exports = async ({
 }) => {
   const omedaGraphQLClient = req[omedaGraphQLProp];
   if (!omedaGraphQLClient) throw new Error(`Unable to load the Omeda GraphQL API from the request using prop ${omedaGraphQLProp}`);
-  const idxRapidIdentify = req[idxOmedaRapidIdentifyProp];
-  if (!idxRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
+  const idxOmedaRapidIdentify = req[idxOmedaRapidIdentifyProp];
+  if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
 
   // get omeda customer id (via rapid identity) and load omeda custom field data
   const [{ data }, { encryptedCustomerId }] = await Promise.all([
     identityX.client.query({ query: FIELD_QUERY }),
-    idxRapidIdentify({
+    idxOmedaRapidIdentify({
       user: user.verified ? user : { id: user.id, email: user.email },
     }),
   ]);

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
@@ -1,7 +1,6 @@
 const gql = require('graphql-tag');
 const { get, getAsArray } = require('@parameter1/base-cms-object-path');
 const isOmedaDemographicId = require('../external-id/is-demographic-id');
-const rapidIdentify = require('../rapid-identify');
 
 const FIELD_QUERY = gql`
   query GetCustomFields {
@@ -58,13 +57,13 @@ const SET_OMEDA_DEMOGRAPHIC_DATA = gql`
   }
 `;
 
-const getOmedaCustomerRecord = async (omedaGraphQL, encryptedCustomerId) => {
+const getOmedaCustomerRecord = async (omedaGraphQLClient, encryptedCustomerId) => {
   const variables = { id: encryptedCustomerId };
-  const { data } = await omedaGraphQL.query({ query: CUSTOMER_QUERY, variables });
+  const { data } = await omedaGraphQLClient.query({ query: CUSTOMER_QUERY, variables });
   return data.customerByEncryptedId;
 };
 
-const setOmedaData = async ({ service, user, omedaCustomer }) => {
+const setOmedaData = async ({ identityX, user, omedaCustomer }) => {
   const input = {
     email: user.email,
 
@@ -77,14 +76,14 @@ const setOmedaData = async ({ service, user, omedaCustomer }) => {
     regionCode: get(omedaCustomer, 'primaryPostalAddress.regionCode'),
     postalCode: get(omedaCustomer, 'primaryPostalAddress.postalCode'),
   };
-  return service.client.mutate({
+  return identityX.client.mutate({
     mutation: SET_OMEDA_DATA,
     variables: { input },
   });
 };
 
 const setOmedaDemographics = async ({
-  service,
+  identityX,
   user,
   omedaCustomer,
   omedaLinkedFields,
@@ -118,35 +117,33 @@ const setOmedaDemographics = async ({
     answerMap.forEach((optionIdSet, fieldId) => {
       answers.push({ fieldId, optionIds: [...optionIdSet] });
     });
-    await service.client.mutate({
+    await identityX.client.mutate({
       mutation: SET_OMEDA_DEMOGRAPHIC_DATA,
       variables: { input: { id: user.id, answers } },
-      context: { apiToken: service.config.getApiToken() },
+      context: { apiToken: identityX.config.getApiToken() },
     });
   }
 };
 
 module.exports = async ({
   brandKey,
-  productId,
-  omedaGraphQLProp = '$omeda',
+  omedaGraphQLProp = '$omedaGraphQLClient',
+  idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
 
   req,
-  service,
+  service: identityX,
   user,
 }) => {
-  const omedaGraphQL = req[omedaGraphQLProp];
-  if (!omedaGraphQL) throw new Error(`Unable to load the Omeda GraphQL API from the request using prop ${omedaGraphQLProp}`);
+  const omedaGraphQLClient = req[omedaGraphQLProp];
+  if (!omedaGraphQLClient) throw new Error(`Unable to load the Omeda GraphQL API from the request using prop ${omedaGraphQLProp}`);
+  const idxRapidIdentify = req[idxOmedaRapidIdentifyProp];
+  if (!idxRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
 
   // get omeda customer id (via rapid identity) and load omeda custom field data
   const [{ data }, { encryptedCustomerId }] = await Promise.all([
-    service.client.query({ query: FIELD_QUERY }),
-    rapidIdentify({
-      brandKey,
-      productId,
-      appUser: user.verified ? user : { id: user.id, email: user.email },
-      identityX: service,
-      omedaGraphQL,
+    identityX.client.query({ query: FIELD_QUERY }),
+    idxRapidIdentify({
+      user: user.verified ? user : { id: user.id, email: user.email },
     }),
   ]);
 
@@ -170,12 +167,12 @@ module.exports = async ({
   }
 
   // find the omeda customer record to "prime" the identity-x user.
-  const omedaCustomer = await getOmedaCustomerRecord(omedaGraphQL, encryptedCustomerId);
+  const omedaCustomer = await getOmedaCustomerRecord(omedaGraphQLClient, encryptedCustomerId);
   const promises = [];
-  if (!user.verified) promises.push(setOmedaData({ service, user, omedaCustomer }));
+  if (!user.verified) promises.push(setOmedaData({ identityX, user, omedaCustomer }));
   if (!hasAnsweredAllOmedaQuestions) {
     promises.push(setOmedaDemographics({
-      service,
+      identityX,
       user,
       omedaCustomer,
       omedaLinkedFields,

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
@@ -1,21 +1,9 @@
-const rapidIdentify = require('../rapid-identify');
-
 module.exports = async ({
-  brandKey,
-  productId,
-  omedaGraphQLProp = '$omeda',
-
-  user,
-  service,
+  idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
   req,
+  user,
 }) => {
-  const omedaGraphQL = req[omedaGraphQLProp];
-  if (!omedaGraphQL) throw new Error(`Unable to load the Omeda GraphQL API from the request using prop ${omedaGraphQLProp}`);
-  return rapidIdentify({
-    brandKey,
-    productId,
-    appUser: user,
-    identityX: service,
-    omedaGraphQL,
-  });
+  const idxRapidIdentify = req[idxOmedaRapidIdentifyProp];
+  if (!idxRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
+  return idxRapidIdentify({ user });
 };

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
@@ -3,7 +3,7 @@ module.exports = async ({
   req,
   user,
 }) => {
-  const idxRapidIdentify = req[idxOmedaRapidIdentifyProp];
-  if (!idxRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
-  return idxRapidIdentify({ user });
+  const idxOmedaRapidIdentify = req[idxOmedaRapidIdentifyProp];
+  if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
+  return idxOmedaRapidIdentify({ user });
 };

--- a/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
@@ -1,0 +1,30 @@
+const idxRapidIdentify = require('../rapid-identify');
+
+module.exports = ({
+  brandKey,
+  productId,
+
+  prop = '$idxOmedaRapidIdentify',
+  omedaRapidIdentifyProp = '$omedaRapidIdentify',
+}) => {
+  if (!prop) throw new Error('An Omeda + IdentityX rapid identifcation prop is required.');
+  if (!omedaRapidIdentifyProp) throw new Error('The Omeda rapid identifcation prop is required.');
+
+  return (req, res, next) => {
+    const rapidIdentify = req[omedaRapidIdentifyProp];
+    if (!rapidIdentify) throw new Error(`Unable to find the Omeda rapid identifier on the request using ${omedaRapidIdentifyProp}`);
+
+    const handler = async ({ user } = {}) => idxRapidIdentify({
+      brandKey,
+      productId,
+      appUser: user,
+
+      identityX: req.identityX,
+      rapidIdentify,
+    });
+
+    req[prop] = handler;
+    res.locals[prop] = handler;
+    next();
+  };
+};

--- a/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
@@ -1,4 +1,4 @@
-const idxRapidIdentify = require('../rapid-identify');
+const idxOmedaRapidIdentify = require('../rapid-identify');
 
 module.exports = ({
   brandKey,
@@ -11,16 +11,16 @@ module.exports = ({
   if (!omedaRapidIdentifyProp) throw new Error('The Omeda rapid identifcation prop is required.');
 
   return (req, res, next) => {
-    const rapidIdentify = req[omedaRapidIdentifyProp];
-    if (!rapidIdentify) throw new Error(`Unable to find the Omeda rapid identifier on the request using ${omedaRapidIdentifyProp}`);
+    const omedaRapidIdentify = req[omedaRapidIdentifyProp];
+    if (!omedaRapidIdentify) throw new Error(`Unable to find the Omeda rapid identifier on the request using ${omedaRapidIdentifyProp}`);
 
-    const handler = async ({ user } = {}) => idxRapidIdentify({
+    const handler = async ({ user } = {}) => idxOmedaRapidIdentify({
       brandKey,
       productId,
       appUser: user,
 
       identityX: req.identityX,
-      rapidIdentify,
+      omedaRapidIdentify,
     });
 
     req[prop] = handler;

--- a/packages/marko-web-omeda-identity-x/package.json
+++ b/packages/marko-web-omeda-identity-x/package.json
@@ -11,6 +11,7 @@
     "test": "yarn compile && yarn lint"
   },
   "dependencies": {
+    "@parameter1/base-cms-marko-web-identity-x": "^2.53.1",
     "@parameter1/base-cms-marko-web-omeda": "^2.52.0",
     "@parameter1/base-cms-object-path": "^2.45.0",
     "@parameter1/base-cms-utils": "^2.22.2",
@@ -19,7 +20,6 @@
   },
   "peerDependencies": {
     "@parameter1/base-cms-marko-web": "^2.13.0",
-    "@parameter1/base-cms-marko-web-identity-x": "^2.16.0",
     "express": "^4.17.1"
   },
   "publishConfig": {

--- a/packages/marko-web-omeda-identity-x/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/rapid-identify.js
@@ -23,7 +23,7 @@ const getAlpha3CodeFor = async (alpha2, identityX) => {
  * @param {number} params.productId The Omeda product ID to associate with the identification
  * @param {object} params.appUser The IdentityX user
  * @param {IdentityX} params.identityX The Marko web IdentityX service
- * @param {function} params.rapidIdentify The Omeda rapid identifcation action
+ * @param {function} params.omedaRapidIdentify The Omeda rapid identifcation action
  */
 module.exports = async ({
   brandKey,
@@ -31,7 +31,7 @@ module.exports = async ({
   appUser,
 
   identityX,
-  rapidIdentify,
+  omedaRapidIdentify,
 } = {}) => {
   const {
     givenName,
@@ -63,7 +63,7 @@ module.exports = async ({
     };
   });
 
-  const { id, encryptedCustomerId } = await rapidIdentify({
+  const { id, encryptedCustomerId } = await omedaRapidIdentify({
     email: appUser.email,
     productId,
     ...(givenName && { firstName: givenName }),

--- a/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
@@ -28,8 +28,6 @@ module.exports = ({
     const idxUserExists = tokenCookie.exists(req);
     if (!idxUserExists) return res.json(data);
 
-
-    // const { identityX } = req;
     const context = await req.identityX.loadActiveContext();
     const user = getAsObject(context, 'user');
     if (!user.id) return res.json(data);

--- a/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
@@ -6,14 +6,18 @@ const jsonErrorHandler = require('@parameter1/base-cms-marko-web/express/json-er
 const tokenCookie = require('@parameter1/base-cms-marko-web-identity-x/utils/token-cookie');
 const olyticsCookie = require('@parameter1/base-cms-marko-web-omeda/olytics/customer-cookie');
 
-const omedaRapidIdentityX = require('../rapid-identify');
 const findEncryptedId = require('../external-id/find-encrypted-customer-id');
 
-module.exports = ({ brandKey, productId } = {}) => {
+module.exports = ({
+  brandKey,
+  idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
+} = {}) => {
   if (!brandKey) throw new Error('An Omeda brand key is required to use this middleware.');
-  if (!productId) throw new Error('An Omeda rapid identification product ID is required to use this middleware.');
   const router = Router();
   router.get('/', asyncRoute(async (req, res) => {
+    const idxOmedaRapidIdentify = req[idxOmedaRapidIdentifyProp];
+    if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
+
     const data = {
       userId: null,
       encryptedId: null,
@@ -25,8 +29,8 @@ module.exports = ({ brandKey, productId } = {}) => {
     if (!idxUserExists) return res.json(data);
 
 
-    const { identityX } = req;
-    const context = await identityX.loadActiveContext();
+    // const { identityX } = req;
+    const context = await req.identityX.loadActiveContext();
     const user = getAsObject(context, 'user');
     if (!user.id) return res.json(data);
     data.userId = user.id;
@@ -38,13 +42,7 @@ module.exports = ({ brandKey, productId } = {}) => {
       data.source = 'existing';
     } else {
       // no omeda identifier found for this user, rapidly identify.
-      const { encryptedCustomerId } = await omedaRapidIdentityX({
-        brandKey,
-        productId,
-        appUser: user,
-        identityX,
-        omedaGraphQL: req.$omeda,
-      });
+      const { encryptedCustomerId } = await idxOmedaRapidIdentify({ user });
       data.encryptedId = encryptedCustomerId;
       data.source = 'new';
     }

--- a/packages/marko-web-omeda/index.js
+++ b/packages/marko-web-omeda/index.js
@@ -1,1 +1,24 @@
-module.exports = {};
+const { graphqlClient, rapidIdentify } = require('./middleware');
+
+module.exports = (app, {
+  brandKey,
+  clientKey,
+  appId,
+  inputId,
+  rapidIdentProductId,
+  omedaGraphQLClientProp = '$omedaGraphQLClient',
+  omedaRapidIdentifyProp = '$omedaRapidIdentify',
+} = {}) => {
+  app.use(graphqlClient({
+    brandKey,
+    clientKey,
+    appId,
+    inputId,
+    prop: omedaGraphQLClientProp,
+  }));
+  app.use(rapidIdentify({
+    productId: rapidIdentProductId,
+    omedaGraphQLClientProp,
+    prop: omedaRapidIdentifyProp,
+  }));
+};

--- a/packages/marko-web-omeda/middleware/graphql-client.js
+++ b/packages/marko-web-omeda/middleware/graphql-client.js
@@ -1,7 +1,7 @@
 const createClient = require('@parameter1/omeda-graphql-client');
 
 module.exports = ({
-  uri = 'https://graphql.omeda.parameter1.com/',
+  uri = process.env.OMEDA_GRAPHQL_URI || 'https://graphql.omeda.parameter1.com/',
   brandKey,
   clientKey,
   appId,

--- a/packages/marko-web-omeda/middleware/graphql-client.js
+++ b/packages/marko-web-omeda/middleware/graphql-client.js
@@ -1,0 +1,32 @@
+const createClient = require('@parameter1/omeda-graphql-client');
+
+module.exports = ({
+  uri = 'https://graphql.omeda.parameter1.com/',
+  brandKey,
+  clientKey,
+  appId,
+  inputId,
+
+  config = {},
+  linkConfig = {},
+  prop = '$omedaGraphQLClient',
+} = {}) => {
+  if (!uri) throw new Error('The Omeda GraphQL `uri` is required.');
+  if (!brandKey) throw new Error('The Omeda `brandKey` is required.');
+  if (!appId) throw new Error('The Omeda `appId` is required.');
+  if (!prop) throw new Error('The middleware request property is required.');
+  return (req, res, next) => {
+    const client = createClient({
+      uri,
+      brandKey,
+      clientKey,
+      appId,
+      inputId,
+      config,
+      linkConfig,
+    });
+    req[prop] = client;
+    res.locals[prop] = client;
+    next();
+  };
+};

--- a/packages/marko-web-omeda/middleware/index.js
+++ b/packages/marko-web-omeda/middleware/index.js
@@ -1,19 +1,4 @@
 const graphqlClient = require('./graphql-client');
 const rapidIdentify = require('./rapid-identify');
 
-module.exports = (app, {
-  brandKey,
-  clientKey,
-  appId,
-  inputId,
-
-  rapidIdentProductId,
-} = {}) => {
-  app.use(graphqlClient({
-    brandKey,
-    clientKey,
-    appId,
-    inputId,
-  }));
-  app.use(rapidIdentify({ productId: rapidIdentProductId }));
-};
+module.exports = { graphqlClient, rapidIdentify };

--- a/packages/marko-web-omeda/middleware/index.js
+++ b/packages/marko-web-omeda/middleware/index.js
@@ -1,0 +1,19 @@
+const graphqlClient = require('./graphql-client');
+const rapidIdentify = require('./rapid-identify');
+
+module.exports = (app, {
+  brandKey,
+  clientKey,
+  appId,
+  inputId,
+
+  rapidIdentProductId,
+} = {}) => {
+  app.use(graphqlClient({
+    brandKey,
+    clientKey,
+    appId,
+    inputId,
+  }));
+  app.use(rapidIdentify({ productId: rapidIdentProductId }));
+};

--- a/packages/marko-web-omeda/middleware/rapid-identify.js
+++ b/packages/marko-web-omeda/middleware/rapid-identify.js
@@ -1,0 +1,21 @@
+const rapidIdentify = require('../rapid-identify');
+
+module.exports = ({
+  productId,
+  prop = '$omedaRapidIdentify',
+  graphqlProp = '$omedaGraphQLClient',
+} = {}) => {
+  if (!productId) throw new Error('No Omeda rapid identification product ID was provided.');
+  return (req, res, next) => {
+    const omedaGraphQLClient = req[graphqlProp];
+    if (!omedaGraphQLClient) throw new Error(`Unable to find the Omeda GraphQL client on the request using ${graphqlProp}`);
+    const handler = (params = {}) => rapidIdentify(omedaGraphQLClient, {
+      productId,
+      ...params,
+    });
+
+    req[prop] = handler;
+    res.locals[prop] = handler;
+    next();
+  };
+};

--- a/packages/marko-web-omeda/middleware/rapid-identify.js
+++ b/packages/marko-web-omeda/middleware/rapid-identify.js
@@ -10,8 +10,8 @@ module.exports = ({
     const omedaGraphQLClient = req[omedaGraphQLClientProp];
     if (!omedaGraphQLClient) throw new Error(`Unable to find the Omeda GraphQL client on the request using ${omedaGraphQLClientProp}`);
     const handler = async (params = {}) => rapidIdentify(omedaGraphQLClient, {
-      productId,
       ...params,
+      productId,
     });
 
     req[prop] = handler;

--- a/packages/marko-web-omeda/middleware/rapid-identify.js
+++ b/packages/marko-web-omeda/middleware/rapid-identify.js
@@ -3,13 +3,13 @@ const rapidIdentify = require('../rapid-identify');
 module.exports = ({
   productId,
   prop = '$omedaRapidIdentify',
-  graphqlProp = '$omedaGraphQLClient',
+  omedaGraphQLClientProp = '$omedaGraphQLClient',
 } = {}) => {
   if (!productId) throw new Error('No Omeda rapid identification product ID was provided.');
   return (req, res, next) => {
-    const omedaGraphQLClient = req[graphqlProp];
-    if (!omedaGraphQLClient) throw new Error(`Unable to find the Omeda GraphQL client on the request using ${graphqlProp}`);
-    const handler = (params = {}) => rapidIdentify(omedaGraphQLClient, {
+    const omedaGraphQLClient = req[omedaGraphQLClientProp];
+    if (!omedaGraphQLClient) throw new Error(`Unable to find the Omeda GraphQL client on the request using ${omedaGraphQLClientProp}`);
+    const handler = async (params = {}) => rapidIdentify(omedaGraphQLClient, {
       productId,
       ...params,
     });

--- a/packages/marko-web-omeda/package.json
+++ b/packages/marko-web-omeda/package.json
@@ -11,7 +11,11 @@
     "test": "yarn compile && yarn lint"
   },
   "dependencies": {
-    "@parameter1/base-cms-marko-web-deferred-script-loader": "^2.48.1"
+    "@parameter1/base-cms-marko-web-deferred-script-loader": "^2.48.1",
+    "@parameter1/base-cms-utils": "^2.22.2",
+    "@parameter1/omeda-graphql-client": "^0.7.0",
+    "graphql": "^14.7.0",
+    "graphql-tag": "^2.12.5"
   },
   "peerDependencies": {
     "@parameter1/base-cms-marko-web": "^2.0.0"

--- a/packages/marko-web-omeda/rapid-identify.js
+++ b/packages/marko-web-omeda/rapid-identify.js
@@ -1,0 +1,47 @@
+const gql = require('graphql-tag');
+
+const RAPID_IDENT = gql`
+  mutation RapidIdentityX($input: RapidCustomerIdentificationMutationInput!) {
+    result: rapidCustomerIdentification(input: $input) { id encryptedCustomerId }
+  }
+`;
+
+const { isArray } = Array;
+
+module.exports = async (omedaGraphQLClient, {
+  email,
+  productId,
+
+  firstName,
+  lastName,
+  companyName,
+  title,
+
+  regionCode,
+  countryCode,
+  postalCode,
+
+  deploymentTypeIds,
+  demographics,
+} = {}) => {
+  const input = {
+    productId,
+    email,
+    ...(firstName && { firstName }),
+    ...(lastName && { lastName }),
+    ...(companyName && { companyName }),
+    ...(title && { title }),
+
+    ...(regionCode && { regionCode }),
+    ...(countryCode && { countryCode }),
+    ...(postalCode && { postalCode }),
+
+    ...(isArray(deploymentTypeIds) && deploymentTypeIds.length && { deploymentTypeIds }),
+    ...(isArray(demographics) && demographics.length && { demographics }),
+  };
+  const { data } = await omedaGraphQLClient.mutate({
+    mutation: RAPID_IDENT,
+    variables: { input },
+  });
+  return data.result;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,6 +3085,17 @@
   dependencies:
     joi "^17.4.2"
 
+"@parameter1/omeda-graphql-client@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@parameter1/omeda-graphql-client/-/omeda-graphql-client-0.7.0.tgz#d2d7e5a640565494680287f1b5e60b495776b547"
+  integrity sha512-1BZUfMyv8LDBZOlD57awctPNX8c0EzsM3Us16+Z5uF/hOg7l+VkyTyIeO/fTgxzGtbr+TkbgbO6CERuF4K92sQ==
+  dependencies:
+    apollo-cache-inmemory "^1.6.6"
+    apollo-client "^2.6.10"
+    apollo-link-http "^1.5.17"
+    graphql "^15.6.1"
+    node-fetch "^2.6.5"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -10109,6 +10120,11 @@ graphql@^14.5.4, graphql@^14.7.0:
   integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
   dependencies:
     iterall "^1.2.2"
+
+graphql@^15.6.1:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.7.2.tgz#85ab0eeb83722977151b3feb4d631b5f2ab287ef"
+  integrity sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==
 
 growl@1.10.5:
   version "1.10.5"


### PR DESCRIPTION
This consolidates the site setup required when using these various packages. Four usage options exist:
- a site uses none of these services (install nothing)
- a site uses only omeda (install `marko-web-omeda`)
- a site uses only identity-x (install `marko-web-identity-x`)
- a site uses omeda _and_ identity-x (install `marko-web-omeda-identity-x`)