### PR TITLE
Set the Omeda cookie for the backend request

### DIFF
--- a/packages/marko-web-omeda-identity-x/middleware/strip-olytics-param.js
+++ b/packages/marko-web-omeda-identity-x/middleware/strip-olytics-param.js
@@ -11,7 +11,7 @@ module.exports = () => (req, res, next) => {
   // No IdentityX context, set the cookie and move on
   if (!idxUserExists && incomingEncId && incomingEncId !== currentEncId) {
     olyticsCookie.setTo(res, incomingEncId);
-    const params = (new URLSearchParams(req.query)).toString();
+    const params = (new URLSearchParams(q)).toString();
     const redirectTo = `${req.path}${params ? `?${params}` : ''}`;
     res.redirect(302, redirectTo);
   }

--- a/packages/marko-web-omeda-identity-x/middleware/strip-olytics-param.js
+++ b/packages/marko-web-omeda-identity-x/middleware/strip-olytics-param.js
@@ -8,6 +8,15 @@ module.exports = () => (req, res, next) => {
   const { oly_enc_id: id, ...q } = req.query;
   const incomingEncId = olyticsCookie.clean(id);
 
+  // No IdentityX context, set the cookie and move on
+  if (!idxUserExists && incomingEncId && incomingEncId !== currentEncId) {
+    olyticsCookie.setTo(res, incomingEncId);
+    const params = (new URLSearchParams(req.query)).toString();
+    const redirectTo = `${req.path}${params ? `?${params}` : ''}`;
+    res.redirect(302, redirectTo);
+  }
+
+  // Incoming id conflicts!
   if (idxUserExists && incomingEncId && incomingEncId !== currentEncId) {
     const params = (new URLSearchParams(q)).toString();
     const redirectTo = `${req.path}${params ? `?${params}` : ''}`;


### PR DESCRIPTION
Now that the backend request is being checked for the Omeda context (in #240), the Olytics identity cookie must be set on the incoming request in order for FII population to work.

For example, if a customer clicks on a link with an oly_enc_id in the URL, the FII package will not properly use this encrypted ID when the customer is not logged in. This PR sets the cookie via the backend request ahead of the front-end Olytics library doing the same. To effect this, the server does an inline 302 when the parameter is present in the URL, but the cookie is not.