### PR TITLE
Add city, street, extra fields, hidden support

### DIFF
--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -14,6 +14,9 @@ fragment ActiveUserFragment on AppUser {
   countryCode
   regionCode
   postalCode
+  city
+  street
+  addressExtra
   receiveEmail
   mustReVerifyProfile
   externalIds {

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -1,5 +1,9 @@
 <template>
-  <div :class="classNames">
+  <fieldset class="p-3 border mb-2">
+    <legend class="h5">
+      Address
+    </legend>
+
     <div class="row">
       <div v-if="displayRegionField" class="col-md-6">
         <region
@@ -40,6 +44,7 @@
       </div>
     </div>
   </div>
+  </fieldset>
 </template>
 
 <script>
@@ -72,13 +77,17 @@ export default {
     AddressExtra,
   },
   props: {
+    isFieldRequired: {
+      type: Function,
+      required: true,
+    },
+    isFieldVisible: {
+      type: Function,
+      required: true,
+    },
     user: {
       type: Object,
-      default: () => ({}),
-    },
-    hiddenFields: {
-      type: Array,
-      default: () => [],
+      required: true,
     },
   },
   computed: {
@@ -98,14 +107,6 @@ export default {
     },
     displayPostalCodeField() {
       return this.displayRegionField;
-    },
-  },
-  methods: {
-    isFieldHidden(name) {
-      return this.hiddenFields.includes(name);
-    },
-    isFieldVisible(name) {
-      return !this.isFieldHidden(name);
     },
   },
 };

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -8,7 +8,7 @@
       <street
         v-model="user.street"
         :required="isFieldRequired('street')"
-        :full-width="!isFieldVisible('addressExtra')"
+        :class-name="isFieldVisible('addressExtra') ? 'col-md-8' : 'col-md-12'"
       />
       <address-extra
         v-if="isFieldVisible('addressExtra')"
@@ -22,20 +22,20 @@
         v-if="isFieldVisible('city')"
         v-model="user.city"
         :required="isFieldRequired('city')"
-        :half-width="!displayRegionField"
+        :class-name="displayRegionField ? 'col-md-4' : 'col-md-6'"
       />
       <region
         v-if="displayRegionField"
         v-model="user.regionCode"
         :country-code="user.countryCode"
         :required="isFieldRequired('regionCode')"
-        :half-width="!isFieldVisible('city')"
+        :class-name="isFieldVisible('city') ? 'col-md-4' : 'col-md-6'"
       />
       <postal-code
         v-if="displayRegionField"
         v-model="user.postalCode"
         :required="isFieldRequired('postalCode')"
-        :half-width="!isFieldVisible('city')"
+        :class-name="isFieldVisible('city') ? 'col-md-4' : 'col-md-6'"
       />
     </div>
   </fieldset>

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -42,25 +42,11 @@
 </template>
 
 <script>
-import regionCountryCodes from '../utils/region-country-codes';
-
 import City from './fields/city.vue';
 import Region from './fields/region.vue';
 import PostalCode from './fields/postal-code.vue';
 import Street from './fields/street.vue';
 import AddressExtra from './fields/address-extra.vue';
-
-
-/**
-country (50)
-
-*group fields, border, hr, etc, subhead with address*
-*show block when country is selected*
-
-street longer than extra (66/33) (w/o extra, 100)
-city region postal code (33/33/33) or 50/50
-postal code last even if by itself
- */
 
 export default {
   components: {
@@ -79,6 +65,10 @@ export default {
       type: Function,
       required: true,
     },
+    displayRegionField: {
+      type: Boolean,
+      default: false,
+    },
     user: {
       type: Object,
       required: true,
@@ -95,9 +85,6 @@ export default {
       const { user } = this;
       if (!user) return null;
       return user.countryCode;
-    },
-    displayRegionField() {
-      return regionCountryCodes.includes(this.countryCode);
     },
   },
 };

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -1,6 +1,6 @@
 <template>
   <fieldset class="px-3 border mb-2">
-    <legend class="h5">
+    <legend class="h5 w-auto">
       Address
     </legend>
 

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -1,5 +1,5 @@
 <template>
-  <fieldset class="p-3 border mb-2">
+  <fieldset class="px-3 border mb-2">
     <legend class="h5">
       Address
     </legend>
@@ -17,29 +17,26 @@
       />
     </div>
 
-    <div class="row">
-      <div v-if="displayRegionField" class="col-md-6">
-        <region
-          v-model="user.regionCode"
-          :country-code="user.countryCode"
-          :required="isFieldRequired('regionCode')"
-        />
-      </div>
-    </div>
-
-    <div v-if="isFieldVisible('city') || displayPostalCodeField" class="row">
-      <div v-if="isFieldVisible('city')" class="col-md-6">
-        <city
-          v-model="user.city"
-          :required="isFieldRequired('city')"
-        />
-      </div>
-      <div v-if="displayPostalCodeField" class="col-md-6">
-        <postal-code
-          v-model="user.postalCode"
-          :required="isFieldRequired('postalCode')"
-        />
-      </div>
+    <div v-if="isFieldVisible('city') || displayRegionField" class="row">
+      <city
+        v-if="isFieldVisible('city')"
+        v-model="user.city"
+        :required="isFieldRequired('city')"
+        :half-width="!displayRegionField"
+      />
+      <region
+        v-if="displayRegionField"
+        v-model="user.regionCode"
+        :country-code="user.countryCode"
+        :required="isFieldRequired('regionCode')"
+        :half-width="!isFieldVisible('city')"
+      />
+      <postal-code
+        v-if="displayRegionField"
+        v-model="user.postalCode"
+        :required="isFieldRequired('postalCode')"
+        :half-width="!isFieldVisible('city')"
+      />
     </div>
   </fieldset>
 </template>
@@ -101,9 +98,6 @@ export default {
     },
     displayRegionField() {
       return regionCountryCodes.includes(this.countryCode);
-    },
-    displayPostalCodeField() {
-      return this.displayRegionField;
     },
   },
 };

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -1,5 +1,5 @@
 <template>
