### PR TITLE
Add fallback for non-primary site primary section.

### DIFF
--- a/packages/canonical-path/src/platform/content.js
+++ b/packages/canonical-path/src/platform/content.js
@@ -22,7 +22,7 @@ const pathResolvers = {
     // @todo This should eventually account for secondary sites/sections.
     // For now load an alternate from schedules
     const sectionQuery = getAsArray(content, 'sectionQuery');
-    if (sectionQuery.length && !section) {
+    if (sectionQuery.length) {
       const currentSiteSections = sectionQuery.map((schedule) => {
         if (schedule.siteId === site.id()) return schedule;
         return null;

--- a/packages/canonical-path/src/platform/content.js
+++ b/packages/canonical-path/src/platform/content.js
@@ -1,8 +1,7 @@
-const { isFunction: isFn, cleanPath } = require('@parameter1/base-cms-utils');
+const { isFunction: isFn, cleanPath, getSectionFromSchedules } = require('@parameter1/base-cms-utils');
 const { get } = require('@parameter1/base-cms-object-path');
 const { BaseDB } = require('@parameter1/base-cms-db');
 const { dasherize } = require('@parameter1/base-cms-inflector');
-const getSectionFromSchedules = require('../../../utils/src/get-section-from-schedules');
 
 const pathResolvers = {
   id: content => content._id,

--- a/packages/canonical-path/src/platform/content.js
+++ b/packages/canonical-path/src/platform/content.js
@@ -21,8 +21,13 @@ const pathResolvers = {
     if (section) return section.alias;
     // @todo This should eventually account for secondary sites/sections.
     // For now load an alternate from schedules
-    const sectionFromSched = await getSectionFromSchedules({ content, siteId: site.id(), load });
-    if (sectionFromSched) return sectionFromSched.alias;
+    const sectionFromSchedule = await getSectionFromSchedules({
+      content,
+      siteId: site.id(),
+      projection: { alias: 1 },
+      load,
+    });
+    if (sectionFromSchedule) return sectionFromSchedule.alias;
     // If the requested alternate could not be found.
     return 'home';
   },

--- a/packages/canonical-path/src/platform/content.js
+++ b/packages/canonical-path/src/platform/content.js
@@ -18,7 +18,7 @@ const pathResolvers = {
       'site.$id': site.id(),
     };
     const section = await load('websiteSection', id, { alias: 1 }, query);
-    if (section) return section;
+    if (section) return section.alias;
     // @todo This should eventually account for secondary sites/sections.
     // For now load an alternate from schedules
     const sectionQuery = getAsArray(content, 'sectionQuery');

--- a/packages/canonical-path/src/platform/content.js
+++ b/packages/canonical-path/src/platform/content.js
@@ -1,7 +1,8 @@
 const { isFunction: isFn, cleanPath } = require('@parameter1/base-cms-utils');
-const { get, getAsArray } = require('@parameter1/base-cms-object-path');
+const { get } = require('@parameter1/base-cms-object-path');
 const { BaseDB } = require('@parameter1/base-cms-db');
 const { dasherize } = require('@parameter1/base-cms-inflector');
+const getSectionFromSchedules = require('../../../utils/src/get-section-from-schedules');
 
 const pathResolvers = {
   id: content => content._id,
@@ -21,17 +22,8 @@ const pathResolvers = {
     if (section) return section.alias;
     // @todo This should eventually account for secondary sites/sections.
     // For now load an alternate from schedules
-    const sectionQuery = getAsArray(content, 'sectionQuery');
-    if (sectionQuery.length) {
-      const currentSiteSections = sectionQuery.map((schedule) => {
-        if (schedule.siteId === site.id()) return schedule;
-        return null;
-      }).filter(v => v);
-      if (currentSiteSections.length) {
-        const currentSiteSection = await load('websiteSection', currentSiteSections[0].sectionId, { alias: 1 }, query);
-        if (currentSiteSection) return currentSiteSection.alias;
-      }
-    }
+    const sectionFromSched = await getSectionFromSchedules({ content, siteId: site.id(), load });
+    if (sectionFromSched) return sectionFromSched.alias;
     // If the requested alternate could not be found.
     return 'home';
   },

--- a/packages/canonical-path/src/platform/content.js
+++ b/packages/canonical-path/src/platform/content.js
@@ -18,6 +18,7 @@ const pathResolvers = {
       'site.$id': site.id(),
     };
     const section = await load('websiteSection', id, { alias: 1 }, query);
+    if (section) return section;
     // @todo This should eventually account for secondary sites/sections.
     // For now load an alternate from schedules
     const sectionQuery = getAsArray(content, 'sectionQuery');

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -13,6 +13,6 @@ module.exports = async ({
   };
   const sectionsFromScheds = sectionQuery.filter(schedule => `${schedule.siteId}` === `${siteId}`);
   const foundSections = await Promise.all(sectionsFromScheds.map(section => load('websiteSection', section.sectionId, projection, query)));
-  if (foundSections.length) return foundSections.filter(v => v._id)[0];
+  if (foundSections.length) return foundSections.filter(v => v)[0];
   return null;
 };

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -6,7 +6,7 @@ module.exports = async ({ content, siteId, load }) => {
   };
   if (sectionQuery.length) {
     const sectionsFromScheds = sectionQuery.filter(schedule => schedule.siteId === siteId);
-    const foundSections = await Promise.all([sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query))]);
+    const foundSections = await Promise.all([...sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query))]);
     const currentSiteSection = foundSections.find(({ alias }) => alias !== 'home');
     if (currentSiteSection) return currentSiteSection;
     return null;

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -8,7 +8,7 @@ module.exports = async ({ content, siteId, load }) => {
   if (sectionQuery.length) {
     const sectionsFromScheds = sectionQuery.filter(schedule => schedule.siteId === siteId);
     const foundSections = await Promise.all(sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query)));
-    if (foundSections) return foundSections[0];
+    if (foundSections.length) return foundSections[0];
     return null;
   }
   return null;

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -1,15 +1,18 @@
-module.exports = async ({ content, siteId, load }) => {
+module.exports = async ({
+  content,
+  siteId,
+  projection,
+  load,
+}) => {
   const { sectionQuery } = content;
+  if (!sectionQuery.length) return null;
   const query = {
     status: 1,
     'site.$id': siteId,
     alias: { $ne: 'home' },
   };
-  if (sectionQuery.length) {
-    const sectionsFromScheds = sectionQuery.filter(schedule => schedule.siteId === siteId);
-    const foundSections = await Promise.all(sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query)));
-    if (foundSections.length) return foundSections.filter(v => v._id)[0];
-    return null;
-  }
+  const sectionsFromScheds = sectionQuery.filter(schedule => `${schedule.siteId}` === `${siteId}`);
+  const foundSections = await Promise.all(sectionsFromScheds.map(section => load('websiteSection', section.sectionId, projection, query)));
+  if (foundSections.length) return foundSections.filter(v => v._id)[0];
   return null;
 };

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -5,10 +5,7 @@ module.exports = async ({ content, siteId, load }) => {
     'site.$id': siteId,
   };
   if (sectionQuery.length) {
-    const sectionsFromScheds = sectionQuery.map((schedule) => {
-      if (schedule.siteId === siteId) return schedule;
-      return null;
-    }).filter(v => v);
+    const sectionsFromScheds = sectionQuery.filter(schedule => schedule.siteId === siteId);
     const foundSections = await Promise.all([sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query))]);
     const currentSiteSection = foundSections.find(({ alias }) => alias !== 'home');
     if (currentSiteSection) return currentSiteSection;

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -12,7 +12,7 @@ module.exports = async ({
     alias: { $ne: 'home' },
   };
   const sectionsFromScheds = sectionQuery.filter(schedule => `${schedule.siteId}` === `${siteId}`);
-  const foundSections = await Promise.all(sectionsFromScheds.map(section => load('websiteSection', section.sectionId, projection, query)));
+  const foundSections = await load('websiteSection', sectionsFromScheds.map(schedule => schedule.sectionId), projection, query);
   if (foundSections.length) return foundSections.filter(v => v._id)[0];
   return null;
 };

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -1,0 +1,16 @@
+module.exports = async ({ content, siteId, load }) => {
+  const { sectionQuery } = content;
+  const query = {
+    status: 1,
+    'site.$id': siteId,
+  };
+  if (sectionQuery.length) {
+    const sectionFromSched = sectionQuery.find(({ siteId: schedSiteId }) => siteId === schedSiteId);
+    if (sectionFromSched) {
+      const currentSiteSection = await load('websiteSection', sectionFromSched.sectionId, { alias: 1 }, query);
+      if (currentSiteSection) return currentSiteSection;
+    }
+    return null;
+  }
+  return null;
+};

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -7,7 +7,7 @@ module.exports = async ({ content, siteId, load }) => {
   if (sectionQuery.length) {
     const sectionFromSched = sectionQuery.find(({ siteId: schedSiteId }) => siteId === schedSiteId);
     if (sectionFromSched) {
-      const currentSiteSection = await load('websiteSection', sectionFromSched.sectionId, { alias: 1 }, query);
+      const currentSiteSection = await load('websiteSection', sectionFromSched.sectionId, {}, query);
       if (currentSiteSection) return currentSiteSection;
     }
     return null;

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -8,7 +8,7 @@ module.exports = async ({ content, siteId, load }) => {
   if (sectionQuery.length) {
     const sectionsFromScheds = sectionQuery.filter(schedule => schedule.siteId === siteId);
     const foundSections = await Promise.all(sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query)));
-    if (foundSections.length) return foundSections[0];
+    if (foundSections.length) return foundSections.filter(v => v._id)[0];
     return null;
   }
   return null;

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -3,12 +3,12 @@ module.exports = async ({ content, siteId, load }) => {
   const query = {
     status: 1,
     'site.$id': siteId,
+    alias: { $ne: 'home' },
   };
   if (sectionQuery.length) {
     const sectionsFromScheds = sectionQuery.filter(schedule => schedule.siteId === siteId);
     const foundSections = await Promise.all(sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query)));
-    const currentSiteSection = foundSections.find(({ alias }) => alias !== 'home');
-    if (currentSiteSection) return currentSiteSection;
+    if (foundSections) return foundSections[0];
     return null;
   }
   return null;

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -6,7 +6,7 @@ module.exports = async ({ content, siteId, load }) => {
   };
   if (sectionQuery.length) {
     const sectionsFromScheds = sectionQuery.filter(schedule => schedule.siteId === siteId);
-    const foundSections = await Promise.all([...sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query))]);
+    const foundSections = await Promise.all(sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query)));
     const currentSiteSection = foundSections.find(({ alias }) => alias !== 'home');
     if (currentSiteSection) return currentSiteSection;
     return null;

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -5,11 +5,13 @@ module.exports = async ({ content, siteId, load }) => {
     'site.$id': siteId,
   };
   if (sectionQuery.length) {
-    const sectionFromSched = sectionQuery.find(({ siteId: schedSiteId }) => siteId === schedSiteId);
-    if (sectionFromSched) {
-      const currentSiteSection = await load('websiteSection', sectionFromSched.sectionId, {}, query);
-      if (currentSiteSection) return currentSiteSection;
-    }
+    const sectionsFromScheds = sectionQuery.map((schedule) => {
+      if (schedule.siteId === siteId) return schedule;
+      return null;
+    }).filter(v => v);
+    const foundSections = await Promise.all([sectionsFromScheds.map(section => load('websiteSection', section.sectionId, {}, query))]);
+    const currentSiteSection = foundSections.find(({ alias }) => alias !== 'home');
+    if (currentSiteSection) return currentSiteSection;
     return null;
   }
   return null;

