### PR TITLE
Create custom `.marko` resolver package

### DIFF
--- a/packages/marko-node-require/README.md
+++ b/packages/marko-node-require/README.md
@@ -1,0 +1,7 @@
+# MarkoJS Node Require
+Overrides the default `marko/node-require` logic to only compile `.marko` files that are new or out-of-date (as opposed to compiling everything).
+
+Load as the first module in your app's entrypoint via
+```js
+require('@parameter1/base-cms-marko-node-require');
+```

--- a/packages/marko-node-require/fs/stat.js
+++ b/packages/marko-node-require/fs/stat.js
@@ -1,0 +1,13 @@
+const { statSync } = require('fs');
+
+module.exports = (path, { throwOnNotFound = true } = {}) => {
+  try {
+    return statSync(path);
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      if (throwOnNotFound) throw e;
+      return null;
+    }
+    throw e;
+  }
+};

--- a/packages/marko-node-require/index.js
+++ b/packages/marko-node-require/index.js
@@ -1,0 +1,81 @@
+require('marko');
+
+const path = require('path');
+const fs = require('fs');
+const resolveFrom = require('resolve-from');
+const stat = require('./fs/stat');
+
+const { MARKO_REQUIRE_DEBUG } = process.env;
+const { log: l } = console;
+const log = (...args) => l('marko-node-require:', ...args);
+
+if (MARKO_REQUIRE_DEBUG) log('debug enabled');
+
+const fsReadOptions = { encoding: 'utf8' };
+const MARKO_EXTENSIONS = Symbol('MARKO_EXTENSIONS');
+
+function getCompileReason({ templatePath, targetFile } = {}) {
+  const targetStats = stat(targetFile, { throwOnNotFound: false });
+  if (!targetStats) return 'notfound';
+  const templateStats = stat(templatePath);
+  return targetStats.mtime < templateStats.mtime ? 'outdated' : false;
+}
+
+function compile(templatePath, markoCompiler, compOptions) {
+  const compilerOptions = {
+    ...markoCompiler.defaultOptions,
+    ...compOptions,
+  };
+
+  let compiledSrc;
+  const targetFile = `${templatePath}.js`;
+  const compileReason = getCompileReason({ templatePath, targetFile });
+  if (compileReason) {
+    if (MARKO_REQUIRE_DEBUG) log(`${compileReason === 'outdated' ? 're' : ''}compiling ${targetFile}...`);
+    const targetDir = path.dirname(templatePath);
+    const templateSrc = fs.readFileSync(templatePath, fsReadOptions);
+    compiledSrc = markoCompiler.compile(templateSrc, templatePath, compilerOptions);
+
+    // Write to a temporary file and move it into place to avoid problems
+    // assocatiated with multiple processes writing to the same file.
+    const filename = path.basename(targetFile);
+    const tempFile = path.join(targetDir, `.${process.pid}.${Date.now()}.${filename}`);
+    fs.writeFileSync(tempFile, compiledSrc, fsReadOptions);
+    fs.renameSync(tempFile, targetFile);
+  } else {
+    compiledSrc = fs.readFileSync(targetFile, fsReadOptions);
+  }
+  return compiledSrc;
+}
+
+(() => {
+  const requireExtensions = require.extensions;
+
+  const compilerOptions = { requireTemplates: true };
+
+  // eslint-disable-next-line global-require
+  require('marko/compiler').configure(compilerOptions);
+
+  const extension = '.marko';
+  function markoRequireExtension(module, filename) {
+    // Resolve the appropriate compiler relative to the location of the
+    // marko template file on disk using the "resolve-from" module.
+    const dirname = path.dirname(filename);
+    const markoCompilerModulePath = resolveFrom(dirname, 'marko/compiler');
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const markoCompiler = require(markoCompilerModulePath);
+
+    // Now use the appropriate Marko compiler to compile the Marko template
+    // file to JavaScript source code:
+    const compiledSrc = compile(filename, markoCompiler, compilerOptions);
+
+    // eslint-disable-next-line no-underscore-dangle
+    return module._compile(compiledSrc, filename);
+  }
+
+  requireExtensions[MARKO_EXTENSIONS] = requireExtensions[MARKO_EXTENSIONS]
+    || (requireExtensions[MARKO_EXTENSIONS] = []);
+
+  requireExtensions[extension] = markoRequireExtension;
+  requireExtensions[MARKO_EXTENSIONS].push(extension);
+})();

--- a/packages/marko-node-require/package.json
+++ b/packages/marko-node-require/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@parameter1/base-cms-marko-node-require",
+  "version": "2.56.0",
+  "description": "Custom Node extension resolver/compiler for Marko files.",
+  "author": "Jacob Bare <jacob@parameter1.com>",
+  "main": "index.js",
+  "license": "MIT",
+  "repository": "https://github.com/parameter1/base-cms/tree/master/packages/marko-node-require",
+  "scripts": {
+    "lint": "eslint --ext .js --ext .vue --max-warnings 5 --ignore-path ../../.eslintignore ./",
+    "test": "yarn lint"
+  },
+  "dependencies": {
+    "resolve-from": "^2.0.0",
+    "marko": "~4.20.0"
+  }
+}

--- a/packages/marko-web/node-require.js
+++ b/packages/marko-web/node-require.js
@@ -1,0 +1,6 @@
+/* eslint-disable global-require */
+if (process.env.BASE_CMS_MARKO_NODE_REQUIRE) {
+  require('@parameter1/base-cms-marko-node-require');
+} else {
+  require('marko/node-require');
+}

--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -21,6 +21,7 @@
     "@parameter1/base-cms-graphql-fragment-types": "^2.45.0",
     "@parameter1/base-cms-image": "^2.45.0",
     "@parameter1/base-cms-inflector": "^2.0.0",
+    "@parameter1/base-cms-marko-node-require": "^2.56.0",
     "@parameter1/base-cms-object-path": "^2.45.0",
     "@parameter1/base-cms-tenant-context": "^2.0.0",
     "@parameter1/base-cms-utils": "^2.22.2",

--- a/packages/marko-web/start-server.js
+++ b/packages/marko-web/start-server.js
@@ -1,4 +1,4 @@
-require('marko/node-require');
+require('./node-require');
 const http = require('http');
 const path = require('path');
 const { createTerminus } = require('@godaddy/terminus');


### PR DESCRIPTION
Customizes the default require extensions loader for `.marko` files to more efficiently compile. Only new and changed `.marko` files will be compiled to their `.marko.js` versions.

Marko Web still uses the original node resolver, but the new can be enabled by setting the `BASE_CMS_MARKO_NODE_REQUIRE` env value.

In addition, if the `MARKO_REQUIRE_DEBUG` env value is set, the node resolver will log when files are compiled or recompiled.