-  <fieldset class="px-3 border mb-2">
+  <fieldset class="px-3 border mb-3">
     <legend class="h5 w-auto">
       Address
     </legend>

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -4,6 +4,19 @@
       Address
     </legend>
 
+    <div v-if="isFieldVisible('street')" class="row">
+      <street
+        v-model="user.street"
+        :required="isFieldRequired('street')"
+        :full-width="!isFieldVisible('addressExtra')"
+      />
+      <address-extra
+        v-if="isFieldVisible('addressExtra')"
+        v-model="user.addressExtra"
+        :required="isFieldRequired('addressExtra')"
+      />
+    </div>
+
     <div class="row">
       <div v-if="displayRegionField" class="col-md-6">
         <region
@@ -28,22 +41,6 @@
         />
       </div>
     </div>
-
-    <div v-if="isFieldVisible('street') || isFieldVisible('addressExtra')" class="row">
-      <div v-if="isFieldVisible('street')" class="col-md-6">
-        <street
-          v-model="user.street"
-          :required="isFieldRequired('street')"
-        />
-      </div>
-      <div v-if="isFieldVisible('addressExtra')" class="col-md-6">
-        <address-extra
-          v-model="user.addressExtra"
-          :required="isFieldRequired('addressExtra')"
-        />
-      </div>
-    </div>
-  </div>
   </fieldset>
 </template>
 

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -1,6 +1,6 @@
 <template>
   <fieldset class="px-3 border mb-3">
-    <legend class="h5 w-auto">
+    <legend class="h6 w-auto">
       Address
     </legend>
 

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -1,0 +1,112 @@
+<template>
+  <div :class="classNames">
+    <div class="row">
+      <div v-if="displayRegionField" class="col-md-6">
+        <region
+          v-model="user.regionCode"
+          :country-code="user.countryCode"
+          :required="isFieldRequired('regionCode')"
+        />
+      </div>
+    </div>
+
+    <div v-if="isFieldVisible('city') || displayPostalCodeField" class="row">
+      <div v-if="isFieldVisible('city')" class="col-md-6">
+        <city
+          v-model="user.city"
+          :required="isFieldRequired('city')"
+        />
+      </div>
+      <div v-if="displayPostalCodeField" class="col-md-6">
+        <postal-code
+          v-model="user.postalCode"
+          :required="isFieldRequired('postalCode')"
+        />
+      </div>
+    </div>
+
+    <div v-if="isFieldVisible('street') || isFieldVisible('addressExtra')" class="row">
+      <div v-if="isFieldVisible('street')" class="col-md-6">
+        <street
+          v-model="user.street"
+          :required="isFieldRequired('street')"
+        />
+      </div>
+      <div v-if="isFieldVisible('addressExtra')" class="col-md-6">
+        <address-extra
+          v-model="user.addressExtra"
+          :required="isFieldRequired('addressExtra')"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import regionCountryCodes from '../utils/region-country-codes';
+
+import City from './fields/city.vue';
+import Region from './fields/region.vue';
+import PostalCode from './fields/postal-code.vue';
+import Street from './fields/street.vue';
+import AddressExtra from './fields/address-extra.vue';
+
+
+/**
+country (50)
+
+*group fields, border, hr, etc, subhead with address*
+*show block when country is selected*
+
+street longer than extra (66/33) (w/o extra, 100)
+city region postal code (33/33/33) or 50/50
+postal code last even if by itself
+ */
+
+export default {
+  components: {
+    City,
+    Region,
+    PostalCode,
+    Street,
+    AddressExtra,
+  },
+  props: {
+    user: {
+      type: Object,
+      default: () => ({}),
+    },
+    hiddenFields: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    classNames() {
+      const classNames = ['form-group'];
+      const { className } = this;
+      if (className) classNames.push(className);
+      return classNames;
+    },
+    countryCode() {
+      const { user } = this;
+      if (!user) return null;
+      return user.countryCode;
+    },
+    displayRegionField() {
+      return regionCountryCodes.includes(this.countryCode);
+    },
+    displayPostalCodeField() {
+      return this.displayRegionField;
+    },
+  },
+  methods: {
+    isFieldHidden(name) {
+      return this.hiddenFields.includes(name);
+    },
+    isFieldVisible(name) {
+      return !this.isFieldHidden(name);
+    },
+  },
+};
+</script>

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -4,38 +4,38 @@
       Address
     </legend>
 
-    <div v-if="isFieldVisible('street')" class="row">
+    <div v-if="street.visible" class="row">
       <street
         v-model="user.street"
-        :required="isFieldRequired('street')"
-        :class-name="isFieldVisible('addressExtra') ? 'col-md-8' : 'col-md-12'"
+        :required="street.required"
+        :class-name="addressExtra.visible ? 'col-md-8' : 'col-md-12'"
       />
       <address-extra
-        v-if="isFieldVisible('addressExtra')"
+        v-if="addressExtra.visible"
         v-model="user.addressExtra"
-        :required="isFieldRequired('addressExtra')"
+        :required="addressExtra.required"
       />
     </div>
 
-    <div v-if="isFieldVisible('city') || displayRegionField" class="row">
+    <div v-if="city.visible || regionCode.visible" class="row">
       <city
-        v-if="isFieldVisible('city')"
+        v-if="city.visible"
         v-model="user.city"
-        :required="isFieldRequired('city')"
-        :class-name="displayRegionField ? 'col-md-4' : 'col-md-6'"
+        :required="city.required"
+        :class-name="regionCode.visible ? 'col-md-4' : 'col-md-6'"
       />
       <region
-        v-if="displayRegionField"
+        v-if="regionCode.visible"
         v-model="user.regionCode"
         :country-code="user.countryCode"
-        :required="isFieldRequired('regionCode')"
-        :class-name="isFieldVisible('city') ? 'col-md-4' : 'col-md-6'"
+        :required="regionCode.required"
+        :class-name="city.visible ? 'col-md-4' : 'col-md-6'"
       />
       <postal-code
-        v-if="displayRegionField"
+        v-if="regionCode.visible"
         v-model="user.postalCode"
-        :required="isFieldRequired('postalCode')"
-        :class-name="isFieldVisible('city') ? 'col-md-4' : 'col-md-6'"
+        :required="postalCode.required"
+        :class-name="city.visible ? 'col-md-4' : 'col-md-6'"
       />
     </div>
   </fieldset>
