### PR TITLE
Add `customAttributes` input to `allPublishedContent`

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -473,6 +473,8 @@ input ContentEventDatesMutationInput {
 }
 
 input AllPublishedContentQueryInput {
+  "Allows for return of the _import.entity field if requested"
+  importEntity: String
   "Limits results to content with a primary site matching the current site context "
   withSite: Boolean = true
   "A websiteSite identifier. If present, overrides the current site context."

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -486,7 +486,7 @@ input AllPublishedContentQueryInput {
   "Deprecated. Use includeContentTypes instead."
   contentTypes: [ContentType!] = []
   "Limit results to items matching specific custom attribute key value pairs"
-  customAttributes: [ContentCustomAttributeQueryInput] = []
+  customAttributes: [ContentCustomAttributeQueryInput!] = []
   "Limit results to items matching at least one of these types."
   includeContentTypes: [ContentType!] = []
   "Limit results to items matching none of these types."

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -473,8 +473,6 @@ input ContentEventDatesMutationInput {
 }
 
 input AllPublishedContentQueryInput {
-  "Allows for return of the _import.entity field if requested"
-  importEntity: String
   "Limits results to content with a primary site matching the current site context "
   withSite: Boolean = true
   "A websiteSite identifier. If present, overrides the current site context."
@@ -487,6 +485,8 @@ input AllPublishedContentQueryInput {
   sectionId: Int
   "Deprecated. Use includeContentTypes instead."
   contentTypes: [ContentType!] = []
+  "Limit results to items matching specific custom attribute key value pairs"
+  customAttributes: [ContentCustomAttributeQueryInput] = []
   "Limit results to items matching at least one of these types."
   includeContentTypes: [ContentType!] = []
   "Limit results to items matching none of these types."
@@ -566,6 +566,13 @@ input ContentEndingInput {
 input ContentCustomAttributeInput {
   "The custom attribute field path."
   path: String!
+}
+
+input ContentCustomAttributeQueryInput {
+  "The object property key to query against"
+  key: String!
+  "The value of that property key to query against"
+  value: String!
 }
 
 input AllContentQueryInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -876,8 +876,7 @@ module.exports = {
       });
 
       customAttributes.forEach(({ key, value }) => {
-        const fullKeyPath = `customAttributes.${key}`;
-        query.$and.push({ [fullKeyPath]: value });
+        query.$and.push({ [`customAttributes.${key}`]: value });
       });
 
       const siteId = input.siteId || site.id();

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -861,7 +861,7 @@ module.exports = {
         beginning,
         ending,
         withSite,
-        importEntity,
+        customAttributes,
       } = input;
 
       // @deprecated Prefer includeContentTypes over contentTypes.
@@ -875,7 +875,10 @@ module.exports = {
         excludeContentTypes,
       });
 
-      if (importEntity) query['_import.entity'] = importEntity;
+      customAttributes.forEach(({ key, value }) => {
+        const fullKeyPath = `customAttributes.${key}`;
+        query.$and.push({ [fullKeyPath]: value });
+      });
 
       const siteId = input.siteId || site.id();
       if (withSite && siteId) query['mutations.Website.primarySite'] = siteId;

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -861,6 +861,7 @@ module.exports = {
         beginning,
         ending,
         withSite,
+        importEntity,
       } = input;
 
       // @deprecated Prefer includeContentTypes over contentTypes.
@@ -873,6 +874,8 @@ module.exports = {
         excludeContentIds,
         excludeContentTypes,
       });
+
+      if (importEntity) query['_import.entity'] = importEntity;
 
       const siteId = input.siteId || site.id();
       if (withSite && siteId) query['mutations.Website.primarySite'] = siteId;


### PR DESCRIPTION
This is being utilized by the new custom redirect handler on RR here: https://github.com/parameter1/randall-reilly-websites/pull/315


<img width="1920" alt="Screen Shot 2021-11-30 at 10 16 32 AM" src="https://user-images.githubusercontent.com/46794001/144085384-45a2c090-3bb1-4910-99b6-2491ea4eba79.png">


