### PR TITLE
Allow overriding of sortField, ```marko-web-search-sort-by```

### DIFF
--- a/packages/marko-web-search/browser/sort-select.vue
+++ b/packages/marko-web-search/browser/sort-select.vue
@@ -1,5 +1,5 @@
 <template>
-  <select class="custom-select" @change="onChange">
+  <select v-if="searchQuery" class="custom-select" @change="onChange">
     <option
       v-for="option in options"
       :key="option.id"
@@ -22,13 +22,34 @@ export default {
       type: String,
       default: 'PUBLISHED',
     },
+    searchQuery: {
+      type: Boolean,
+      default: true,
+    },
+    defaultWithSearchQuery: {
+      type: String,
+      default: 'PUBLISHED',
+    },
+  },
+  mounted() {
+    const url = new URL(window.location);
+    const params = new URLSearchParams(window.location.search);
+    if (!this.searchQuery && params.sortField) {
+      delete params.sortField;
+      url.search = `${params}`;
+      window.location.href = `${url}`;
+    }
   },
   methods: {
     onChange(event) {
       const { value } = event.target;
       const url = new URL(window.location);
       const params = new URLSearchParams(window.location.search);
-      params.set('sortField', value);
+      if ((value !== this.defaultWithSearchQuery)) {
+        params.set('sortField', value);
+      } else {
+        params.delete('sortField');
+      }
       url.search = `${params}`;
       window.location.href = `${url}`;
     },

--- a/packages/marko-web-search/browser/sort-select.vue
+++ b/packages/marko-web-search/browser/sort-select.vue
@@ -34,8 +34,8 @@ export default {
   mounted() {
     const url = new URL(window.location);
     const params = new URLSearchParams(window.location.search);
-    if (!this.searchQuery && params.sortField) {
-      delete params.sortField;
+    if (!this.searchQuery && params.get('sortField')) {
+      params.delete('sortField');
       url.search = `${params}`;
       window.location.href = `${url}`;
     }

--- a/packages/marko-web-search/browser/sort-select.vue
+++ b/packages/marko-web-search/browser/sort-select.vue
@@ -26,10 +26,6 @@ export default {
       type: Boolean,
       default: true,
     },
-    defaultWithSearchQuery: {
-      type: String,
-      default: 'PUBLISHED',
-    },
   },
   mounted() {
     const url = new URL(window.location);
@@ -45,11 +41,7 @@ export default {
       const { value } = event.target;
       const url = new URL(window.location);
       const params = new URLSearchParams(window.location.search);
-      if ((value !== this.defaultWithSearchQuery)) {
-        params.set('sortField', value);
-      } else {
-        params.delete('sortField');
-      }
+      params.set('sortField', value);
       url.search = `${params}`;
       window.location.href = `${url}`;
     },

--- a/packages/marko-web-search/browser/sort-select.vue
+++ b/packages/marko-web-search/browser/sort-select.vue
@@ -27,15 +27,6 @@ export default {
       default: true,
     },
   },
-  mounted() {
-    const url = new URL(window.location);
-    const params = new URLSearchParams(window.location.search);
-    if (!this.searchQuery && params.get('sortField')) {
-      params.delete('sortField');
-      url.search = `${params}`;
-      window.location.href = `${url}`;
-    }
-  },
   methods: {
     onChange(event) {
       const { value } = event.target;

--- a/packages/marko-web-search/browser/sort-select.vue
+++ b/packages/marko-web-search/browser/sort-select.vue
@@ -1,5 +1,5 @@
 <template>
-  <select v-if="searchQuery" class="custom-select" @change="onChange">
+  <select class="custom-select" @change="onChange">
     <option
       v-for="option in options"
       :key="option.id"
@@ -21,10 +21,6 @@ export default {
     selectedId: {
       type: String,
       default: 'PUBLISHED',
-    },
-    searchQuery: {
-      type: Boolean,
-      default: true,
     },
   },
   methods: {

--- a/packages/marko-web-search/components/sort-by/index.marko
+++ b/packages/marko-web-search/components/sort-by/index.marko
@@ -12,10 +12,22 @@ $ const options = [
 
 <marko-web-block name=blockName modifiers=input.modifiers>
   $ const { searchQuery, sortField } = search.input;
+  $ const selectedId = input.sortField || sortField;
+  $ const defaultWithSearchQuery = input.defaultWithSearchQuery || 'PUBLISHED';
   <if(searchQuery)>
     <marko-web-browser-component
       name="MarkoWebSearchSortSelect"
-      props={ options, selectedId: sortField }
+      props={
+        options,
+        selectedId,
+        defaultWithSearchQuery
+      }
     />
   </if>
+  <else>
+    <marko-web-browser-component
+      name="MarkoWebSearchSortSelect"
+      props={ options, searchQuery: Boolean(searchQuery) }
+    />
+  </else>
 </marko-web-block>

--- a/packages/marko-web-search/components/sort-by/index.marko
+++ b/packages/marko-web-search/components/sort-by/index.marko
@@ -13,15 +13,10 @@ $ const options = [
 <marko-web-block name=blockName modifiers=input.modifiers>
   $ const { searchQuery, sortField } = search.input;
   $ const selectedId = input.sortField || sortField;
-  $ const defaultWithSearchQuery = input.defaultWithSearchQuery || 'PUBLISHED';
   <if(searchQuery)>
     <marko-web-browser-component
       name="MarkoWebSearchSortSelect"
-      props={
-        options,
-        selectedId,
-        defaultWithSearchQuery
-      }
+      props={ options, selectedId }
     />
   </if>
   <else>

--- a/packages/marko-web-search/components/sort-by/index.marko
+++ b/packages/marko-web-search/components/sort-by/index.marko
@@ -19,10 +19,4 @@ $ const options = [
       props={ options, selectedId }
     />
   </if>
-  <else>
-    <marko-web-browser-component
-      name="MarkoWebSearchSortSelect"
-      props={ options, searchQuery: Boolean(searchQuery) }
-    />
-  </else>
 </marko-web-block>


### PR DESCRIPTION
Landing page (sort by published date):
<img width="1920" alt="Screen Shot 2022-01-27 at 10 42 29 AM" src="https://user-images.githubusercontent.com/46794001/151404015-dbb31fa0-c9c5-4995-9ca0-2ca139f37c44.png">

With search query (Overriding to sort by relevance):
<img width="1920" alt="Screen Shot 2022-01-27 at 10 42 36 AM" src="https://user-images.githubusercontent.com/46794001/151404264-30cc5cf9-67ab-4a3d-9107-5d72b30a5250.png">

With search query and non-default sort selected (In this case this is now PUBLISHED as the default is overridden to SCORE):
<img width="1920" alt="Screen Shot 2022-01-27 at 10 42 44 AM" src="https://user-images.githubusercontent.com/46794001/151404328-53fd6391-0215-4f3d-90e9-794d12da073e.png">

With search query removed following having one (Result is the same whether or not the default sort for when there is a search query was used or not):
<img width="1920" alt="Screen Shot 2022-01-27 at 10 42 50 AM" src="https://user-images.githubusercontent.com/46794001/151404576-e2feb2f2-404c-48b0-8558-61dcae04f04f.png">