@@ -57,19 +57,27 @@ export default {
     AddressExtra,
   },
   props: {
-    isFieldRequired: {
-      type: Function,
-      required: true,
-    },
-    isFieldVisible: {
-      type: Function,
-      required: true,
-    },
-    displayRegionField: {
-      type: Boolean,
-      default: false,
-    },
     user: {
+      type: Object,
+      required: true,
+    },
+    street: {
+      type: Object,
+      required: true,
+    },
+    addressExtra: {
+      type: Object,
+      required: true,
+    },
+    city: {
+      type: Object,
+      required: true,
+    },
+    regionCode: {
+      type: Object,
+      required: true,
+    },
+    postalCode: {
       type: Object,
       required: true,
     },

--- a/packages/marko-web-identity-x/browser/form/fields/address-extra.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/address-extra.vue
@@ -1,0 +1,64 @@
+<template>
+  <form-group>
+    <form-label :for="id" :required="required">
+      {{ label }}
+    </form-label>
+    <input
+      :id="id"
+      v-model="addressExtra"
+      class="form-control"
+      type="text"
+      :required="required"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      autocomplete="address-extra"
+    >
+  </form-group>
+</template>
+
+<script>
+import FormGroup from '../common/form-group.vue';
+import FormLabel from '../common/form-label.vue';
+
+export default {
+  components: {
+    FormGroup,
+    FormLabel,
+  },
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    required: {
+      type: Boolean,
+      default: false,
+    },
+    label: {
+      type: String,
+      default: 'Extra (Apt, Suite, etc.)',
+    },
+    placeholder: {
+      type: String,
+      default: '',
+    },
+    value: {
+      type: String,
+      default: '',
+    },
+  },
+  data: () => ({
+    id: 'sign-on-address-extra',
+  }),
+  computed: {
+    addressExtra: {
+      get() {
+        return this.value || '';
+      },
+      set(addressExtra) {
+        this.$emit('input', addressExtra || null);
+      },
+    },
+  },
+};
+</script>

--- a/packages/marko-web-identity-x/browser/form/fields/address-extra.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/address-extra.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group class-name="col-lg-3 col-md-4">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>

--- a/packages/marko-web-identity-x/browser/form/fields/address-extra.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/address-extra.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group class-name="col-lg-3 col-md-4">
+  <form-group class-name="col-md-4">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>

--- a/packages/marko-web-identity-x/browser/form/fields/city.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/city.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group :class-name="classNames">
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -46,19 +46,15 @@ export default {
       type: String,
       default: '',
     },
