### PR TITLE
Create/migrate contact us package

### DIFF
--- a/packages/marko-web-contact-us/browser/.eslintrc.js
+++ b/packages/marko-web-contact-us/browser/.eslintrc.js
@@ -1,0 +1,8 @@
+const commonConfig = require('../../../eslintrc.browser');
+
+module.exports = {
+  ...commonConfig,
+  parserOptions: {
+    parser: 'babel-eslint',
+  },
+};

--- a/packages/marko-web-contact-us/browser/.eslintrc.js
+++ b/packages/marko-web-contact-us/browser/.eslintrc.js
@@ -1,7 +1,20 @@
-const commonConfig = require('../../../eslintrc.browser');
-
 module.exports = {
-  ...commonConfig,
+  extends: [
+    'airbnb-base',
+    'plugin:vue/recommended',
+  ],
+  env: {
+    browser: true,
+  },
+  rules: {
+    'vue/max-attributes-per-line': ['error', {
+      singleline: 3,
+      multiline: {
+        max: 1,
+        allowFirstLine: false,
+      },
+    }],
+  },
   parserOptions: {
     parser: 'babel-eslint',
   },

--- a/packages/marko-web-contact-us/browser/form.vue
+++ b/packages/marko-web-contact-us/browser/form.vue
@@ -115,7 +115,6 @@ import VueRecaptcha from 'vue-recaptcha';
 
 const block = 'contact-us-form';
 
-// @todo this should be removed once contact us is moved to core.
 export default {
   components: { VueRecaptcha },
   props: {

--- a/packages/marko-web-contact-us/browser/form.vue
+++ b/packages/marko-web-contact-us/browser/form.vue
@@ -1,0 +1,214 @@
+<template>
+  <div :class="bem('container')">
+    <div :class="bem('header')">
+      {{ title }}
+    </div>
+    <form
+      :class="bem('contents')"
+      @submit.prevent="verify"
+    >
+      <div :class="bem('row')">
+        <label
+          :class="bem('label')"
+          for="cuf__name"
+        >
+          Name
+        </label>
+        <input
+          id="cuf__name"
+          v-model="name"
+          :class="[...bem('field'), 'form-control']"
+          type="text"
+          name="name"
+          required
+        >
+      </div>
+      <div :class="bem('row')">
+        <label
+          :class="bem('label')"
+          for="cuf__phone"
+        >
+          Phone
+        </label>
+        <input
+          id="cuf__phone"
+          v-model="phone"
+          :class="[...bem('field'), 'form-control']"
+          type="text"
+          name="phone"
+          required
+        >
+      </div>
+      <div :class="bem('row')">
+        <label
+          :class="bem('label')"
+          for="cuf__email"
+        >
+          Email
+        </label>
+        <input
+          id="cuf__email"
+          v-model="email"
+          :class="[...bem('field'), 'form-control']"
+          type="email"
+          name="email"
+          required
+        >
+      </div>
+      <div :class="bem('row')">
+        <label
+          :class="bem('label')"
+          for="cuf__comments"
+        >
+          Comments
+        </label>
+        <textarea
+          id="cuf__comments"
+          v-model="comments"
+          :class="[...bem('field'), 'form-control']"
+          name="comments"
+          required
+        />
+      </div>
+      <hr>
+      <div :class="bem('row')">
+        <p
+          v-if="submitted"
+          :class="bem('text', ['success'])"
+        >
+          {{ successMessage }}
+        </p>
+        <p
+          v-else-if="loading"
+          :class="bem('text', ['loading'])"
+        >
+          Hold up, we're processing your submission...
+        </p>
+        <p
+          v-else-if="error"
+          :class="bem('text', ['danger'])"
+        >
+          {{ errorLabel }} {{ error }}
+        </p>
+        <vue-recaptcha
+          v-if="!submitted"
+          ref="recaptcha"
+          :sitekey="sitekey"
+          @verify="onVerify"
+          @expired="onExpired"
+        >
+          <button
+            type="submit"
+            :class="bem('submit')"
+            :disabled="disabled"
+          >
+            Submit
+          </button>
+        </vue-recaptcha>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import VueRecaptcha from 'vue-recaptcha';
+
+const block = 'contact-us-form';
+
+// @todo this should be removed once contact us is moved to core.
+export default {
+  components: { VueRecaptcha },
+  props: {
+    title: {
+      type: String,
+      default: 'Drop us a line!',
+    },
+    sitekey: {
+      type: String,
+      require: true,
+      default: null,
+    },
+    configName: {
+      type: String,
+      require: true,
+      default: 'submitPodcast',
+    },
+    successMessage: {
+      type: String,
+      default: 'Thanks! Your comments have been received.',
+    },
+    errorLabel: {
+      type: String,
+      default: 'Oh snap! There was a problem with your submission:',
+    },
+  },
+  data: () => ({
+    name: null,
+    phone: null,
+    email: null,
+    comments: null,
+    error: null,
+    loading: false,
+    submitted: false,
+  }),
+  computed: {
+    disabled() {
+      return !(this.name && this.phone && this.email && this.comments && !this.loading);
+    },
+  },
+
+  async mounted() {
+    await Promise.all([
+      this.loadRecaptchaLibrary(),
+    ]);
+  },
+
+  methods: {
+    async loadRecaptchaLibrary() {
+      if (!window.recaptcha) {
+        await (new Promise((resolve, reject) => {
+          const s = document.createElement('script');
+          s.src = 'https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit';
+          s.async = 1;
+          s.onerror = () => reject(new Error('Unable to load resizer form script.'));
+          s.onload = resolve;
+          const scr = document.getElementsByTagName('script')[0];
+          scr.parentNode.insertBefore(s, scr);
+        }));
+      }
+    },
+    bem: (name, mod = []) => [block, `${block}__${name}`, ...mod.map(m => `${block}__${name}--${m}`)],
+    onExpired() {
+      this.error = 'Timed out validating your submission.';
+      this.loading = false;
+    },
+    async onVerify(token) {
+      this.loading = true;
+      this.error = null;
+      if (token) {
+        // eslint-disable-next-line no-underscore-dangle
+        const payload = { ...this._data, configName: this.configName, token };
+        try {
+          const res = await fetch('/__contact-us', {
+            method: 'post',
+            body: JSON.stringify(payload),
+            headers: { 'Content-Type': 'application/json' },
+          });
+          if (res.ok) {
+            this.submitted = true;
+          } else {
+            throw new Error(res.statusText);
+          }
+        } catch (e) {
+          this.error = e.message;
+        } finally {
+          this.loading = false;
+        }
+      } else {
+        this.error = 'Unable to submit your request. Please try again!';
+        this.loading = false;
+      }
+    },
+  },
+};
+</script>

--- a/packages/marko-web-contact-us/browser/form.vue
+++ b/packages/marko-web-contact-us/browser/form.vue
@@ -124,13 +124,11 @@ export default {
     },
     sitekey: {
       type: String,
-      require: true,
-      default: null,
+      required: true,
     },
     configName: {
       type: String,
-      require: true,
-      default: 'submitPodcast',
+      required: true,
     },
     successMessage: {
       type: String,

--- a/packages/marko-web-contact-us/browser/form.vue
+++ b/packages/marko-web-contact-us/browser/form.vue
@@ -167,7 +167,7 @@ export default {
           const s = document.createElement('script');
           s.src = 'https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit';
           s.async = 1;
-          s.onerror = () => reject(new Error('Unable to load resizer form script.'));
+          s.onerror = () => reject(new Error('Unable to load google recaptcha script.'));
           s.onload = resolve;
           const scr = document.getElementsByTagName('script')[0];
           scr.parentNode.insertBefore(s, scr);

--- a/packages/marko-web-contact-us/browser/index.js
+++ b/packages/marko-web-contact-us/browser/index.js
@@ -1,0 +1,5 @@
+const ContactUsForm = () => import(/* webpackChunkName: "contact-us-form" */ './form.vue');
+
+export default (Browser) => {
+  Browser.register('ContactUsForm', ContactUsForm);
+};

--- a/packages/marko-web-contact-us/components/contact-us-form.marko
+++ b/packages/marko-web-contact-us/components/contact-us-form.marko
@@ -1,0 +1,3 @@
+$ const { RECAPTCHA_SITE_KEY: sitekey } = process.env;
+$ const { configName } = input;
+<marko-web-browser-component name="ContactUsForm" props={ sitekey, configName } />

--- a/packages/marko-web-contact-us/components/marko.json
+++ b/packages/marko-web-contact-us/components/marko.json
@@ -1,0 +1,9 @@
+{
+  "<contact-us-form>": {
+    "template": "./contact-us-form.marko",
+    "@config-name": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/packages/marko-web-contact-us/email.marko
+++ b/packages/marko-web-contact-us/email.marko
@@ -1,0 +1,79 @@
+$ const styles = "table {width: 630px;margin: 0 auto;} .danger { color: red } body{font-family: sans-serif; color: #333; margin: 0;}h1{font-family: monospace; line-height: 58px; text-align:center; margin: 0;}.subject, .footer{text-align:center; border-top: 1px solid #EEE; padding: 1em;}.footer{font-family: monospace; color: #CCC;}";
+$ const baseLogo = "https://s3.amazonaws.com/media.cygnus.com/base.png";
+$ const { domain, subject } = input;
+$ const { site, config } = out.global;
+$ const defaults = {
+  title: config.siteName(),
+  bgColor: "#FFF",
+  logo: "https://s3.amazonaws.com/media.cygnus.com/base.png",
+  supportName: `${config.siteName()} Support`,
+  supportEmail: "base@endeavorb2b.com",
+};
+
+<!-- @todo this file should be removed once contact us is core -->
+
+<!doctype html>
+<html>
+  <head>
+    <style type="text/css">$!{styles}</style>
+    <title>${subject}</title>
+  </head>
+  <body>
+    <table>
+      <tbody>
+        <tr>
+          <td bgcolor=site.get("contactUs.branding.bgColor", defaults.bgColor)>
+            <img src=site.get("contactUs.branding.logo", defaults.logo) alt=site.get("contactUs.branding.title") />
+          </td>
+        </tr>
+        <tr>
+          <td class="subject">
+            <p>${site.get("contactUs.branding.title", defaults.title)} Notification</p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <p style="font-family:Arial; font-size:12px;">
+              This e-mail is being sent to you because a user filled out the contact us form on ${domain}.
+            </p>
+
+            <table>
+              <tbody>
+                <tr>
+                  <td nowrap><b>Name</b></td>
+                  <td>${input.name}</td>
+                </tr>
+                <tr>
+                  <td nowrap><b>Phone</b></td>
+                  <td>${input.phone}</td>
+                </tr>
+                <tr>
+                  <td nowrap><b>Email</b></td>
+                  <td>${input.email}</td>
+                </tr>
+                <tr>
+                  <td nowrap><b>Comments</b></td>
+                  <td>${input.comments}</td>
+                </tr>
+
+                <p style="font-family:Arial; font-size:12px;">&nbsp;</p>
+                <p style="font-family:Arial; font-size:12px;">&nbsp;</p>
+
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td class="footer">
+            <small>
+              This is an automated message from ${site.get("contactUs.branding.title", defaults.title)}. Please do not reply directly to this email &mdash; direct any inquiries to
+              <a href=`mailto:${site.get("contactUs.support.email", defaults.supportEmail)}`>
+                ${site.get("contactUs.support.name", defaults.supportName)}
+              </a>
+            </small>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/packages/marko-web-contact-us/email.marko
+++ b/packages/marko-web-contact-us/email.marko
@@ -10,8 +10,6 @@ $ const defaults = {
   supportEmail: "base@endeavorb2b.com",
 };
 
-<!-- @todo this file should be removed once contact us is core -->
-
 <!doctype html>
 <html>
   <head>

--- a/packages/marko-web-contact-us/email.marko
+++ b/packages/marko-web-contact-us/email.marko
@@ -1,11 +1,11 @@
 $ const styles = "table {width: 630px;margin: 0 auto;} .danger { color: red } body{font-family: sans-serif; color: #333; margin: 0;}h1{font-family: monospace; line-height: 58px; text-align:center; margin: 0;}.subject, .footer{text-align:center; border-top: 1px solid #EEE; padding: 1em;}.footer{font-family: monospace; color: #CCC;}";
-$ const baseLogo = "https://s3.amazonaws.com/media.cygnus.com/base.png";
+$ const baseLogo = "https://p1-cms-assets.imgix.net/files/base/static/base.png";
 $ const { domain, subject } = input;
 $ const { site, config } = out.global;
 $ const defaults = {
   title: config.siteName(),
   bgColor: "#FFF",
-  logo: "https://s3.amazonaws.com/media.cygnus.com/base.png",
+  logo: "https://p1-cms-assets.imgix.net/files/base/static/base.png",
   supportName: `${config.siteName()} Support`,
   supportEmail: "support@parameter1.com",
 };

--- a/packages/marko-web-contact-us/email.marko
+++ b/packages/marko-web-contact-us/email.marko
@@ -7,7 +7,7 @@ $ const defaults = {
   bgColor: "#FFF",
   logo: "https://s3.amazonaws.com/media.cygnus.com/base.png",
   supportName: `${config.siteName()} Support`,
-  supportEmail: "base@endeavorb2b.com",
+  supportEmail: "support@parameter1.com",
 };
 
 <!doctype html>

--- a/packages/marko-web-contact-us/env.js
+++ b/packages/marko-web-contact-us/env.js
@@ -1,0 +1,9 @@
+const { cleanEnv, validators } = require('@parameter1/base-cms-env');
+
+const { nonemptystr } = validators;
+
+module.exports = cleanEnv(process.env, {
+  RECAPTCHA_SITE_KEY: nonemptystr({ desc: 'The Recaptcha Site key.' }),
+  RECAPTCHA_SECRET_KEY: nonemptystr({ desc: 'The Recaptcha secret key.' }),
+  SENDGRID_API_KEY: nonemptystr({ desc: 'An API key for sending email via SendGrid.' }),
+});

--- a/packages/marko-web-contact-us/index.js
+++ b/packages/marko-web-contact-us/index.js
@@ -9,8 +9,6 @@ const emailTemplate = require('./email.marko');
 
 const { error } = console;
 
-// @todo This entire service should be deleted once contact us is moved to core.
-
 sgMail.setApiKey(SENDGRID_API_KEY);
 
 const exception = (message, code = 400) => {

--- a/packages/marko-web-contact-us/index.js
+++ b/packages/marko-web-contact-us/index.js
@@ -20,7 +20,7 @@ const exception = (message, code = 400) => {
 };
 
 const send = async (res, domain, payload) => {
-  const config = res.app.locals.site.get(`contactUs.${payload.configName}`);
+  const config = res.app.locals.site.getAsObject(`contactUs.${payload.configName}`);
   const subject = defaultValue(config.subject, 'A new contact submission was received.');
   const to = defaultValue(config.to, 'support@parameter1.com');
   const input = {

--- a/packages/marko-web-contact-us/index.js
+++ b/packages/marko-web-contact-us/index.js
@@ -1,0 +1,74 @@
+const defaultValue = require('@parameter1/base-cms-marko-core/utils/default-value');
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const bodyParser = require('body-parser');
+const sgMail = require('@sendgrid/mail');
+const fetch = require('node-fetch');
+const { URLSearchParams } = require('url');
+const { SENDGRID_API_KEY, RECAPTCHA_SECRET_KEY } = require('./env');
+const emailTemplate = require('./email');
+
+const { error } = console;
+
+// @todo This entire service should be deleted once contact us is moved to core.
+
+sgMail.setApiKey(SENDGRID_API_KEY);
+
+const exception = (message, code = 400) => {
+  const err = new Error(message);
+  err.statusCode = code;
+  return err;
+};
+
+const send = async (res, domain, payload) => {
+  const config = res.app.locals.site.get(`contactUs.${payload.configName}`);
+  const subject = defaultValue(config.subject, 'A new contact submission was received.');
+  const to = defaultValue(config.to, 'support@parameter1.com');
+  const input = {
+    $global: res.app.locals,
+    domain,
+    subject,
+    to,
+    ...payload,
+  };
+  const html = emailTemplate.renderToString(input);
+  return sgMail.send({
+    subject,
+    from: 'Base CMS <noreply@base-cms.io>',
+    to,
+    html,
+    ...config.cc && { cc: config.cc },
+    ...config.bcc && { bcc: config.bcc },
+  });
+};
+
+const validateRecaptcha = async ({ token: response }) => {
+  const params = new URLSearchParams();
+  params.append('response', response);
+  params.append('secret', RECAPTCHA_SECRET_KEY);
+  const res = await fetch('https://www.google.com/recaptcha/api/siteverify', { method: 'post', body: params });
+  const json = await res.json();
+  if (!json.success) {
+    error('reCAPTCHA failed!', json, { secret: RECAPTCHA_SECRET_KEY, response });
+    throw exception('Unable to validate your request');
+  }
+  return true;
+};
+
+const validatePayload = (payload = {}) => ['name', 'phone', 'email', 'comments'].every(k => payload[k]);
+
+module.exports = (app, siteConfig) => {
+  app.post('/__contact-us', bodyParser.json(), asyncRoute(async (req, res) => {
+    const payload = req.body;
+
+    if (!await validateRecaptcha(payload)) throw exception('Unable to validate recaptcha');
+    if (!validatePayload(payload)) throw exception('A required parameter was not sent');
+
+    try {
+      await send(res, req.hostname, payload, siteConfig);
+      res.status(201).send();
+    } catch (e) {
+      error(e);
+      throw exception(e);
+    }
+  }));
+};

--- a/packages/marko-web-contact-us/index.js
+++ b/packages/marko-web-contact-us/index.js
@@ -5,7 +5,7 @@ const sgMail = require('@sendgrid/mail');
 const fetch = require('node-fetch');
 const { URLSearchParams } = require('url');
 const { SENDGRID_API_KEY, RECAPTCHA_SECRET_KEY } = require('./env');
-const emailTemplate = require('./email');
+const emailTemplate = require('./email.marko');
 
 const { error } = console;
 

--- a/packages/marko-web-contact-us/marko.json
+++ b/packages/marko-web-contact-us/marko.json
@@ -1,0 +1,6 @@
+{
+  "taglib-id": "@cox-matthews-associates/package-contact-us",
+  "taglib-imports": [
+    "./components/marko.json"
+  ]
+}

--- a/packages/marko-web-contact-us/marko.json
+++ b/packages/marko-web-contact-us/marko.json
@@ -1,5 +1,5 @@
 {
-  "taglib-id": "@cox-matthews-associates/package-contact-us",
+  "taglib-id": "@parameter1/base-cms-marko-web-contact-us",
   "taglib-imports": [
     "./components/marko.json"
   ]

--- a/packages/marko-web-contact-us/package.json
+++ b/packages/marko-web-contact-us/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@parameter1/base-cms-marko-web-contact-us",
+  "version": "2.57.2",
+  "author": "Brian Miller <brian@parameter1.com>",
+  "repository": "https://github.com/parameter1/base-cms/tree/master/packages/marko-web-contact-us",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "lint": "eslint --ext .js --ext .vue --max-warnings 5 --ignore-path ../../.eslintignore ./",
+    "test": "yarn lint"
+  },
+  "dependencies": {
+    "@parameter1/base-cms-env": "^2.45.0",
+    "@parameter1/base-cms-marko-core": "^2.46.0",
+    "@parameter1/base-cms-marko-web": "^2.50.0",
+    "@parameter1/base-cms-utils": "^2.22.2",
+    "@sendgrid/mail": "^6.4.0",
+    "body-parser": "^1.19.0",
+    "node-fetch": "^2.6.0",
+    "vue-recaptcha": "^1.2.0"
+  }
+}

--- a/packages/marko-web-contact-us/package.json
+++ b/packages/marko-web-contact-us/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parameter1/base-cms-marko-web-contact-us",
-  "version": "2.57.2",
+  "version": "2.60.0",
   "author": "Brian Miller <brian@parameter1.com>",
   "repository": "https://github.com/parameter1/base-cms/tree/master/packages/marko-web-contact-us",
   "license": "MIT",

--- a/packages/marko-web-contact-us/package.json
+++ b/packages/marko-web-contact-us/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@parameter1/base-cms-env": "^2.45.0",
     "@parameter1/base-cms-marko-core": "^2.46.0",
-    "@parameter1/base-cms-marko-web": "^2.50.0",
+    "@parameter1/base-cms-marko-web": "^2.60.0",
     "@parameter1/base-cms-utils": "^2.22.2",
     "@sendgrid/mail": "^6.4.0",
     "body-parser": "^1.19.0",

--- a/packages/marko-web-contact-us/scss/index.scss
+++ b/packages/marko-web-contact-us/scss/index.scss
@@ -1,0 +1,46 @@
+// @todo This file should be moved to core themes once contact us is moved.
+.contact-us-form {
+  &__container {
+    @include theme-card();
+  }
+
+  &__header {
+    @include theme-card-header();
+    @include border-top-radius($theme-card-border-radius);
+    padding: $theme-item-padding ($theme-item-padding + $theme-item-contents-padding);
+    margin-bottom: 0;
+  }
+
+  &__contents {
+    flex: 1 1 auto;
+    padding: $card-spacer-x;
+    color: $card-color;
+  }
+
+  &__label {
+    display: block;
+  }
+
+  &__field,
+  &__submit {
+    width: 100%;
+    margin-bottom: map-get($spacers, 1);
+  }
+
+  &__submit:disabled {
+    cursor: not-allowed;
+  }
+
+  &__text {
+    &--success {
+      color: $success;
+    }
+    &--loading {
+      color: $text-muted;
+      cursor: wait;
+    }
+    &--danger {
+      color: $danger;
+    }
+  }
+}

--- a/packages/marko-web-contact-us/scss/index.scss
+++ b/packages/marko-web-contact-us/scss/index.scss
@@ -1,4 +1,3 @@
-// @todo This file should be moved to core themes once contact us is moved.
 .contact-us-form {
   &__container {
     @include theme-card();


### PR DESCRIPTION
Make a global package for contact us.  The component can be sent a config-name which will map & use the following key: values within the given site config under the contactUs. 

For Example:
```js
const siteConfig = {
  contactUs: {
    submitPodcast: {
      title: 'Submit A podcast',
      to: 'sendTo@pararameter1.com',
      cc: 'cc@pararameter1.com',
      bcc: 'test@test.com',
      subject: 'User\'s Podcast Submission',
    },
  },
},
```
In porting this I also moved the required inclusion of the recaptcha js into the vue component instead of having to place it on the page
<img width="1145" alt="Screen Shot 2021-12-01 at 2 58 39 PM" src="https://user-images.githubusercontent.com/3845869/144312935-384e53d1-246a-49f8-84fe-1f57e83e7de4.png">
<img width="717" alt="Screen Shot 2021-12-01 at 2 59 09 PM" src="https://user-images.githubusercontent.com/3845869/144313004-57537d9a-9310-4263-ba4e-bd759756c524.png">


