### PR TITLE
Freshly return `sectionQuery` from `Content.websiteSchedules`

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -623,6 +623,7 @@ input WebsiteScheduledContentQueryInput {
   excludeContentIds: [Int!] = []
   excludeSectionIds: [Int!] = []
   excludeContentTypes: [ContentType!] = []
+  includeContentIds: [Int!] = []
   includeContentTypes: [ContentType!] = []
   includeLabels: [String!]! = []
   excludeLabels: [String!]! = []

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -79,7 +79,7 @@ interface Content @requiresProject(fields: ["type"]) {
   relatedContent(input: ContentRelatedContentInput = {}): ContentConnection! @projection(localField: "_id", needs: ["relatedTo", "mutations.Website.primarySection"])
   userRegistration: ContentUserRegistration! @projection(localField: "mutations.Website.requiresAccessLevels", needs: ["mutations.Website.requiresRegistration"])
   # Returns the website section query schedules
-  websiteSchedules: [ContentWebsiteSchedule]! @projection(localField: "sectionQuery") @arrayValue(localField: "sectionQuery")
+  websiteSchedules: [ContentWebsiteSchedule]!
 
   hasWebsiteSchedule(input: ContentHasWebsiteScheduleInput!): Boolean! @projection(localField: "sectionQuery")
 

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -407,6 +407,15 @@ module.exports = {
     },
 
     /**
+     * Ensures that the website schedules result isn't filtered/adjusted when running
+     * inside a `websiteScheduleContent` query.
+     */
+    websiteSchedules: async (content, _, { load }) => {
+      const { sectionQuery } = await load('platformContent', content._id, { sectionQuery: 1 });
+      return sectionQuery;
+    },
+
+    /**
      * Load primary section of content.
      * If primary section's site matches the current site, return the section.
      * If not, check for alternative site + section (@todo).
@@ -1302,6 +1311,7 @@ module.exports = {
         includeContentTypes,
         excludeContentTypes,
         includeLabels,
+        includeContentIds,
         excludeLabels,
         requiresImage,
         sectionBubbling,

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1370,7 +1370,8 @@ module.exports = {
         query.$and.push({ type: { $in: getDefaultContentTypes() } });
       }
       if (excludeContentTypes.length) query.$and.push({ type: { $nin: excludeContentTypes } });
-      if (excludeContentIds.length) query._id = { $nin: excludeContentIds };
+      if (includeContentIds.length) query.$and.push({ _id: { $in: includeContentIds } });
+      if (excludeContentIds.length) query.$and.push({ _id: { $nin: excludeContentIds } });
       if (includeLabels.length) query.$and.push({ labels: { $in: includeLabels } });
       if (excludeLabels.length) query.$and.push({ labels: { $nin: excludeLabels } });
 


### PR DESCRIPTION
Prevents an edge case where, when returning content via the `websiteScheduledContent` query, the `sectionQuery` value is already pre-filtered based on that query's input criteria.

See #185

Also related: #186 and #197