-    halfWidth: {
-      type: Boolean,
-      default: false,
+    className: {
+      type: String,
+      default: 'col-md-6',
     },
   },
   data: () => ({
     id: 'sign-on-city',
   }),
   computed: {
-    classNames() {
-      const { halfWidth } = this;
-      return halfWidth ? 'col-md-6' : 'col-md-4';
-    },
     city: {
       get() {
         return this.value || '';

--- a/packages/marko-web-identity-x/browser/form/fields/city.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/city.vue
@@ -1,0 +1,64 @@
+<template>
+  <form-group>
+    <form-label :for="id" :required="required">
+      {{ label }}
+    </form-label>
+    <input
+      :id="id"
+      v-model="city"
+      class="form-control"
+      type="text"
+      :required="required"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      autocomplete="city"
+    >
+  </form-group>
+</template>
+
+<script>
+import FormGroup from '../common/form-group.vue';
+import FormLabel from '../common/form-label.vue';
+
+export default {
+  components: {
+    FormGroup,
+    FormLabel,
+  },
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    required: {
+      type: Boolean,
+      default: false,
+    },
+    label: {
+      type: String,
+      default: 'City',
+    },
+    placeholder: {
+      type: String,
+      default: '',
+    },
+    value: {
+      type: String,
+      default: '',
+    },
+  },
+  data: () => ({
+    id: 'sign-on-city',
+  }),
+  computed: {
+    city: {
+      get() {
+        return this.value || '';
+      },
+      set(city) {
+        this.$emit('input', city || null);
+      },
+    },
+  },
+};
+</script>

--- a/packages/marko-web-identity-x/browser/form/fields/city.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/city.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group :class-name="classNames">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -46,11 +46,19 @@ export default {
       type: String,
       default: '',
     },
+    halfWidth: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: () => ({
     id: 'sign-on-city',
   }),
   computed: {
+    classNames() {
+      const { halfWidth } = this;
+      return halfWidth ? 'col-md-6' : 'col-md-4';
+    },
     city: {
       get() {
         return this.value || '';

--- a/packages/marko-web-identity-x/browser/form/fields/postal-code.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/postal-code.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group :class-name="classNames">
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -46,19 +46,15 @@ export default {
       type: String,
       default: '',
     },
-    halfWidth: {
-      type: Boolean,
-      default: false,
+    className: {
+      type: String,
+      default: 'col-md-12',
     },
   },
   data: () => ({
     id: 'sign-on-postal-code',
   }),
   computed: {
-    classNames() {
-      const { halfWidth } = this;
-      return halfWidth ? 'col-md-6' : 'col-md-4';
-    },
     postalCode: {
       get() {
         return this.value || '';

--- a/packages/marko-web-identity-x/browser/form/fields/postal-code.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/postal-code.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group :class-name="classNames">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -46,11 +46,19 @@ export default {
       type: String,
       default: '',
     },
+    halfWidth: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: () => ({
     id: 'sign-on-postal-code',
   }),
   computed: {
+    classNames() {
+      const { halfWidth } = this;
+      return halfWidth ? 'col-md-6' : 'col-md-4';
+    },
     postalCode: {
       get() {
         return this.value || '';

--- a/packages/marko-web-identity-x/browser/form/fields/region.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/region.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group :class-name="classNames">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -57,6 +57,10 @@ export default {
       type: String,
       default: '',
     },
+    halfWidth: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: () => ({
     id: 'sign-on-region',
@@ -65,6 +69,10 @@ export default {
     regions: [],
   }),
   computed: {
+    classNames() {
+      const { halfWidth } = this;
+      return halfWidth ? 'col-md-6' : 'col-md-4';
+    },
     regionCode: {
       get() {
         return this.value || '';

--- a/packages/marko-web-identity-x/browser/form/fields/region.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/region.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group :class-name="classNames">
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -57,9 +57,9 @@ export default {
       type: String,
       default: '',
     },
-    halfWidth: {
-      type: Boolean,
-      default: false,
+    className: {
+      type: String,
+      default: 'col-md-6',
     },
   },
   data: () => ({
@@ -69,10 +69,6 @@ export default {
     regions: [],
   }),
   computed: {
-    classNames() {
-      const { halfWidth } = this;
-      return halfWidth ? 'col-md-6' : 'col-md-4';
-    },
     regionCode: {
       get() {
         return this.value || '';

--- a/packages/marko-web-identity-x/browser/form/fields/street.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/street.vue
@@ -57,7 +57,7 @@ export default {
   computed: {
     classNames() {
       const { fullWidth } = this;
-      return fullWidth ? 'col-md-12' : 'col-lg-9 col-md-8';
+      return fullWidth ? 'col-md-12' : 'col-md-8';
     },
     street: {
       get() {

--- a/packages/marko-web-identity-x/browser/form/fields/street.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/street.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group :class-name="classNames">
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -46,19 +46,15 @@ export default {
       type: String,
       default: '',
     },
-    fullWidth: {
-      type: Boolean,
-      default: true,
+    className: {
+      type: String,
+      default: 'col-md-12',
     },
   },
   data: () => ({
     id: 'sign-on-street',
   }),
   computed: {
-    classNames() {
-      const { fullWidth } = this;
-      return fullWidth ? 'col-md-12' : 'col-md-8';
-    },
     street: {
       get() {
         return this.value || '';

--- a/packages/marko-web-identity-x/browser/form/fields/street.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/street.vue
@@ -1,0 +1,64 @@
+<template>
+  <form-group>
+    <form-label :for="id" :required="required">
+      {{ label }}
+    </form-label>
+    <input
+      :id="id"
+      v-model="street"
+      class="form-control"
+      type="text"
+      :required="required"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      autocomplete="street"
+    >
+  </form-group>
+</template>
+
+<script>
+import FormGroup from '../common/form-group.vue';
+import FormLabel from '../common/form-label.vue';
+
+export default {
+  components: {
+    FormGroup,
+    FormLabel,
+  },
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    required: {
+      type: Boolean,
+      default: false,
+    },
+    label: {
+      type: String,
+      default: 'Street',
+    },
+    placeholder: {
+      type: String,
+      default: '',
+    },
+    value: {
+      type: String,
+      default: '',
+    },
+  },
+  data: () => ({
+    id: 'sign-on-street',
+  }),
+  computed: {
+    street: {
+      get() {
+        return this.value || '';
+      },
+      set(street) {
+        this.$emit('input', street || null);
+      },
+    },
+  },
+};
+</script>

--- a/packages/marko-web-identity-x/browser/form/fields/street.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/street.vue
@@ -1,19 +1,21 @@
 <template>
-  <form-group>
-    <form-label :for="id" :required="required">
-      {{ label }}
-    </form-label>
-    <input
-      :id="id"
-      v-model="street"
-      class="form-control"
-      type="text"
-      :required="required"
-      :disabled="disabled"
-      :placeholder="placeholder"
-      autocomplete="street"
-    >
-  </form-group>
+  <div :class="classNames">
+    <form-group>
+      <form-label :for="id" :required="required">
+        {{ label }}
+      </form-label>
+      <input
+        :id="id"
+        v-model="street"
+        class="form-control"
+        type="text"
+        :required="required"
+        :disabled="disabled"
+        :placeholder="placeholder"
+        autocomplete="street"
+      >
+    </form-group>
+  </div>
 </template>
 
 <script>
@@ -46,11 +48,19 @@ export default {
       type: String,
       default: '',
     },
+    fullWidth: {
+      type: Boolean,
+      default: true,
+    },
   },
   data: () => ({
     id: 'sign-on-street',
   }),
   computed: {
+    classNames() {
+      const { fullWidth } = this;
+      return fullWidth ? 'col-md-12' : 'col-md-9';
+    },
     street: {
       get() {
         return this.value || '';

--- a/packages/marko-web-identity-x/browser/form/fields/street.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/street.vue
@@ -1,21 +1,19 @@
 <template>
-  <div :class="classNames">
-    <form-group>
-      <form-label :for="id" :required="required">
-        {{ label }}
-      </form-label>
-      <input
-        :id="id"
-        v-model="street"
-        class="form-control"
-        type="text"
-        :required="required"
-        :disabled="disabled"
-        :placeholder="placeholder"
-        autocomplete="street"
-      >
-    </form-group>
-  </div>
+  <form-group :class-name="classNames">
+    <form-label :for="id" :required="required">
+      {{ label }}
+    </form-label>
+    <input
+      :id="id"
+      v-model="street"
+      class="form-control"
+      type="text"
+      :required="required"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      autocomplete="street"
+    >
+  </form-group>
 </template>
 
 <script>
@@ -59,7 +57,7 @@ export default {
   computed: {
     classNames() {
       const { fullWidth } = this;
-      return fullWidth ? 'col-md-12' : 'col-md-9';
+      return fullWidth ? 'col-md-12' : 'col-lg-9 col-md-8';
     },
     street: {
       get() {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -43,10 +43,11 @@
         </div>
 
         <address-block
-          v-if="countryCode"
+          v-if="showAddressBlock"
           :user="user"
           :is-field-required="isFieldRequired"
           :is-field-visible="isFieldVisible"
+          :display-region-field="displayRegionField"
         />
 
         <div v-if="customSelectFieldAnswers.length" class="row">
@@ -136,6 +137,7 @@
 </template>
 
 <script>
+import regionCountryCodes from './utils/region-country-codes';
 import post from './utils/post';
 import cookiesEnabled from './utils/cookies-enabled';
 
@@ -294,6 +296,21 @@ export default {
     customSelectFieldAnswers() {
       const { customSelectFieldAnswers } = this.user;
       return isArray(customSelectFieldAnswers) ? customSelectFieldAnswers : [];
+    },
+
+    displayRegionField() {
+      return regionCountryCodes.includes(this.countryCode);
+    },
+
+    showAddressBlock() {
+      // Don't show at all until country is selected.
+      if (!this.countryCode) return false;
+
+      // Only show if a subfield is visible
+      if (this.isFieldVisible('city')) return true;
+      if (this.isFieldVisible('street')) return true;
+
+      return this.displayRegionField;
     },
   },
 

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -137,9 +137,9 @@
 </template>
 
 <script>
-import regionCountryCodes from './utils/region-country-codes';
 import post from './utils/post';
 import cookiesEnabled from './utils/cookies-enabled';
+import regionCountryCodes from './utils/region-country-codes';
 
 import AddressBlock from './form/address-block.vue';
 import CustomBoolean from './form/fields/custom-boolean.vue';
@@ -267,6 +267,13 @@ export default {
       return user.countryCode;
     },
 
+    /**
+     *
+     */
+    displayRegionField() {
+      return regionCountryCodes.includes(this.countryCode);
+    },
+
     submitMessage() {
       const message = 'Profile updated.';
       if (this.isReloadingPage) return `${message} Reloading page...`;
@@ -296,10 +303,6 @@ export default {
     customSelectFieldAnswers() {
       const { customSelectFieldAnswers } = this.user;
       return isArray(customSelectFieldAnswers) ? customSelectFieldAnswers : [];
-    },
-
-    displayRegionField() {
-      return regionCountryCodes.includes(this.countryCode);
     },
 
     showAddressBlock() {
@@ -347,12 +350,8 @@ export default {
       return this.requiredFields.includes(name);
     },
 
-    isFieldHidden(name) {
-      return this.hiddenFields.includes(name);
-    },
-
     isFieldVisible(name) {
-      return !this.isFieldHidden(name);
+      return !this.hiddenFields.includes(name);
     },
 
     getRegionalPolicyAnswer(policyId) {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -45,7 +45,8 @@
         <address-block
           v-if="countryCode"
           :user="user"
-          :hidden-fields="hiddenFields"
+          :is-field-required="isFieldRequired"
+          :is-field-visible="isFieldVisible"
         />
 
         <div v-if="customSelectFieldAnswers.length" class="row">
@@ -138,6 +139,7 @@
 import post from './utils/post';
 import cookiesEnabled from './utils/cookies-enabled';
 
+import AddressBlock from './form/address-block.vue';
 import CustomBoolean from './form/fields/custom-boolean.vue';
 import CustomSelect from './form/fields/custom-select.vue';
 import GivenName from './form/fields/given-name.vue';
@@ -156,6 +158,7 @@ const { isArray } = Array;
 
 export default {
   components: {
+    AddressBlock,
     CustomBoolean,
     CustomSelect,
     GivenName,
@@ -325,6 +328,14 @@ export default {
      */
     isFieldRequired(name) {
       return this.requiredFields.includes(name);
+    },
+
+    isFieldHidden(name) {
+      return this.hiddenFields.includes(name);
+    },
+
+    isFieldVisible(name) {
+      return !this.isFieldHidden(name);
     },
 
     getRegionalPolicyAnswer(policyId) {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -7,13 +7,13 @@
           <div class="col-md-6">
             <given-name
               v-model="user.givenName"
-              :required="isFieldRequired('givenName')"
+              :required="givenNameSettings.required"
             />
           </div>
           <div class="col-md-6">
             <family-name
               v-model="user.familyName"
-              :required="isFieldRequired('familyName')"
+              :required="familyNameSettings.required"
             />
           </div>
         </div>
@@ -22,13 +22,13 @@
           <div class="col-md-6">
             <organization
               v-model="user.organization"
-              :required="isFieldRequired('organization')"
+              :required="organizationSettings.required"
             />
           </div>
           <div class="col-md-6">
             <organization-title
               v-model="user.organizationTitle"
-              :required="isFieldRequired('organizationTitle')"
+              :required="organizationTitleSettings.required"
             />
           </div>
         </div>
@@ -37,7 +37,7 @@
           <div class="col-md-6">
             <country
               v-model="user.countryCode"
-              :required="isFieldRequired('countryCode')"
+              :required="countryCodeSettings.required"
             />
           </div>
         </div>
@@ -45,9 +45,11 @@
         <address-block
           v-if="showAddressBlock"
           :user="user"
-          :is-field-required="isFieldRequired"
-          :is-field-visible="isFieldVisible"
-          :display-region-field="displayRegionField"
+          :street="streetSettings"
+          :address-extra="addressExtraSettings"
+          :city="citySettings"
+          :region-code="regionCodeSettings"
+          :postal-code="postalCodeSettings"
         />
 
         <div v-if="customSelectFieldAnswers.length" class="row">
@@ -268,7 +270,7 @@ export default {
     },
 
     /**
-     *
+     * @todo remove, should merge into regionCodeSettings prop.
      */
     displayRegionField() {
       return regionCountryCodes.includes(this.countryCode);
@@ -313,7 +315,72 @@ export default {
       if (this.isFieldVisible('city')) return true;
       if (this.isFieldVisible('street')) return true;
 
+      // @todo update
       return this.displayRegionField;
+    },
+
+    /**
+     * Field settings
+     */
+    givenNameSettings() {
+      return {
+        required: this.isFieldRequired('givenName'),
+        visible: this.isFieldVisible('givenName'),
+      };
+    },
+    familyNameSettings() {
+      return {
+        required: this.isFieldRequired('familyName'),
+        visible: this.isFieldVisible('familyName'),
+      };
+    },
+    organizationSettings() {
+      return {
+        required: this.isFieldRequired('organization'),
+        visible: this.isFieldVisible('organization'),
+      };
+    },
+    organizationTitleSettings() {
+      return {
+        required: this.isFieldRequired('organizationTitle'),
+        visible: this.isFieldVisible('organizationTitle'),
+      };
+    },
+    countryCodeSettings() {
+      return {
+        required: this.isFieldRequired('countryCode'),
+        visible: this.isFieldVisible('countryCode'),
+      };
+    },
+    streetSettings() {
+      return {
+        required: this.isFieldRequired('street'),
+        visible: this.isFieldVisible('street'),
+      };
+    },
+    addressExtraSettings() {
+      return {
+        required: this.isFieldRequired('addressExtra'),
+        visible: this.isFieldVisible('addressExtra'),
+      };
+    },
+    citySettings() {
+      return {
+        required: this.isFieldRequired('city'),
+        visible: this.isFieldVisible('city'),
+      };
+    },
+    regionCodeSettings() {
+      return {
+        required: this.isFieldRequired('regionCode'),
+        visible: this.isFieldVisible('regionCode'),
+      };
+    },
+    postalCodeSettings() {
+      return {
+        required: this.isFieldRequired('postalCode'),
+        visible: this.isFieldVisible('postalCode'),
+      };
     },
   },
 

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -40,9 +40,6 @@
               :required="isFieldRequired('countryCode')"
             />
           </div>
-        </div>
-
-        <div v-if="displayRegionField || displayPostalCodeField" class="row">
           <div v-if="displayRegionField" class="col-md-6">
             <region
               v-model="user.regionCode"
@@ -50,10 +47,34 @@
               :required="isFieldRequired('regionCode')"
             />
           </div>
+        </div>
+
+        <div v-if="isFieldVisible('city') || displayPostalCodeField" class="row">
+          <div v-if="isFieldVisible('city')" class="col-md-6">
+            <city
+              v-model="user.city"
+              :required="isFieldRequired('city')"
+            />
+          </div>
           <div v-if="displayPostalCodeField" class="col-md-6">
             <postal-code
               v-model="user.postalCode"
               :required="isFieldRequired('postalCode')"
+            />
+          </div>
+        </div>
+
+        <div v-if="isFieldVisible('street') || isFieldVisible('addressExtra')" class="row">
+          <div v-if="isFieldVisible('street')" class="col-md-6">
+            <street
+              v-model="user.street"
+              :required="isFieldRequired('street')"
+            />
+          </div>
+          <div v-if="isFieldVisible('addressExtra')" class="col-md-6">
+            <address-extra
+              v-model="user.addressExtra"
+              :required="isFieldRequired('addressExtra')"
             />
           </div>
         </div>
@@ -149,6 +170,7 @@ import post from './utils/post';
 import cookiesEnabled from './utils/cookies-enabled';
 import regionCountryCodes from './utils/region-country-codes';
 
+import City from './form/fields/city.vue';
 import CustomBoolean from './form/fields/custom-boolean.vue';
 import CustomSelect from './form/fields/custom-select.vue';
 import GivenName from './form/fields/given-name.vue';
@@ -160,6 +182,8 @@ import Region from './form/fields/region.vue';
 import PostalCode from './form/fields/postal-code.vue';
 import ReceiveEmail from './form/fields/receive-email.vue';
 import RegionalPolicy from './form/fields/regional-policy.vue';
+import Street from './form/fields/street.vue';
+import AddressExtra from './form/fields/address-extra.vue';
 import Login from './login.vue';
 
 import FeatureError from './errors/feature';
@@ -169,6 +193,7 @@ const { isArray } = Array;
 
 export default {
   components: {
+    City,
     CustomBoolean,
     CustomSelect,
     GivenName,
@@ -180,6 +205,8 @@ export default {
     PostalCode,
     ReceiveEmail,
     RegionalPolicy,
+    Street,
+    AddressExtra,
     Login,
   },
 
@@ -204,6 +231,10 @@ export default {
       default: () => [],
     },
     requiredClientFields: {
+      type: Array,
+      default: () => [],
+    },
+    hiddenFields: {
       type: Array,
       default: () => [],
     },
@@ -350,6 +381,16 @@ export default {
      */
     isFieldRequired(name) {
       return this.requiredFields.includes(name);
+    },
+    /**
+     *
+     */
+    isFieldHidden(name) {
+      return this.hiddenFields.includes(name);
+    },
+
+    isFieldVisible(name) {
+      return !this.isFieldHidden(name);
     },
 
     getRegionalPolicyAnswer(policyId) {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -317,64 +317,64 @@ export default {
      */
     givenNameSettings() {
       return {
-        required: this.isFieldRequired('givenName'),
-        visible: this.isFieldVisible('givenName'),
+        required: this.requiredFields.includes('givenName'),
+        visible: !this.hiddenFields.includes('givenName'),
       };
     },
     familyNameSettings() {
       return {
-        required: this.isFieldRequired('familyName'),
-        visible: this.isFieldVisible('familyName'),
+        required: this.requiredFields.includes('familyName'),
+        visible: !this.hiddenFields.includes('familyName'),
       };
     },
     organizationSettings() {
       return {
-        required: this.isFieldRequired('organization'),
-        visible: this.isFieldVisible('organization'),
+        required: this.requiredFields.includes('organization'),
+        visible: !this.hiddenFields.includes('organization'),
       };
     },
     organizationTitleSettings() {
       return {
-        required: this.isFieldRequired('organizationTitle'),
-        visible: this.isFieldVisible('organizationTitle'),
+        required: this.requiredFields.includes('organizationTitle'),
+        visible: !this.hiddenFields.includes('organizationTitle'),
       };
     },
     countryCodeSettings() {
       return {
-        required: this.isFieldRequired('countryCode'),
-        visible: this.isFieldVisible('countryCode'),
+        required: this.requiredFields.includes('countryCode'),
+        visible: !this.hiddenFields.includes('countryCode'),
       };
     },
     streetSettings() {
       return {
-        required: this.isFieldRequired('street'),
-        visible: this.isFieldVisible('street'),
+        required: this.requiredFields.includes('street'),
+        visible: !this.hiddenFields.includes('street'),
       };
     },
     addressExtraSettings() {
       return {
-        required: this.isFieldRequired('addressExtra'),
-        visible: this.isFieldVisible('addressExtra'),
+        required: this.requiredFields.includes('addressExtra'),
+        visible: !this.hiddenFields.includes('addressExtra'),
       };
     },
     citySettings() {
       return {
-        required: this.isFieldRequired('city'),
-        visible: this.isFieldVisible('city'),
+        required: this.requiredFields.includes('city'),
+        visible: !this.hiddenFields.includes('city'),
       };
     },
     regionCodeSettings() {
       const canRequire = regionCountryCodes.includes(this.countryCode);
       return {
-        required: canRequire && this.isFieldRequired('regionCode'),
-        visible: canRequire && this.isFieldVisible('regionCode'),
+        required: canRequire && this.requiredFields.includes('regionCode'),
+        visible: canRequire && !this.hiddenFields.includes('regionCode'),
       };
     },
     postalCodeSettings() {
       const canRequire = regionCountryCodes.includes(this.countryCode);
       return {
-        required: canRequire && this.isFieldRequired('postalCode'),
-        visible: canRequire && this.isFieldVisible('postalCode'),
+        required: canRequire && this.requiredFields.includes('postalCode'),
+        visible: canRequire && !this.hiddenFields.includes('postalCode'),
       };
     },
   },
@@ -409,14 +409,6 @@ export default {
     /**
      *
      */
-    isFieldRequired(name) {
-      return this.requiredFields.includes(name);
-    },
-
-    isFieldVisible(name) {
-      return !this.hiddenFields.includes(name);
-    },
-
     getRegionalPolicyAnswer(policyId) {
       return this.user.regionalConsentAnswers.find(a => a.id === policyId);
     },

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -269,13 +269,6 @@ export default {
       return user.countryCode;
     },
 
-    /**
-     * @todo remove, should merge into regionCodeSettings prop.
-     */
-    displayRegionField() {
-      return regionCountryCodes.includes(this.countryCode);
-    },
-
     submitMessage() {
       const message = 'Profile updated.';
       if (this.isReloadingPage) return `${message} Reloading page...`;
@@ -312,11 +305,11 @@ export default {
       if (!this.countryCode) return false;
 
       // Only show if a subfield is visible
-      if (this.isFieldVisible('city')) return true;
-      if (this.isFieldVisible('street')) return true;
-
-      // @todo update
-      return this.displayRegionField;
+      if (this.citySettings.visible) return true;
+      if (this.streetSettings.visible) return true;
+      if (this.regionCodeSettings.visible) return true;
+      if (this.postalCodeSettings.visible) return true;
+      return false;
     },
 
     /**
@@ -371,15 +364,17 @@ export default {
       };
     },
     regionCodeSettings() {
+      const canRequire = regionCountryCodes.includes(this.countryCode);
       return {
-        required: this.isFieldRequired('regionCode'),
-        visible: this.isFieldVisible('regionCode'),
+        required: canRequire && this.isFieldRequired('regionCode'),
+        visible: canRequire && this.isFieldVisible('regionCode'),
       };
     },
     postalCodeSettings() {
+      const canRequire = regionCountryCodes.includes(this.countryCode);
       return {
-        required: this.isFieldRequired('postalCode'),
-        visible: this.isFieldVisible('postalCode'),
+        required: canRequire && this.isFieldRequired('postalCode'),
+        visible: canRequire && this.isFieldVisible('postalCode'),
       };
     },
   },
@@ -389,10 +384,11 @@ export default {
    */
   watch: {
     /**
-     * Clear region code on country code change.
+     * Clear region and postal codes on country code change.
      */
     countryCode() {
       this.user.regionCode = null;
+      this.user.postalCode = null;
     },
   },
 

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -40,44 +40,13 @@
               :required="isFieldRequired('countryCode')"
             />
           </div>
-          <div v-if="displayRegionField" class="col-md-6">
-            <region
-              v-model="user.regionCode"
-              :country-code="user.countryCode"
-              :required="isFieldRequired('regionCode')"
-            />
-          </div>
         </div>
 
-        <div v-if="isFieldVisible('city') || displayPostalCodeField" class="row">
-          <div v-if="isFieldVisible('city')" class="col-md-6">
-            <city
-              v-model="user.city"
-              :required="isFieldRequired('city')"
-            />
-          </div>
-          <div v-if="displayPostalCodeField" class="col-md-6">
-            <postal-code
-              v-model="user.postalCode"
-              :required="isFieldRequired('postalCode')"
-            />
-          </div>
-        </div>
-
-        <div v-if="isFieldVisible('street') || isFieldVisible('addressExtra')" class="row">
-          <div v-if="isFieldVisible('street')" class="col-md-6">
-            <street
-              v-model="user.street"
-              :required="isFieldRequired('street')"
-            />
-          </div>
-          <div v-if="isFieldVisible('addressExtra')" class="col-md-6">
-            <address-extra
-              v-model="user.addressExtra"
-              :required="isFieldRequired('addressExtra')"
-            />
-          </div>
-        </div>
+        <address-block
+          v-if="countryCode"
+          :user="user"
+          :hidden-fields="hiddenFields"
+        />
 
         <div v-if="customSelectFieldAnswers.length" class="row">
           <custom-select
@@ -168,9 +137,7 @@
 <script>
 import post from './utils/post';
 import cookiesEnabled from './utils/cookies-enabled';
-import regionCountryCodes from './utils/region-country-codes';
 
-import City from './form/fields/city.vue';
 import CustomBoolean from './form/fields/custom-boolean.vue';
 import CustomSelect from './form/fields/custom-select.vue';
 import GivenName from './form/fields/given-name.vue';
@@ -178,12 +145,8 @@ import FamilyName from './form/fields/family-name.vue';
 import Organization from './form/fields/organization.vue';
 import OrganizationTitle from './form/fields/organization-title.vue';
 import Country from './form/fields/country.vue';
-import Region from './form/fields/region.vue';
-import PostalCode from './form/fields/postal-code.vue';
 import ReceiveEmail from './form/fields/receive-email.vue';
 import RegionalPolicy from './form/fields/regional-policy.vue';
-import Street from './form/fields/street.vue';
-import AddressExtra from './form/fields/address-extra.vue';
 import Login from './login.vue';
 
 import FeatureError from './errors/feature';
@@ -193,7 +156,6 @@ const { isArray } = Array;
 
 export default {
   components: {
-    City,
     CustomBoolean,
     CustomSelect,
     GivenName,
@@ -201,12 +163,8 @@ export default {
     Organization,
     OrganizationTitle,
     Country,
-    Region,
-    PostalCode,
     ReceiveEmail,
     RegionalPolicy,
-    Street,
-    AddressExtra,
     Login,
   },
 
@@ -304,20 +262,6 @@ export default {
       return user.countryCode;
     },
 
-    /**
-     *
-     */
-    displayRegionField() {
-      return regionCountryCodes.includes(this.countryCode);
-    },
-
-    /**
-     *
-     */
-    displayPostalCodeField() {
-      return this.displayRegionField;
-    },
-
     submitMessage() {
       const message = 'Profile updated.';
       if (this.isReloadingPage) return `${message} Reloading page...`;
@@ -381,16 +325,6 @@ export default {
      */
     isFieldRequired(name) {
       return this.requiredFields.includes(name);
-    },
-    /**
-     *
-     */
-    isFieldHidden(name) {
-      return this.hiddenFields.includes(name);
-    },
-
-    isFieldVisible(name) {
-      return !this.isFieldHidden(name);
     },
 
     getRegionalPolicyAnswer(policyId) {

--- a/packages/marko-web-identity-x/components/form-profile.marko
+++ b/packages/marko-web-identity-x/components/form-profile.marko
@@ -9,6 +9,7 @@ $ const { identityX } = req;
       activeUser: user,
       requiredServerFields: identityX.config.getRequiredServerFields(),
       requiredClientFields: identityX.config.getRequiredClientFields(),
+      hiddenFields: identityX.config.getHiddenFields(),
       callToAction: input.callToAction,
       reloadPageOnSubmit: input.reloadPageOnSubmit,
       endpoints: identityX.config.getEndpoints(),

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -93,7 +93,7 @@ class IdentityXConfiguration {
   }
 
   getHiddenFields() {
-    return this.getAsArray('requiredClientFields');
+    return this.getAsArray('hiddenFields');
   }
 
   get(path, def) {

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -12,7 +12,7 @@ class IdentityXConfiguration {
    * @param {string} [options.apiToken] An API token to use. Only required when doing write ops.
    * @param {string[]} [options.requiredServerFields] Required fields, server enforced.
    * @param {string[]} [options.requiredClientFields] Required fields, client-side only.
-   * @param {string[]} [options.hiddenFields] The fields to include in the profile.
+   * @param {string[]} [options.hiddenFields] The fields to hide from the profile.
    * @param {function} [options.onHookError]
    * @param {...object} options.rest
    */

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -12,6 +12,7 @@ class IdentityXConfiguration {
    * @param {string} [options.apiToken] An API token to use. Only required when doing write ops.
    * @param {string[]} [options.requiredServerFields] Required fields, server enforced.
    * @param {string[]} [options.requiredClientFields] Required fields, client-side only.
+   * @param {string[]} [options.hiddenFields] The fields to include in the profile.
    * @param {function} [options.onHookError]
    * @param {...object} options.rest
    */
@@ -20,6 +21,7 @@ class IdentityXConfiguration {
     apiToken,
     requiredServerFields = [],
     requiredClientFields = [],
+    hiddenFields = ['city', 'street', 'addressExtra'],
     onHookError,
     ...rest
   } = {}) {
@@ -29,6 +31,7 @@ class IdentityXConfiguration {
     this.options = {
       requiredServerFields,
       requiredClientFields,
+      hiddenFields,
       onHookError: (e) => {
         if (process.env.NODE_ENV === 'development') {
           log('ERROR IN IDENTITY-X HOOK', e);
@@ -86,6 +89,10 @@ class IdentityXConfiguration {
   }
 
   getRequiredClientFields() {
+    return this.getAsArray('requiredClientFields');
+  }
+
+  getHiddenFields() {
     return this.getAsArray('requiredClientFields');
   }
 

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -47,6 +47,9 @@ module.exports = asyncRoute(async (req, res) => {
     countryCode,
     regionCode,
     postalCode,
+    city,
+    street,
+    addressExtra,
     receiveEmail,
     regionalConsentAnswers,
     customBooleanFieldAnswers,
@@ -60,6 +63,9 @@ module.exports = asyncRoute(async (req, res) => {
     countryCode,
     regionCode,
     postalCode,
+    city,
+    street,
+    addressExtra,
     receiveEmail,
   };
 


### PR DESCRIPTION
Adds support for `city`, `street`, and `addressExtra` within IdentityX. Reorders form fields (slightly) to make for a more consistant layout when these fields are not displayed (the default)

| Description | Screenshot |
| - | - |
| Current (no selection) | <img width="690" alt="image" src="https://user-images.githubusercontent.com/1778222/154337437-639ef7bd-299b-4f2c-9dc9-89b70a21f5fd.png">
| Current (NA) | <img width="693" alt="image" src="https://user-images.githubusercontent.com/1778222/154152997-9df9631b-4a38-4481-b7a7-35e135dc3205.png">
| Current (non-NA) | <img width="687" alt="image" src="https://user-images.githubusercontent.com/1778222/154153083-4ac8f312-b18e-45ca-9e42-61224a5a5c60.png">
--
| New (no selection) | <img width="740" alt="image" src="https://user-images.githubusercontent.com/1778222/154368166-957aeb64-6427-40d3-87c0-5811e6179095.png">
| New with fields shown (NA) | <img width="743" alt="image" src="https://user-images.githubusercontent.com/1778222/154368079-4ccfa882-296c-469c-8b37-b8d0f86e62d0.png">
| New with fields shown (non-NA) | <img width="744" alt="image" src="https://user-images.githubusercontent.com/1778222/154367994-5ebf26d2-7450-44d8-beb0-e8693c4780aa.png">
--
| New with fields hidden (NA) | <img width="742" alt="image" src="https://user-images.githubusercontent.com/1778222/154368475-09019117-0e62-419d-9d23-d6993163dd53.png">
| New with fields hidden (non-NA) | <img width="743" alt="image" src="https://user-images.githubusercontent.com/1778222/154368508-bdf66060-72dc-48de-a38b-69927a51b490.png">