### PR TITLE
Add ```updateEmailNewsletterProvider``` mutation and resolver.

### DIFF
--- a/services/graphql-server/src/graphql/definitions/email/newsletter.js
+++ b/services/graphql-server/src/graphql/definitions/email/newsletter.js
@@ -25,6 +25,10 @@ extend type Query {
   )
 }
 
+extend type Mutation {
+  updateEmailNewsletterProvider(input: UpdateEmailNewsletterProviderInput!): EmailNewsletter! @requiresAuth
+}
+
 type EmailNewsletter {
   # fields from platform.model::Product
   id: ObjectID! @projection(localField: "_id") @value(localField: "_id")
@@ -148,6 +152,13 @@ input EmailNewsletterSiteInput {
 input EmailNewsletterSortInput {
   field: EmailNewsletterSortField = id
   order: SortOrder = desc
+}
+
+input UpdateEmailNewsletterProviderInput {
+  id: ObjectID!
+  type: String
+  providerId: String
+  attributes: JSON
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/email/newsletter.js
+++ b/services/graphql-server/src/graphql/definitions/email/newsletter.js
@@ -157,7 +157,7 @@ input EmailNewsletterSortInput {
 input UpdateEmailNewsletterProviderInput {
   id: ObjectID!
   type: String
-  providerId: Int
+  providerId: String
   attributes: JSON
 }
 

--- a/services/graphql-server/src/graphql/definitions/email/newsletter.js
+++ b/services/graphql-server/src/graphql/definitions/email/newsletter.js
@@ -157,7 +157,7 @@ input EmailNewsletterSortInput {
 input UpdateEmailNewsletterProviderInput {
   id: ObjectID!
   type: String
-  providerId: String
+  providerId: Int
   attributes: JSON
 }
 

--- a/services/graphql-server/src/graphql/resolvers/email/index.js
+++ b/services/graphql-server/src/graphql/resolvers/email/index.js
@@ -1,9 +1,11 @@
 const deepAssign = require('deep-assign');
 
 const campaign = require('./campaign');
+const newsletter = require('./newsletter');
 const schedule = require('./schedule');
 
 module.exports = deepAssign(
   campaign,
+  newsletter,
   schedule,
 );

--- a/services/graphql-server/src/graphql/resolvers/email/newsletter.js
+++ b/services/graphql-server/src/graphql/resolvers/email/newsletter.js
@@ -22,7 +22,7 @@ module.exports = {
       body.set('provider.providerId', providerId);
       body.set('provider.attributes', attributes);
       body.set('id', id);
-      console.log(await base4rest.updateOne({ model: type, id, body }));
+      await base4rest.updateOne({ model: type, id, body });
       return basedb.findOne('platform.Product', { _id: id });
     },
   },

--- a/services/graphql-server/src/graphql/resolvers/email/newsletter.js
+++ b/services/graphql-server/src/graphql/resolvers/email/newsletter.js
@@ -1,0 +1,29 @@
+const { Base4RestPayload } = require('@parameter1/base-cms-base4-rest-api');
+
+const validateRest = require('../../utils/validate-rest');
+
+module.exports = {
+  /**
+   *
+   */
+  Mutation: {
+    updateEmailNewsletterProvider: async (_, { input }, { base4rest, basedb }) => {
+      validateRest(base4rest);
+      const type = 'email/product/newsletter';
+      const {
+        id,
+        type: providerType,
+        providerId,
+        attributes,
+      } = input;
+
+      const body = new Base4RestPayload({ type });
+      body.set('provider.type', providerType);
+      body.set('provider.providerId', providerId);
+      body.set('provider.attributes', attributes);
+      body.set('id', id);
+      console.log(await base4rest.updateOne({ model: type, id, body }));
+      return basedb.findOne('platform.Product', { _id: id });
+    },
+  },
+};


### PR DESCRIPTION
<img width="475" alt="Screen Shot 2022-03-15 at 11 09 24 AM" src="https://user-images.githubusercontent.com/46794001/158421633-f713c78e-27d9-4d99-a449-e1bd60be8c5a.png">

I believe providerId needs to be written as an Int however it is currently writing as a string, I'm guessing this has something to do with the API and how it encodes the update operation as I tried hard casting it as a Number as well as changing the Graph definition to Int instead of String and it still writes it as a string.

EDIT: The previously described behavior is likely due to the Base YAML definition.