### PR TITLE
Revert "Remove default `{ field: null }` from `WebsiteScheduledContentQueryInput.sort`"

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -630,7 +630,7 @@ input WebsiteScheduledContentQueryInput {
   useOptionFallback: Boolean = false
   sectionBubbling: Boolean = true
   pagination: PaginationInput = {}
-  sort: ContentSortInput = {}
+  sort: ContentSortInput = { field: null }
   after: Date
   since: Date
   "For types with a startDate field: Limit results to items with a startDate matching the criteria."


### PR DESCRIPTION
Reverts parameter1/base-cms#186

This caused a breaking change in how website scheduled content is sorted by default. Without `{ field: null }` as the default sort input, scheduled content won't sort by start date (by default) and instead sort by ID. This breaks most scheduled content queries on the websites.