### PR TITLE
Support multiple consent checkboxes

### DIFF
--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -115,22 +115,34 @@
         </div>
       </div>
     </div>
+    <div class="row">
+      <div class="col-12">
+        <div class="form-group">
+          <textarea
+            id="inquiry-form.comments"
+            v-model="comments"
+            name="comments"
+            class="form-control"
+          />
+        </div>
+      </div>
+    </div>
     <div
-      v-for="(consent, name) in consentCheckboxes"
-      :key="'inquiry-' + name"
+      v-for="(consent) in consentCheckboxes"
+      :key="consent.key"
       class="row"
     >
       <div class="col-12">
         <div class="form-group">
           <input
-            :id="'inquiry-' + name"
-            :value="name"
+            :id="consent.key"
+            :value="consent.key"
             v-model="checkedConsents"
-            :required="true"
+            :required="consent.required"
             type="checkbox"
           >
-          <form-label :for="'inquiry-' + name" :required="true">
-            <div class="consent-html" v-html="consentCheckboxes[name]" />
+          <form-label :for="consent.key" :required="true">
+            <div class="consent-html" v-html="consent.html" />
           </form-label>
         </div>
       </div>
@@ -159,7 +171,6 @@ import FormMixin from './form-mixin';
 import CountryField from './fields/country.vue';
 import FormLabel from './elements/label.vue';
 import i18n from '../i18n';
-
 export default {
   components: { VueRecaptcha, CountryField, FormLabel },
   inject: ['EventBus'],
@@ -180,7 +191,7 @@ export default {
       default: 'en',
     },
     consentCheckboxes: {
-      type: Object,
+      type: Array,
       default: null,
     },
   },
@@ -225,6 +236,11 @@ export default {
         comments,
         checkedConsents,
       } = this;
