### PR TITLE
Expand Omeda promo code handling

### DIFF
--- a/packages/marko-web-omeda-identity-x/README.md
+++ b/packages/marko-web-omeda-identity-x/README.md
@@ -26,6 +26,7 @@ All configuration data must be passed to the middleware when loaded (See [Middle
 | `idxOmedaRapidIdentifyProp` | (Optional) Custom path to the IdentityX Omeda Rapid Identification handler (within app.locals), default value `$idXOmedaRapidIdentify`
 | `omedaPromoCodeCookieName` | (Optional) The Omeda promocode cookie name to detect, default value `oly_promo_src`
 | `omedaPromoCodeStripQueryParam` | (Optional) If the promo code param should be stripped from the request, default `true`
+| `omedaPromoCodeDefault` | (Optional) The default promo code to send with rapid identification requests
 
 ## Usage
 This package:

--- a/packages/marko-web-omeda-identity-x/README.md
+++ b/packages/marko-web-omeda-identity-x/README.md
@@ -21,9 +21,11 @@ All configuration data must be passed to the middleware when loaded (See [Middle
 | `rapidIdentProductId` | (Required) The Omeda identifier for a Website product (ProductType=7).
 | `idxConfig` | (Required) An instance of the IdentityX configuration class | [marko-web-identity-x#1](../marko-web-identity-x/config.js)
 | `idxRouteTemplates` | (Required) An object containing the Marko templates to use for each IdentityX endpoint. | [marko-web-identity-x#2](../marko-web-identity-x/index.js)
-| `omedaGraphQLClientProp` | (Optional) Custom path to the Omeda GraphQL client (within app.locals)
-| `omedaRapidIdentifyProp` | (Optional) Custom path to the Omeda Rapid Identification handler (within app.locals)
-| `idxOmedaRapidIdentifyProp` | (Optional) Custom path to the IdentityX Omeda Rapid Identification handler (within app.locals)
+| `omedaGraphQLClientProp` | (Optional) Custom path to the Omeda GraphQL client (within app.locals), default value `$omedaGraphQLClient`
+| `omedaRapidIdentifyProp` | (Optional) Custom path to the Omeda Rapid Identification handler (within app.locals), default value `$omedaRapidIdentify`
+| `idxOmedaRapidIdentifyProp` | (Optional) Custom path to the IdentityX Omeda Rapid Identification handler (within app.locals), default value `$idXOmedaRapidIdentify`
+| `omedaPromoCodeCookieName` | (Optional) The Omeda promocode cookie name to detect, default value `oly_promo_src`
+| `omedaPromoCodeStripQueryParam` | (Optional) If the promo code param should be stripped from the request, default `true`
 
 ## Usage
 This package:

--- a/packages/marko-web-omeda-identity-x/README.md
+++ b/packages/marko-web-omeda-identity-x/README.md
@@ -25,7 +25,6 @@ All configuration data must be passed to the middleware when loaded (See [Middle
 | `omedaRapidIdentifyProp` | (Optional) Custom path to the Omeda Rapid Identification handler (within app.locals), default value `$omedaRapidIdentify`
 | `idxOmedaRapidIdentifyProp` | (Optional) Custom path to the IdentityX Omeda Rapid Identification handler (within app.locals), default value `$idXOmedaRapidIdentify`
 | `omedaPromoCodeCookieName` | (Optional) The Omeda promocode cookie name to detect, default value `omeda_promo_code`
-| `omedaPromoCodeStripQueryParam` | (Optional) If the promo code param should be stripped from the request, default `true`
 | `omedaPromoCodeDefault` | (Optional) The default promo code to send with rapid identification requests
 
 ## Usage

--- a/packages/marko-web-omeda-identity-x/README.md
+++ b/packages/marko-web-omeda-identity-x/README.md
@@ -24,7 +24,7 @@ All configuration data must be passed to the middleware when loaded (See [Middle
 | `omedaGraphQLClientProp` | (Optional) Custom path to the Omeda GraphQL client (within app.locals), default value `$omedaGraphQLClient`
 | `omedaRapidIdentifyProp` | (Optional) Custom path to the Omeda Rapid Identification handler (within app.locals), default value `$omedaRapidIdentify`
 | `idxOmedaRapidIdentifyProp` | (Optional) Custom path to the IdentityX Omeda Rapid Identification handler (within app.locals), default value `$idXOmedaRapidIdentify`
-| `omedaPromoCodeCookieName` | (Optional) The Omeda promocode cookie name to detect, default value `oly_promo_src`
+| `omedaPromoCodeCookieName` | (Optional) The Omeda promocode cookie name to detect, default value `omeda_promo_code`
 | `omedaPromoCodeStripQueryParam` | (Optional) If the promo code param should be stripped from the request, default `true`
 | `omedaPromoCodeDefault` | (Optional) The default promo code to send with rapid identification requests
 

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -16,7 +16,7 @@ module.exports = (app, {
   omedaGraphQLClientProp = '$omedaGraphQLClient',
   omedaRapidIdentifyProp = '$omedaRapidIdentify',
 
-  omedaPromoCodeCookieName = 'oly_promo_src',
+  omedaPromoCodeCookieName = 'omeda_promo_code',
   omedaPromoCodeStripQueryParam = true,
   omedaPromoCodeDefault,
 
@@ -72,7 +72,7 @@ module.exports = (app, {
   // strip `oly_enc_id` when identity-x user is logged-in
   app.use(stripOlyticsParam());
 
-  // set `oly_promo_src` when the URL parameter is present
+  // set `omeda_promo_code` when the URL parameter is present
   app.use(setPromoSourceCookie({
     omedaPromoCodeCookieName,
     omedaPromoCodeStripQueryParam,

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -17,7 +17,6 @@ module.exports = (app, {
   omedaRapidIdentifyProp = '$omedaRapidIdentify',
 
   omedaPromoCodeCookieName = 'omeda_promo_code',
-  omedaPromoCodeStripQueryParam = true,
   omedaPromoCodeDefault,
 
   idxConfig,
@@ -75,6 +74,5 @@ module.exports = (app, {
   // set `omeda_promo_code` when the URL parameter is present
   app.use(setPromoSourceCookie({
     omedaPromoCodeCookieName,
-    omedaPromoCodeStripQueryParam,
   }));
 };

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -1,6 +1,7 @@
 const omeda = require('@parameter1/base-cms-marko-web-omeda');
 const identityX = require('@parameter1/base-cms-marko-web-identity-x');
 const addOmedaHooksToIdentityXConfig = require('./add-integration-hooks');
+const setPromoSourceCookie = require('./middleware/set-promo-source');
 const stripOlyticsParam = require('./middleware/strip-olytics-param');
 const rapidIdentify = require('./middleware/rapid-identify');
 const rapidIdentifyRouter = require('./routes/rapid-identify');
@@ -14,6 +15,9 @@ module.exports = (app, {
   rapidIdentProductId,
   omedaGraphQLClientProp = '$omedaGraphQLClient',
   omedaRapidIdentifyProp = '$omedaRapidIdentify',
+
+  omedaPromoCodeCookieName = 'oly_promo_src',
+  omedaPromoCodeStripQueryParam = true,
 
   idxConfig,
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
@@ -64,4 +68,10 @@ module.exports = (app, {
 
   // strip `oly_enc_id` when identity-x user is logged-in
   app.use(stripOlyticsParam());
+
+  // set `oly_promo_src` when the URL parameter is present
+  app.use(setPromoSourceCookie({
+    omedaPromoCodeCookieName,
+    omedaPromoCodeStripQueryParam,
+  }));
 };

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -18,6 +18,7 @@ module.exports = (app, {
 
   omedaPromoCodeCookieName = 'oly_promo_src',
   omedaPromoCodeStripQueryParam = true,
+  omedaPromoCodeDefault,
 
   idxConfig,
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
@@ -55,6 +56,8 @@ module.exports = (app, {
     productId: rapidIdentProductId,
     prop: idxOmedaRapidIdentifyProp,
     omedaRapidIdentifyProp,
+    omedaPromoCodeCookieName,
+    omedaPromoCodeDefault,
   }));
 
   // install identity x

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
@@ -222,6 +222,8 @@ module.exports = async ({
   brandKey,
   omedaGraphQLProp = '$omedaGraphQLClient',
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
+  omedaPromoCodeCookieName = 'oly_promo_src',
+  omedaPromoCodeDefault: defaultPromoCode,
 
   req,
   service: identityX,
@@ -232,11 +234,14 @@ module.exports = async ({
   const idxOmedaRapidIdentify = req[idxOmedaRapidIdentifyProp];
   if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
 
+  const promoCode = req.cookies[omedaPromoCodeCookieName] || defaultPromoCode;
+
   // get omeda customer id (via rapid identity) and load omeda custom field data
   const [{ data }, { encryptedCustomerId }] = await Promise.all([
     identityX.client.query({ query: FIELD_QUERY }),
     idxOmedaRapidIdentify({
       user: user.verified ? user : { id: user.id, email: user.email },
+      ...(promoCode && { promoCode }),
     }),
   ]);
 

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
@@ -222,7 +222,7 @@ module.exports = async ({
   brandKey,
   omedaGraphQLProp = '$omedaGraphQLClient',
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
-  omedaPromoCodeCookieName = 'oly_promo_src',
+  omedaPromoCodeCookieName = 'omeda_promo_code',
   omedaPromoCodeDefault: defaultPromoCode,
 
   req,

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
@@ -2,6 +2,7 @@ const gql = require('graphql-tag');
 const { get, getAsArray } = require('@parameter1/base-cms-object-path');
 const isOmedaDeploymentTypeId = require('../external-id/is-deployment-type-id');
 const isOmedaDemographicId = require('../external-id/is-demographic-id');
+const extractPromoCode = require('../utils/extract-promo-code');
 
 const FIELD_QUERY = gql`
   query GetCustomFields {
@@ -223,7 +224,7 @@ module.exports = async ({
   omedaGraphQLProp = '$omedaGraphQLClient',
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
   omedaPromoCodeCookieName = 'omeda_promo_code',
-  omedaPromoCodeDefault: defaultPromoCode,
+  omedaPromoCodeDefault,
 
   req,
   service: identityX,
@@ -234,7 +235,11 @@ module.exports = async ({
   const idxOmedaRapidIdentify = req[idxOmedaRapidIdentifyProp];
   if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
 
-  const promoCode = req.cookies[omedaPromoCodeCookieName] || defaultPromoCode;
+  const promoCode = extractPromoCode({
+    omedaPromoCodeCookieName,
+    omedaPromoCodeDefault,
+    cookies: req.cookies,
+  });
 
   // get omeda customer id (via rapid identity) and load omeda custom field data
   const [{ data }, { encryptedCustomerId }] = await Promise.all([

--- a/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
@@ -6,7 +6,7 @@ module.exports = ({
 
   prop = '$idxOmedaRapidIdentify',
   omedaRapidIdentifyProp = '$omedaRapidIdentify',
-  omedaPromoCodeCookieName = 'oly_promo_src',
+  omedaPromoCodeCookieName = 'omeda_promo_code',
   omedaPromoCodeDefault,
 }) => {
   if (!prop) throw new Error('An Omeda + IdentityX rapid identifcation prop is required.');

--- a/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
@@ -6,6 +6,8 @@ module.exports = ({
 
   prop = '$idxOmedaRapidIdentify',
   omedaRapidIdentifyProp = '$omedaRapidIdentify',
+  omedaPromoCodeCookieName = 'oly_promo_src',
+  omedaPromoCodeDefault,
 }) => {
   if (!prop) throw new Error('An Omeda + IdentityX rapid identifcation prop is required.');
   if (!omedaRapidIdentifyProp) throw new Error('The Omeda rapid identifcation prop is required.');
@@ -14,11 +16,11 @@ module.exports = ({
     const omedaRapidIdentify = req[omedaRapidIdentifyProp];
     if (!omedaRapidIdentify) throw new Error(`Unable to find the Omeda rapid identifier on the request using ${omedaRapidIdentifyProp}`);
 
-    const handler = async ({ user, promoCode } = {}) => idxOmedaRapidIdentify({
+    const handler = async ({ user, promoCode: explicitCode } = {}) => idxOmedaRapidIdentify({
       brandKey,
       productId,
       appUser: user,
-      promoCode,
+      promoCode: explicitCode || req.cookies[omedaPromoCodeCookieName] || omedaPromoCodeDefault,
 
       identityX: req.identityX,
       omedaRapidIdentify,

--- a/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
@@ -1,4 +1,5 @@
 const idxOmedaRapidIdentify = require('../rapid-identify');
+const extractPromoCode = require('../utils/extract-promo-code');
 
 module.exports = ({
   brandKey,
@@ -16,11 +17,16 @@ module.exports = ({
     const omedaRapidIdentify = req[omedaRapidIdentifyProp];
     if (!omedaRapidIdentify) throw new Error(`Unable to find the Omeda rapid identifier on the request using ${omedaRapidIdentifyProp}`);
 
-    const handler = async ({ user, promoCode: explicitCode } = {}) => idxOmedaRapidIdentify({
+    const handler = async ({ user, promoCode } = {}) => idxOmedaRapidIdentify({
       brandKey,
       productId,
       appUser: user,
-      promoCode: explicitCode || req.cookies[omedaPromoCodeCookieName] || omedaPromoCodeDefault,
+      promoCode: extractPromoCode({
+        promoCode,
+        omedaPromoCodeCookieName,
+        omedaPromoCodeDefault,
+        cookies: req.cookies,
+      }),
 
       identityX: req.identityX,
       omedaRapidIdentify,

--- a/packages/marko-web-omeda-identity-x/middleware/set-promo-source.js
+++ b/packages/marko-web-omeda-identity-x/middleware/set-promo-source.js
@@ -8,15 +8,13 @@ const clean = (value) => {
  * `omeda_promo_code` URL parameter is present.
  * '
  * @param {String} omedaPromoCodeCookieName The name of the cookie to interact with
- * @param {Boolean} stripIncomingPromoCode
  */
 module.exports = ({
   omedaPromoCodeCookieName = 'omeda_promo_code',
-  stripIncomingPromoCode = true,
 } = {}) => (req, res, next) => {
   const promoSource = clean(req.cookies[omedaPromoCodeCookieName]);
 
-  const { [omedaPromoCodeCookieName]: promoCode, ...q } = req.query;
+  const { [omedaPromoCodeCookieName]: promoCode } = req.query;
   const incomingPromoCode = clean(promoCode);
 
   // Only set the promo source cookie if it doesn't already exist
@@ -25,12 +23,5 @@ module.exports = ({
     res.cookie(omedaPromoCodeCookieName, `${incomingPromoCode}`, options);
   }
 
-  // If enabled, strip the URL parameter from the query string
-  if (incomingPromoCode && stripIncomingPromoCode) {
-    const params = (new URLSearchParams(q)).toString();
-    const redirectTo = `${req.path}${params ? `?${params}` : ''}`;
-    res.redirect(302, redirectTo);
-  } else {
-    next();
-  }
+  next();
 };

--- a/packages/marko-web-omeda-identity-x/middleware/set-promo-source.js
+++ b/packages/marko-web-omeda-identity-x/middleware/set-promo-source.js
@@ -1,0 +1,36 @@
+const clean = (value) => {
+  if (!value || value === 'null') return null;
+  return value.replace(/"'/g, '').trim().toUpperCase();
+};
+
+/**
+ * Sets the `oly_promo_src` cookie to identify the customer's original promotion source if the
+ * `oly_promo_src` URL parameter is present.
+ * '
+ * @param {String} omedaPromoCodeCookieName The name of the cookie to interact with
+ * @param {Boolean} stripIncomingPromoCode
+ */
+module.exports = ({
+  omedaPromoCodeCookieName = 'oly_promo_src',
+  stripIncomingPromoCode = true,
+} = {}) => (req, res, next) => {
+  const promoSource = clean(req.cookies[omedaPromoCodeCookieName]);
+
+  const { [omedaPromoCodeCookieName]: promoCode, ...q } = req.query;
+  const incomingPromoCode = clean(promoCode);
+
+  // Only set the promo source cookie if it doesn't already exist
+  if (!promoSource && incomingPromoCode) {
+    const options = { maxAge: 60 * 60 * 24 * 365, httpOnly: false };
+    res.cookie(omedaPromoCodeCookieName, `${incomingPromoCode}`, options);
+  }
+
+  // If enabled, strip the URL parameter from the query string
+  if (incomingPromoCode && stripIncomingPromoCode) {
+    const params = (new URLSearchParams(q)).toString();
+    const redirectTo = `${req.path}${params ? `?${params}` : ''}`;
+    res.redirect(302, redirectTo);
+  } else {
+    next();
+  }
+};

--- a/packages/marko-web-omeda-identity-x/middleware/set-promo-source.js
+++ b/packages/marko-web-omeda-identity-x/middleware/set-promo-source.js
@@ -1,10 +1,5 @@
-const clean = (value) => {
-  if (!value || value === 'null') return null;
-  return value.replace(/"'/g, '').trim().toUpperCase();
-};
-
 /**
- * Sets the `omeda_promo_code` cookie to identify the customer's original promotion source if the
+ * Sets the `omeda_promo_code` cookie to identify the customer's promotion source if the
  * `omeda_promo_code` URL parameter is present.
  * '
  * @param {String} omedaPromoCodeCookieName The name of the cookie to interact with
@@ -12,15 +7,13 @@ const clean = (value) => {
 module.exports = ({
   omedaPromoCodeCookieName = 'omeda_promo_code',
 } = {}) => (req, res, next) => {
-  const promoSource = clean(req.cookies[omedaPromoCodeCookieName]);
-
   const { [omedaPromoCodeCookieName]: promoCode } = req.query;
-  const incomingPromoCode = clean(promoCode);
+  const incomingPromoCode = `${promoCode || ''}`.trim().toUpperCase();
 
-  // Only set the promo source cookie if it doesn't already exist
-  if (!promoSource && incomingPromoCode) {
+  // Set the promo source cookie
+  if (incomingPromoCode) {
     const options = { maxAge: 60 * 60 * 24 * 365, httpOnly: false };
-    res.cookie(omedaPromoCodeCookieName, `${incomingPromoCode}`, options);
+    res.cookie(omedaPromoCodeCookieName, incomingPromoCode, options);
   }
 
   next();

--- a/packages/marko-web-omeda-identity-x/middleware/set-promo-source.js
+++ b/packages/marko-web-omeda-identity-x/middleware/set-promo-source.js
@@ -4,14 +4,14 @@ const clean = (value) => {
 };
 
 /**
- * Sets the `oly_promo_src` cookie to identify the customer's original promotion source if the
- * `oly_promo_src` URL parameter is present.
+ * Sets the `omeda_promo_code` cookie to identify the customer's original promotion source if the
+ * `omeda_promo_code` URL parameter is present.
  * '
  * @param {String} omedaPromoCodeCookieName The name of the cookie to interact with
  * @param {Boolean} stripIncomingPromoCode
  */
 module.exports = ({
-  omedaPromoCodeCookieName = 'oly_promo_src',
+  omedaPromoCodeCookieName = 'omeda_promo_code',
   stripIncomingPromoCode = true,
 } = {}) => (req, res, next) => {
   const promoSource = clean(req.cookies[omedaPromoCodeCookieName]);

--- a/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
@@ -11,7 +11,7 @@ const findEncryptedId = require('../external-id/find-encrypted-customer-id');
 module.exports = ({
   brandKey,
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
-  omedaPromoCodeCookieName = 'oly_promo_src',
+  omedaPromoCodeCookieName = 'omeda_promo_code',
   defaultOmedaPromoCode,
 } = {}) => {
   if (!brandKey) throw new Error('An Omeda brand key is required to use this middleware.');

--- a/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
@@ -7,19 +7,25 @@ const tokenCookie = require('@parameter1/base-cms-marko-web-identity-x/utils/tok
 const olyticsCookie = require('@parameter1/base-cms-marko-web-omeda/olytics/customer-cookie');
 
 const findEncryptedId = require('../external-id/find-encrypted-customer-id');
+const extractPromoCode = require('../utils/extract-promo-code');
 
 module.exports = ({
   brandKey,
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
   omedaPromoCodeCookieName = 'omeda_promo_code',
-  defaultOmedaPromoCode,
+  omedaPromoCodeDefault,
 } = {}) => {
   if (!brandKey) throw new Error('An Omeda brand key is required to use this middleware.');
   const router = Router();
   router.get('/', asyncRoute(async (req, res) => {
     const idxOmedaRapidIdentify = req[idxOmedaRapidIdentifyProp];
     if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
-    const promoCode = req.cookies[omedaPromoCodeCookieName] || defaultOmedaPromoCode;
+
+    const promoCode = extractPromoCode({
+      omedaPromoCodeCookieName,
+      omedaPromoCodeDefault,
+      cookies: req.cookies,
+    });
 
     const data = {
       userId: null,

--- a/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/routes/rapid-identify.js
@@ -11,12 +11,15 @@ const findEncryptedId = require('../external-id/find-encrypted-customer-id');
 module.exports = ({
   brandKey,
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
+  omedaPromoCodeCookieName = 'oly_promo_src',
+  defaultOmedaPromoCode,
 } = {}) => {
   if (!brandKey) throw new Error('An Omeda brand key is required to use this middleware.');
   const router = Router();
   router.get('/', asyncRoute(async (req, res) => {
     const idxOmedaRapidIdentify = req[idxOmedaRapidIdentifyProp];
     if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
+    const promoCode = req.cookies[omedaPromoCodeCookieName] || defaultOmedaPromoCode;
 
     const data = {
       userId: null,
@@ -40,7 +43,7 @@ module.exports = ({
       data.source = 'existing';
     } else {
       // no omeda identifier found for this user, rapidly identify.
-      const { encryptedCustomerId } = await idxOmedaRapidIdentify({ user });
+      const { encryptedCustomerId } = await idxOmedaRapidIdentify({ user, promoCode });
       data.encryptedId = encryptedCustomerId;
       data.source = 'new';
     }

--- a/packages/marko-web-omeda-identity-x/utils/extract-promo-code.js
+++ b/packages/marko-web-omeda-identity-x/utils/extract-promo-code.js
@@ -1,0 +1,8 @@
+const { get } = require('@parameter1/base-cms-object-path');
+
+module.exports = ({
+  promoCode,
+  omedaPromoCodeCookieName = 'omeda_promo_code',
+  omedaPromoCodeDefault,
+  cookies = {},
+} = {}) => promoCode || get(cookies, omedaPromoCodeCookieName) || omedaPromoCodeDefault;


### PR DESCRIPTION
This PR adds the following configuration options to the Omeda+IdentityX package. Each of these can be overridden by specifying a new value in the sites startServer handler.

@zarathustra323 I think this covers the conditions we talked about regarding sticky codes and site customization. Let me know if I missed something!

| Param | Default Value | Description
| ----------- | ----------- | ----------- |
| `omedaPromoCodeCookieName` | `omeda_promo_code` | The cookie/query parameter that should be checked for promo codes |
| `omedaPromoCodeDefault` | `undefined` | The promo code that should be set if there is none available from the request (cookie/query param) |

### omedaPromoCodeCookieName
The specified cookie will be set from the same named URL parameter, similar to the `oly_enc_id` handling. If this cookie is present on the request, the value will be used as the promo code sent with the rapid identification calls.

### omedaPromoCodeDefault
A global default promo code value to set, if the user has no specific promo code.

In practice, this means the following:
1. An anonymous visitor accessing a base-cms site with a URL parameter of `?omeda_promo_code=foo.bar.baz` will have the promo code `FOO.BAR.BAZ` set. If the visitor then attempts to log in via IdentityX (or returns later to do so), this promo code will be sent with the Omeda rapid identification call.
2. An authenticated visitor accessing the site with a new promo code will have the new promo code stored. Each request that rapidly identifies them in the future will include this promo code.
3. If a visitor returns to the site with a different promo code (`baz.bar.foo`), the _new_ promocode will be used and the original promo code will be discarded.