### PR TITLE
Add marko-web-native-x-query component

### DIFF
--- a/packages/marko-web-native-x/components/marko.json
+++ b/packages/marko-web-native-x/components/marko.json
@@ -7,6 +7,12 @@
     "@target-tag": "string",
     "@request-frame": "boolean"
   },
+  "<marko-web-native-x-query>": {
+    "template": "./query.marko",
+    "@uri": "string",
+    "@id": "string",
+    "@opts": "object"
+  },
   "<marko-web-native-x-retrieve>": {
     "template": "./retrieve.marko",
     "@uri": "string",

--- a/packages/marko-web-native-x/components/query.marko
+++ b/packages/marko-web-native-x/components/query.marko
@@ -1,0 +1,15 @@
+import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+import { warn } from "@parameter1/base-cms-utils";
+
+$ const { uri, id, opts } = input;
+$ const ads = [];
+
+<if(uri && id)>
+  <marko-web-native-x-fetch-elements|{ ads }| uri=uri id=id opts=opts>
+    <${input.renderBody} ads=ads />
+  </marko-web-native-x-fetch-elements>
+</if>
+<else>
+    $ warn('Unable to render NativeX placement: a uri and placement ID are required.');
+    <${input.renderBody} ads=ads />
+</else>


### PR DESCRIPTION
Allows one or more native-x ads to be returned for further processing/formatting.

Enables a dedicated native ad block like this one:
<img width="1099" alt="Screen Shot 2022-01-29 at 4 57 56 PM" src="https://user-images.githubusercontent.com/2855198/151680267-f18c1129-0359-428e-a813-c59de853fd5f.png">
