### PR TITLE
Ensure Omeda encrypted IDs are properly kept in-sync with server state

### DIFF
--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -1,7 +1,7 @@
 const { get, getAsArray, getAsObject } = require('@parameter1/base-cms-object-path');
 const { isFunction: isFn } = require('@parameter1/base-cms-utils');
 
-const validHooks = ['onAuthenticationSuccess', 'onUserProfileUpdate', 'onLoginLinkSent', 'onLogout'];
+const validHooks = ['onAuthenticationSuccess', 'onUserProfileUpdate', 'onLoadActiveContext', 'onLoginLinkSent', 'onLogout'];
 const { log } = console;
 
 class IdentityXConfiguration {

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -3,6 +3,8 @@ const getActiveContext = require('./api/queries/get-active-context');
 const checkContentAccess = require('./api/queries/check-content-access');
 const addExternalUserId = require('./api/mutations/add-external-user-id');
 const tokenCookie = require('./utils/token-cookie');
+const callHooksFor = require('./utils/call-hooks-for');
+
 
 const isEmpty = v => v == null || v === '';
 
@@ -34,7 +36,13 @@ class IdentityX {
       this.activeContextQuery = this.client.query({ query: getActiveContext });
     }
     const { data = {} } = await this.activeContextQuery;
-    return data.activeAppContext || {};
+    const activeContext = data.activeAppContext || {};
+    await callHooksFor(this, 'onLoadActiveContext', {
+      req: this.req,
+      res: this.res,
+      activeContext,
+    });
+    return activeContext;
   }
 
   /**

--- a/packages/marko-web-omeda-identity-x/add-integration-hooks.js
+++ b/packages/marko-web-omeda-identity-x/add-integration-hooks.js
@@ -1,6 +1,7 @@
 
 const {
   onAuthenticationSuccess,
+  onLoadActiveContext,
   onLoginLinkSent,
   onLogout,
   onUserProfileUpdate,
@@ -29,6 +30,17 @@ module.exports = ({
       req,
       service,
       user,
+    }),
+  });
+
+  idxConfig.addHook({
+    name: 'onLoadActiveContext',
+    shouldAwait: true,
+    fn: async ({ activeContext, req, res }) => onLoadActiveContext({
+      brandKey,
+      activeContext,
+      req,
+      res,
     }),
   });
 

--- a/packages/marko-web-omeda-identity-x/integration-hooks/index.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/index.js
@@ -1,10 +1,12 @@
 const onAuthenticationSuccess = require('./on-authentication-success');
+const onLoadActiveContext = require('./on-load-active-context');
 const onLoginLinkSent = require('./on-login-link-sent');
 const onLogout = require('./on-logout');
 const onUserProfileUpdate = require('./on-user-profile-update');
 
 module.exports = {
   onAuthenticationSuccess,
+  onLoadActiveContext,
   onLoginLinkSent,
   onLogout,
   onUserProfileUpdate,

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-load-active-context.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-load-active-context.js
@@ -1,0 +1,26 @@
+const { get } = require('@parameter1/base-cms-object-path');
+const olyticsCookie = require('@parameter1/base-cms-marko-web-omeda/olytics/customer-cookie');
+const findEncryptedId = require('../external-id/find-encrypted-customer-id');
+
+module.exports = ({
+  brandKey,
+  activeContext,
+  req,
+  res,
+}) => {
+  const user = get(activeContext, 'user');
+  if (!user || !user.id) return;
+  const idxEncId = findEncryptedId({ externalIds: user.externalIds, brandKey });
+  const cookieEncId = olyticsCookie.parseFrom(req);
+  if (!idxEncId && cookieEncId && !res.headersSent) {
+    // an identity-x user without an encrypted id is logged in.
+    // clear any encrypted id cookies if they are set.
+    olyticsCookie.clearFrom(res);
+    return;
+  }
+  // if theres a mismatch between the idx user encrypted id and the
+  // cookie id, reset the cookie id.
+  if (idxEncId !== cookieEncId && !res.headersSent) {
+    olyticsCookie.setTo(res, idxEncId);
+  }
+};

--- a/packages/marko-web-omeda/olytics/customer-cookie.js
+++ b/packages/marko-web-omeda/olytics/customer-cookie.js
@@ -1,4 +1,8 @@
+const { getDomain } = require('tldjs');
+
 const COOKIE_NAME = 'oly_enc_id';
+
+const getDotDomainFrom = req => `.${getDomain(req.hostname)}`;
 
 const clean = (value) => {
   if (!value || value === 'null') return null;
@@ -12,16 +16,22 @@ const parseFrom = (req) => {
 };
 
 const clearFrom = (res) => {
+  const dotDomain = getDotDomainFrom(res.req);
   res.clearCookie(COOKIE_NAME);
+  res.clearCookie(COOKIE_NAME, { domain: dotDomain });
 };
 
 const setTo = (res, value) => {
   const cleaned = clean(value);
   if (!cleaned) return false;
-  res.cookie(COOKIE_NAME, `"${cleaned}"`, {
+  const v = `"${cleaned}"`;
+  const options = {
     maxAge: 60 * 60 * 24 * 365,
     httpOnly: false,
-  });
+  };
+  const dotDomain = getDotDomainFrom(res.req);
+  res.cookie(COOKIE_NAME, v, options);
+  res.cookie(COOKIE_NAME, v, { ...options, domain: dotDomain });
   return true;
 };
 

--- a/packages/marko-web-omeda/package.json
+++ b/packages/marko-web-omeda/package.json
@@ -16,7 +16,8 @@
     "@parameter1/omeda-graphql-client": "^0.7.2",
     "graphql": "^14.7.0",
     "graphql-tag": "^2.12.5",
-    "node-fetch": "^2.6.5"
+    "node-fetch": "^2.6.5",
+    "tldjs": "^2.3.1"
   },
   "peerDependencies": {
     "@parameter1/base-cms-marko-web": "^2.0.0"

--- a/packages/marko-web-p1-fii/browser/omeda-alchemer-form.vue
+++ b/packages/marko-web-p1-fii/browser/omeda-alchemer-form.vue
@@ -22,7 +22,6 @@ export default {
     surveyId: { type: [Number, String], required: true },
     alchemerZone: { type: [Number, String], required: true },
     omedaZone: { type: String, required: true },
-    encryptedCustomerId: { type: String, default: null },
     context: { type: Object, default: () => ({}) },
     height: { type: Number, default: 1000 },
     width: { type: Number, default: 500 },
@@ -73,12 +72,10 @@ export default {
       try {
         this.error = null;
         this.isLoading = true;
-        const { encryptedCustomerId } = this;
         const params = {
           for: `${this.alchemerZone}`,
           using: this.omedaZone,
           surveyId: parseInt(this.surveyId, 10),
-          ...(encryptedCustomerId && { encryptedCustomerId }),
           context: this.context,
           alwaysAppendContext: this.alwaysAppendContext,
         };

--- a/packages/marko-web-p1-fii/browser/omeda-wufoo-form.vue
+++ b/packages/marko-web-p1-fii/browser/omeda-wufoo-form.vue
@@ -16,7 +16,6 @@ export default {
     formHash: { type: String, required: true },
     wufooZone: { type: String, required: true },
     omedaZone: { type: String, required: true },
-    encryptedCustomerId: { type: String, default: null },
     context: { type: Object, default: () => ({}) },
     height: { type: Number, default: 1000 },
     hideHeader: { type: Boolean, default: false },
@@ -73,12 +72,10 @@ export default {
       try {
         this.error = null;
         this.isLoading = true;
-        const { encryptedCustomerId } = this;
         const params = {
           for: this.wufooZone,
           using: this.omedaZone,
           formHash: this.formHash,
-          ...(encryptedCustomerId && { encryptedCustomerId }),
           context: this.context,
           alwaysAppendContext: this.alwaysAppendContext,
         };

--- a/packages/marko-web-p1-fii/components/omeda-alchemer-form.marko
+++ b/packages/marko-web-p1-fii/components/omeda-alchemer-form.marko
@@ -1,6 +1,5 @@
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import { warn } from "@parameter1/base-cms-utils";
-import getOmedaId from "../utils/get-omeda-id";
 
 $ const { site, req } = out.global;
 $ const context = getAsObject(input, "context");
@@ -15,7 +14,6 @@ $ const omedaZone = site.get("p1fii.omedaZone", input.omedaZone);
       surveyId: input.surveyId,
       alchemerZone,
       omedaZone,
-      encryptedCustomerId: getOmedaId(req),
       alwaysAppendContext: input.alwaysAppendContext || false,
       context,
       debugIframe: input.debugIframe || false,

--- a/packages/marko-web-p1-fii/components/omeda-wufoo-form.marko
+++ b/packages/marko-web-p1-fii/components/omeda-wufoo-form.marko
@@ -1,6 +1,5 @@
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import { warn } from "@parameter1/base-cms-utils";
-import getOmedaId from "../utils/get-omeda-id";
 
 $ const { site, req } = out.global;
 $ const context = getAsObject(input, "context");
@@ -15,7 +14,6 @@ $ const omedaZone = site.get("p1fii.omedaZone", input.omedaZone);
       formHash: input.formHash,
       wufooZone,
       omedaZone,
-      encryptedCustomerId: getOmedaId(req),
       alwaysAppendContext: input.alwaysAppendContext || false,
       context,
     }

--- a/packages/marko-web-p1-fii/proxy.js
+++ b/packages/marko-web-p1-fii/proxy.js
@@ -1,4 +1,6 @@
+const { set } = require('@parameter1/base-cms-object-path');
 const proxy = require('express-http-proxy');
+const getOmedaId = require('./utils/get-omeda-id');
 
 module.exports = (app, {
   url = process.env.P1_FII_API_URL || 'https://fii.parameter1.com/',
@@ -8,6 +10,12 @@ module.exports = (app, {
   const mountPoint = '/__p1fii';
   const opts = {
     proxyReqPathResolver: ({ originalUrl }) => originalUrl.replace(mountPoint, ''),
+    proxyReqBodyDecorator: (body, req) => {
+      const encryptedCustomerId = getOmedaId(req);
+      const obj = JSON.parse(body.toString());
+      set(obj, 'params.encryptedCustomerId', encryptedCustomerId || undefined);
+      return Buffer.from(JSON.stringify(obj), 'utf-8');
+    },
     proxyReqOptDecorator: (reqOpts, req) => {
       const proxyHeaders = {
         ...reqOpts.headers,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18138,6 +18138,13 @@ tiny-lr@^1.1.1:
     object-assign "^4.1.0"
     qs "^6.4.0"
 
+tldjs@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tldjs/-/tldjs-2.3.1.tgz#cf09c3eb5d7403a9e214b7d65f3cf9651c0ab039"
+  integrity sha512-W/YVH/QczLUxVjnQhFC61Iq232NWu3TqDdO0S/MtXVz4xybejBov4ud+CIwN9aYqjOecEqIy0PscGkwpG9ZyTw==
+  dependencies:
+    punycode "^1.4.1"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
- ensure the `oly_enc_id` cookie value is set on, and removed from, the "dot" domain name in addition to the root website hostname
  -  resolves an issue where the sub-domained version of the cookie was not being updated when the local hostname cookie was removed or modified
- send the `oly_enc_id` cookie value to FII via the server instead of passing it from the client
  - fixes an issue where page cache could retain an old customer ID even when the user was logged out
- add `onLoadActiveContext` identity-x hook and correct any Omeda encrypted ID cookie mismatches