### PR TITLE
Add support for placeholder being passed to login form

### DIFF
--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -24,7 +24,7 @@
   <div v-else>
     <form @submit.prevent="handleSubmit">
       <fieldset :disabled="loading">
-        <email v-model="email" />
+        <email v-model="email" :placeholder="loginEmailPlaceholder" />
         <small
           v-if="consentPolicy"
           class="text-muted mb-3"
@@ -89,6 +89,10 @@ export default {
       default: null,
     },
     appContextId: {
+      type: String,
+      default: null,
+    },
+    loginEmailPlaceholder: {
       type: String,
       default: null,
     },

--- a/packages/marko-web-identity-x/components/form-login.marko
+++ b/packages/marko-web-identity-x/components/form-login.marko
@@ -10,6 +10,7 @@ $ const { identityX } = req;
       endpoints: identityX.config.getEndpoints(),
       buttonLabels: input.buttonLabels,
       redirect: input.redirect,
+      loginEmailPlaceholder: input.loginEmailPlaceholder,
       consentPolicy: get(application, "organization.consentPolicy"),
       regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
       appContextId: identityX.config.get("appContextId"),

--- a/packages/marko-web-identity-x/components/marko.json
+++ b/packages/marko-web-identity-x/components/marko.json
@@ -18,6 +18,7 @@
   "<marko-web-identity-x-form-login>": {
     "template": "./form-login.marko",
     "@button-labels": "object",
+    "@login-email-placeholder": "string",
     "@redirect": "string"
   },
   "<marko-web-identity-x-form-logout>": {


### PR DESCRIPTION
Ad the ability to pass a placeholder value from the template to the login form vue component.  

This is mostly for the new content meter functionality.
<img width="744" alt="Screen Shot 2022-03-07 at 1 09 06 PM" src="https://user-images.githubusercontent.com/3845869/157101370-0b709d57-ec63-43e5-92d6-2b8ec181e7ed.png">
.