### PR TITLE
Allow use of custom copyright in footer

### DIFF
--- a/packages/marko-web-theme-default/components/site-footer/index.marko
+++ b/packages/marko-web-theme-default/components/site-footer/index.marko
@@ -36,10 +36,17 @@ $ const showCopyright = defaultValue(input.showCopyright, true)
       has-user=input.hasUser
     />
     <if(showCopyright)>
-      <default-theme-site-footer-copyright
-        company=site.get("company")
-        notice=site.get("copyrightNotice")
-      />
+      <if(site.get("customCopyright"))>
+        <default-theme-site-footer-copyright>
+          ${site.get("customCopyright")}
+        </default-theme-site-footer-copyright>
+      </if>
+      <else>
+        <default-theme-site-footer-copyright
+          company=site.get("company")
+          notice=site.get("copyrightNotice")
+        />
+      </else>
     </if>
   </default-theme-site-footer-container>
 </marko-web-block>


### PR DESCRIPTION
The component already supports renderBody it just hasn't been configured in order to do so, this allows for a field in the site config called "customCopyright" to set a custom copyright in the footer.

<img width="1920" alt="Screen Shot 2021-12-16 at 9 10 52 AM" src="https://user-images.githubusercontent.com/46794001/146397807-1223233e-0a83-4b56-87c3-4c6e3831d583.png">