--- a/packages/utils/src/get-section-from-schedules.js
+++ b/packages/utils/src/get-section-from-schedules.js
@@ -12,7 +12,7 @@ module.exports = async ({
     alias: { $ne: 'home' },
   };
   const sectionsFromScheds = sectionQuery.filter(schedule => `${schedule.siteId}` === `${siteId}`);
-  const foundSections = await load('websiteSection', sectionsFromScheds.map(schedule => schedule.sectionId), projection, query);
+  const foundSections = await Promise.all(sectionsFromScheds.map(section => load('websiteSection', section.sectionId, projection, query)));
   if (foundSections.length) return foundSections.filter(v => v._id)[0];
   return null;
 };

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -9,6 +9,7 @@ const compareNumbers = require('./compare-numbers');
 const getDefaultTaxonomyTypes = require('./get-default-taxonomy-types');
 const getDefaultContentTypes = require('./get-default-content-types');
 const getPublishedContentCriteria = require('./get-published-content-criteria');
+const getSectionFromSchedules = require('./get-section-from-schedules');
 const isDev = require('./is-dev');
 const isFunction = require('./is-function');
 const isObject = require('./is-object');
@@ -30,6 +31,7 @@ module.exports = {
   getDefaultTaxonomyTypes,
   getDefaultContentTypes,
   getPublishedContentCriteria,
+  getSectionFromSchedules,
   isDev,
   isFunction,
   isObject,

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -47,7 +47,7 @@ interface Content @requiresProject(fields: ["type"]) {
   # fields from platform.model::Content mutations
   # schedules: PlatformContentSchedules! @passThru
   primarySite(input: ContentPrimarySiteInput = {}): WebsiteSite @projection(localField: "mutations.Website.primarySite") @refOne(loader: "platformProduct", localField: "mutations.Website.primarySite", criteria: "websiteSite")
-  primarySection(input: ContentPrimarySectionInput = {}): WebsiteSection @projection(localField: "mutations.Website.primarySection")
+  primarySection(input: ContentPrimarySectionInput = {}): WebsiteSection @projection(localField: "mutations.Website.primarySection", needs: ["sectionQuery"])
 
   # fields from platform.trait::Content\SeoFields
   seoTitle: String @projection(localField: "mutations.Website.seoTitle", needs: ["name"]) @value(localField: "mutations.Website.seoTitle", fallbackField: "name")

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -28,6 +28,7 @@ const relatedContent = require('../../utils/related-content');
 const inquiryEmails = require('../../utils/inquiry-emails');
 const connectionProjection = require('../../utils/connection-projection');
 const getDescendantIds = require('../../utils/website-section-child-ids');
+const getSectionFromSchedules = require('../../../../../../packages/utils/src/get-section-from-schedules');
 const {
   createTitle,
   createDescription,
@@ -484,18 +485,8 @@ module.exports = {
       // Current section does not match site, load alternate.
       // @todo This should eventually account for secondary sites/sections.
       // For now load an alternate from schedules.
-      const sectionQuery = getAsArray(content, 'sectionQuery');
-      if (sectionQuery.length) {
-        if (!siteId) throw new UserInputError('A site id must be set to generate the `Content.primarySection` field.');
-        const currentSiteSections = sectionQuery.map((schedule) => {
-          if (schedule.siteId === siteId) return schedule;
-          return null;
-        }).filter(v => v);
-        if (currentSiteSections.length) {
-          const currentSiteSection = await load('websiteSection', currentSiteSections[0].sectionId, projection, query);
-          if (currentSiteSection) return currentSiteSection;
-        }
-      }
+      const sectionFromSched = await getSectionFromSchedules({ content, siteId, load });
+      if (sectionFromSched) return sectionFromSched;
       // @todo Should this value be "pure" - meaning, do not override value and simply return?
       return loadHomeSection({
         basedb,

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1,7 +1,7 @@
 const { BaseDB } = require('@parameter1/base-cms-db');
 const { UserInputError } = require('apollo-server-express');
 const { Base4RestPayload } = require('@parameter1/base-cms-base4-rest-api');
-const { cleanPath, asObject } = require('@parameter1/base-cms-utils');
+const { cleanPath, asObject, getSectionFromSchedules } = require('@parameter1/base-cms-utils');
 const { content: canonicalPathFor } = require('@parameter1/base-cms-canonical-path');
 const { get, getAsObject } = require('@parameter1/base-cms-object-path');
 const { underscore, dasherize, titleize } = require('@parameter1/base-cms-inflector');
@@ -28,7 +28,7 @@ const relatedContent = require('../../utils/related-content');
 const inquiryEmails = require('../../utils/inquiry-emails');
 const connectionProjection = require('../../utils/connection-projection');
 const getDescendantIds = require('../../utils/website-section-child-ids');
-const getSectionFromSchedules = require('../../../../../../packages/utils/src/get-section-from-schedules');
+
 const {
   createTitle,
   createDescription,

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -484,8 +484,13 @@ module.exports = {
       // Current section does not match site, load alternate.
       // @todo This should eventually account for secondary sites/sections.
       // For now load an alternate from schedules.
-      const sectionFromSched = await getSectionFromSchedules({ content, siteId, load });
-      if (sectionFromSched) return sectionFromSched;
+      const sectionFromSchedule = await getSectionFromSchedules({
+        content,
+        siteId,
+        projection,
+        load,
+      });
+      if (sectionFromSchedule) return sectionFromSchedule;
       // @todo Should this value be "pure" - meaning, do not override value and simply return?
       return loadHomeSection({
         basedb,

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -493,8 +493,8 @@ module.exports = {
           _id: { $in: sectionQuery.map(schedule => schedule.sectionId) },
           alias: { $ne: 'home' },
         };
-        const currentSiteSections = await basedb.findOne('website.Section', currentSiteSectionQuery, { projection });
-        if (currentSiteSections.length) return currentSiteSections;
+        const currentSiteSection = await basedb.findOne('website.Section', currentSiteSectionQuery, { projection });
+        if (currentSiteSection) return currentSiteSection;
       }
 
       // @todo Should this value be "pure" - meaning, do not override value and simply return?

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -28,7 +28,6 @@ const relatedContent = require('../../utils/related-content');
 const inquiryEmails = require('../../utils/inquiry-emails');
 const connectionProjection = require('../../utils/connection-projection');
 const getDescendantIds = require('../../utils/website-section-child-ids');
-
 const {
   createTitle,
   createDescription,

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -482,8 +482,8 @@ module.exports = {
       if (section) return section;
 
       // Current section does not match site, load alternate.
-      const { sectionQuery } = await load('platformContent', content._id, { sectionQuery: 1 });
-      if (sectionQuery) {
+      const sectionQuery = getAsArray(content, 'sectionQuery');
+      if (sectionQuery.length) {
         const currentSiteSectionQuery = {
           ...formatStatus(status),
           ...(siteId && { 'site.$id': siteId }),

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -447,7 +447,7 @@ module.exports = {
     /**
      * Load primary section of content.
      * If primary section's site matches the current site, return the section.
-     * If not, check for alternative site + section (@todo).
+     * If not, check for alternative site + section.
      * Return alternate section (if found), otherwise return home section of current site.
      * If no site is provided, simply return the current section.
      */
@@ -482,7 +482,17 @@ module.exports = {
       if (section) return section;
 
       // Current section does not match site, load alternate.
-      // @todo This should eventually account for secondary sites/sections. For now, load home.
+      const { sectionQuery } = await load('platformContent', content._id, { sectionQuery: 1 });
+      if (sectionQuery) {
+        const currentSiteSectionQuery = {
+          ...formatStatus(status),
+          ...(siteId && { 'site.$id': siteId }),
+          _id: { $in: sectionQuery.map(schedule => schedule.sectionId) },
+        };
+        const currentSiteSections = await basedb.find('website.Section', currentSiteSectionQuery, { projection });
+        if (currentSiteSections.length) return currentSiteSections[0];
+      }
+
       // @todo Should this value be "pure" - meaning, do not override value and simply return?
       return loadHomeSection({
         basedb,


### PR DESCRIPTION
This will use the first section on the given site within the content items schedules and set it as the primary section.

Example article is one from Food Logistics on SDCE (https://www.foodlogistics.com/professional-development/training/news/22031062/gartner-inc-supply-chain-leaders-expect-permanent-hybrid-work-model-for-frontline-workers)

<img width="1920" alt="Screen Shot 2022-02-03 at 2 28 55 PM" src="https://user-images.githubusercontent.com/46794001/152423765-ba52969f-28c2-4beb-814e-0cc8b88f267e.png">

<img width="1920" alt="Screen Shot 2022-02-03 at 2 28 47 PM" src="https://user-images.githubusercontent.com/46794001/152423752-6b541900-cf93-4403-b4df-26e91ef910dd.png">
.