### PR TITLE
Allow cross-origin requests

### DIFF
--- a/services/oembed/package.json
+++ b/services/oembed/package.json
@@ -17,6 +17,7 @@
     "@parameter1/base-cms-tooling": "^2.45.0",
     "@parameter1/base-cms-utils": "^2.22.2",
     "body-parser": "^1.19.0",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "helmet": "^3.23.3",
     "newrelic": "^6.14.0"

--- a/services/oembed/src/app.js
+++ b/services/oembed/src/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const helmet = require('helmet');
+const cors = require('cors');
 const { json } = require('body-parser');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const embedly = require('./embedly');
@@ -7,9 +8,17 @@ const embedly = require('./embedly');
 const app = express();
 const dev = process.env.NODE_ENV === 'development';
 
+const CORS = cors({
+  methods: ['GET', 'POST'],
+  maxAge: 600,
+});
+
 app.use(helmet());
 app.use(json());
 app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
+
+app.use(CORS);
+app.options('*', CORS);
 
 app.post('/', asyncRoute(async (req, res) => {
   const { body } = req;


### PR DESCRIPTION
This is the same CORS config that the GraphQL service uses. Will allow client-side, cross-origin requests, which eliminates the need to proxy the oembed service on implementing websites