+      const consents = this.consentCheckboxes.reduce((obj, consent) => {
+        const { key, html } = consent;
+        if (checkedConsents.includes(key)) obj[key] = html;
+        return obj;
+      }, {});
       const payload = {
         firstName,
         lastName,
@@ -236,7 +252,7 @@ export default {
         country,
         postalCode,
         comments,
-        ...(checkedConsents.length && { userConsents: checkedConsents.join(', ') }),
+        ...consents,
         token,
       };
       await this.$submit(payload);

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -242,8 +242,7 @@ export default {
       } = this;
       const consents = this.consentCheckboxes.reduce((obj, consent) => {
         const { key, html } = consent;
-        if (checkedConsents.includes(key)) return { ...obj, [key]: html };
-        return obj;
+        return (checkedConsents.includes(key)) ? { ...obj, [key]: html } : obj;
       }, {});
       const payload = {
         firstName,

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -115,24 +115,22 @@
         </div>
       </div>
     </div>
-    <div class="row">
+    <div
+      v-for="(checkbox) in onSubmitConsentCheckboxes"
+      :key="checkbox.label"
+      class="row"
+    >
       <div class="col-12">
         <div class="form-group">
-          <form-label id="inquiry-form.comments">
-            {{ translate("commentsLabel") }}
+          <input
+            :id="checkbox.label"
+            :required="true"
+            type="checkbox"
+          >
+          <form-label :for="checkbox.label" :required="true">
+            <div class="consent-html" v-html="checkbox.html" />
           </form-label>
-          <textarea
-            id="inquiry-form.comments"
-            v-model="comments"
-            name="comments"
-            class="form-control"
-          />
         </div>
-      </div>
-    </div>
-    <div v-if="onSubmitConsentText" class="row">
-      <div class="col-12">
-        <div class="form-group" v-html="onSubmitConsentText" />
       </div>
     </div>
     <pre v-if="error" class="alert alert-danger text-danger">An error occurred: {{ error }}</pre>
@@ -179,8 +177,8 @@ export default {
       type: String,
       default: 'en',
     },
-    onSubmitConsentText: {
-      type: String,
+    onSubmitConsentCheckboxes: {
+      type: Array,
       default: null,
     },
   },

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -118,6 +118,9 @@
     <div class="row">
       <div class="col-12">
         <div class="form-group">
+          <form-label id="inquiry-form.comments">
+            {{ translate("commentsLabel") }}
+          </form-label>
           <textarea
             id="inquiry-form.comments"
             v-model="comments"

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -171,6 +171,7 @@ import FormMixin from './form-mixin';
 import CountryField from './fields/country.vue';
 import FormLabel from './elements/label.vue';
 import i18n from '../i18n';
+
 export default {
   components: { VueRecaptcha, CountryField, FormLabel },
   inject: ['EventBus'],

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -116,19 +116,21 @@
       </div>
     </div>
     <div
-      v-for="(checkbox) in onSubmitConsentCheckboxes"
-      :key="checkbox.label"
+      v-for="(consent, name) in consentCheckboxes"
+      :key="'inquiry-' + name"
       class="row"
     >
       <div class="col-12">
         <div class="form-group">
           <input
-            :id="checkbox.label"
+            :id="'inquiry-' + name"
+            :value="name"
+            v-model="checkedConsents"
             :required="true"
             type="checkbox"
           >
-          <form-label :for="checkbox.label" :required="true">
-            <div class="consent-html" v-html="checkbox.html" />
+          <form-label :for="'inquiry-' + name" :required="true">
+            <div class="consent-html" v-html="consentCheckboxes[name]" />
           </form-label>
         </div>
       </div>
@@ -177,8 +179,8 @@ export default {
       type: String,
       default: 'en',
     },
-    onSubmitConsentCheckboxes: {
-      type: Array,
+    consentCheckboxes: {
+      type: Object,
       default: null,
     },
   },
@@ -192,6 +194,7 @@ export default {
     country: '',
     postalCode: '',
     comments: '',
+    checkedConsents: [],
   }),
   methods: {
     translate(key) {
@@ -220,8 +223,8 @@ export default {
         country,
         postalCode,
         comments,
+        checkedConsents,
       } = this;
-
       const payload = {
         firstName,
         lastName,
@@ -233,9 +236,9 @@ export default {
         country,
         postalCode,
         comments,
+        ...(checkedConsents.length && { userConsents: checkedConsents.join(', ') }),
         token,
       };
-
       await this.$submit(payload);
       this.EventBus.$emit('inquiry-form-submit', { contentId, contentType, payload });
     },

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -144,7 +144,7 @@
             :required="consent.required"
             type="checkbox"
           >
-          <form-label :for="consent.key" :required="true">
+          <form-label :for="consent.key" :required="consent.required">
             <div class="consent-html" v-html="consent.html" />
           </form-label>
         </div>

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -238,7 +238,7 @@ export default {
       } = this;
       const consents = this.consentCheckboxes.reduce((obj, consent) => {
         const { key, html } = consent;
-        if (checkedConsents.includes(key)) obj[key] = html;
+        if (checkedConsents.includes(key)) return { ...obj, [key]: html };
         return obj;
       }, {});
       const payload = {

--- a/packages/marko-web-inquiry/browser/default-form.vue
+++ b/packages/marko-web-inquiry/browser/default-form.vue
@@ -196,7 +196,7 @@ export default {
     },
     consentCheckboxes: {
       type: Array,
-      default: null,
+      default: () => [],
     },
   },
   data: () => ({

--- a/packages/marko-web-inquiry/components/form.marko
+++ b/packages/marko-web-inquiry/components/form.marko
@@ -41,7 +41,7 @@ $ const lang = defaultValue(input.lang, "en");
       contentType: content.type,
       sitekey: RECAPTCHA_SITE_KEY,
       lang: lang,
-      onSubmitConsentText: input.onSubmitConsentText,
+      onSubmitConsentCheckboxes: input.onSubmitConsentCheckboxes,
     } />
   </marko-web-block>
 </if>

--- a/packages/marko-web-inquiry/components/form.marko
+++ b/packages/marko-web-inquiry/components/form.marko
@@ -41,7 +41,7 @@ $ const lang = defaultValue(input.lang, "en");
       contentType: content.type,
       sitekey: RECAPTCHA_SITE_KEY,
       lang: lang,
-      onSubmitConsentCheckboxes: input.onSubmitConsentCheckboxes,
+      consentCheckboxes: input.consentCheckboxes,
     } />
   </marko-web-block>
 </if>

--- a/packages/marko-web-inquiry/components/marko.json
+++ b/packages/marko-web-inquiry/components/marko.json
@@ -4,7 +4,7 @@
     "<header>": {},
     "<description>": {},
     "@content": "object",
-    "@on-submit-consent-checkboxes": "array",
+    "@consent-checkboxes": "object",
 
     "@with-header": "boolean",
     "@with-description": "boolean",

--- a/packages/marko-web-inquiry/components/marko.json
+++ b/packages/marko-web-inquiry/components/marko.json
@@ -4,7 +4,7 @@
     "<header>": {},
     "<description>": {},
     "@content": "object",
-    "@consent-checkboxes": "object",
+    "@consent-checkboxes": "array",
 
     "@with-header": "boolean",
     "@with-description": "boolean",

--- a/packages/marko-web-inquiry/components/marko.json
+++ b/packages/marko-web-inquiry/components/marko.json
@@ -4,7 +4,7 @@
     "<header>": {},
     "<description>": {},
     "@content": "object",
-    "@on-submit-consent-text": "string",
+    "@on-submit-consent-checkboxes": "array",
 
     "@with-header": "boolean",
     "@with-description": "boolean",

--- a/packages/marko-web-inquiry/templates/notification.marko
+++ b/packages/marko-web-inquiry/templates/notification.marko
@@ -75,7 +75,7 @@ $ const bgColor = site.get('inquiry.bgColor', 'transparent');
                   <if(key !== 'confirmationEmail')>
                     <tr>
                       <td nowrap><b>${key}</b></td>
-                      <td>${value}</td>
+                      <td>$!{value}</td>
                     </tr>
                   </if>
                 </for>


### PR DESCRIPTION
Add the ability to pass a consentCheckboxes object to the inquiry form.
 - All are required in order to submit
 - Not conditional
 - Passes list of userConsents to the email with a , separated list of keys
 
<img width="658" alt="Screen Shot 2021-12-01 at 9 38 56 AM" src="https://user-images.githubusercontent.com/3845869/144266522-5f3827f5-a771-4f06-9b85-233807e7efe3.png">
 