### PR TITLE
Enable use of HTML strings for byline field

### DIFF
--- a/packages/marko-web/components/element/content/byline.marko
+++ b/packages/marko-web/components/element/content/byline.marko
@@ -10,5 +10,6 @@ import extractRender from "../extract-render";
   modifiers=input.modifiers
   attrs=input.attrs
   link=input.link
+  html=true
   ...extractRender(input)
 />


### PR DESCRIPTION
DEV:
<img width="1920" alt="Screen Shot 2021-11-30 at 2 41 13 PM" src="https://user-images.githubusercontent.com/46794001/144128518-b28d4a2b-434b-436d-92d2-81d542c8b27e.png">
 
 
PROD: 
<img width="1920" alt="Screen Shot 2021-11-30 at 3 09 53 PM" src="https://user-images.githubusercontent.com/46794001/144128549-3290715c-6ba3-4a8e-bbce-5be69b9d845c.png">


DEV: 
<img width="1920" alt="Screen Shot 2021-11-30 at 3 08 57 PM" src="https://user-images.githubusercontent.com/46794001/144128589-ad98275b-1266-4ac7-8b73-805c9e5776f9.png">

PROD:
<img width="1920" alt="Screen Shot 2021-11-30 at 3 09 01 PM" src="https://user-images.githubusercontent.com/46794001/144128614-9352e326-928b-4cb8-9b62-d0a3f53318f4.png">

 I used FCP as a cross check to make sure this wasn't going to be breaking on other sites if there is potentially some sort of odd CSS targeting going on. It appears these are just using CSS ::before in order to populate the text and are using a text tag and rendering HTML as appropriate.
 
 Allured will need a dependency upgrade to enable this.