### PR TITLE
Update IdX access logic to only check when enabled

### DIFF
--- a/packages/marko-web-identity-x/components/access.marko
+++ b/packages/marko-web-identity-x/components/access.marko
@@ -1,12 +1,10 @@
 import { getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const { req } = out.global;
+$ const isEnabled = input.enabled || false;
 $ const { identityX } = req;
 
-$ const requiredAccessLevelIds = getAsArray(input.requiredAccessLevelIds);
-$ const params = { isEnabled: input.enabled, requiredAccessLevelIds };
-
-$ const checkContentAccess = async () => (Boolean(req.identityX) ? identityX.checkContentAccess(params) : {
+$ const accessObj = {
   canAccess: true,
   isLoggedIn: false,
   hasRequiredAccessLevel: false,
@@ -14,7 +12,12 @@ $ const checkContentAccess = async () => (Boolean(req.identityX) ? identityX.che
   requiredAccessLevels: [],
   requiresUserInput: false,
   messages: {},
-});
+};
+
+$ const requiredAccessLevelIds = getAsArray(input.requiredAccessLevelIds);
+$ const params = { isEnabled, requiredAccessLevelIds };
+
+$ const checkContentAccess = async () => (isEnabled && Boolean(req.identityX) ? identityX.checkContentAccess(params) : accessObj);
 
 <marko-web-resolve|{ resolved }| promise=checkContentAccess()>
   <${input.renderBody} ...resolved />


### PR DESCRIPTION
Only run the identityX.checkContentAccess() when idX is present & this is enabled.  This will prevent the requiresUserInput from returning true on non gated content.  This check should only be enforced when gating is present.