### PR TITLE
Add default prop value for continue in the login-button-labels default prop value

### DIFF
--- a/packages/marko-web-identity-x/browser/comments/stream.vue
+++ b/packages/marko-web-identity-x/browser/comments/stream.vue
@@ -147,6 +147,7 @@ export default {
       type: Object,
       default: () => ({
         submit: 'Login / Register',
+        continue: 'Continue',
         logout: 'Logout',
       }),
     },


### PR DESCRIPTION
This will prevent the login button on the comment stream from being empty.  By default the button label on the login component being referenced was looking for the object key of continue on the button labels prop.