### PR TITLE
Add support for filtering allPublishedContent by updated date

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -509,6 +509,8 @@ input AllPublishedContentQueryInput {
   beginning: ContentBeginningInput = {}
   "For types with a endDate field: Limit results to items with a endDate matching the criteria."
   ending: ContentEndingInput = {}
+  "Limit results using the updated (modified) date."
+  updated: ContentUpdatedInput = {}
 }
 
 input AllPublishedContentDatesQueryInput {
@@ -551,6 +553,13 @@ input AllCompanyContentQueryInput {
   sort: ContentSortInput = { field: published, order: desc }
   pagination: PaginationInput = {}
   withSite: Boolean = true
+}
+
+input ContentUpdatedInput {
+  "If specified, include items updated before this date"
+  before: Date
+  "If specified, include items updated after this date"
+  after: Date
 }
 
 input ContentBeginningInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -862,6 +862,7 @@ module.exports = {
         ending,
         withSite,
         customAttributes,
+        updated,
       } = input;
 
       // @deprecated Prefer includeContentTypes over contentTypes.
@@ -886,6 +887,8 @@ module.exports = {
       if (beginning.after) query.$and.push({ startDate: { $gte: beginning.after } });
       if (ending.before) query.$and.push({ endDate: { $lte: ending.before } });
       if (ending.after) query.$and.push({ endDate: { $gte: ending.after } });
+      if (updated.before) query.$and.push({ updated: { $lte: updated.before } });
+      if (updated.after) query.$and.push({ updated: { $gte: updated.after } });
 
       if (requiresImage) {
         query.primaryImage = { $exists: true };


### PR DESCRIPTION
```graphql
query {
  allPublishedContent(input: {
    includeContentTypes: Article
    sort: {
      field: updated
      order: desc
    }
    updated: {
      before: 1641535200000
      after: 1641448800000
    }
  }) {
    edges {
      node {
        id
        name
        updatedDate
      }
    }
  }
}
```