### PR TITLE
Allow for HTML tags in section name

### DIFF
--- a/packages/marko-web/components/element/website-section/name.marko
+++ b/packages/marko-web/components/element/website-section/name.marko
@@ -13,5 +13,6 @@ $ const attrs = { title: get(input.obj, "fullName"), ...input.attrs };
   modifiers=input.modifiers
   attrs=attrs
   link=input.link
+  html=true
   ...extractRender(input)
 />


### PR DESCRIPTION
This is already supported in the interface (as at the very least em is not being stripped).

<img width="1920" alt="Screen Shot 2021-12-08 at 12 38 34 PM" src="https://user-images.githubusercontent.com/46794001/145265449-93d47c09-232f-4bf4-b54a-a5f48e88af79.png">

<img width="1920" alt="Screen Shot 2021-12-08 at 12 38 38 PM" src="https://user-images.githubusercontent.com/46794001/145265453-a9810bf1-63ef-4059-aa6f-7e08ac182fb0.png">
