### PR TITLE
Add updated filter to websiteScheduledContent

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -674,6 +674,8 @@ input WebsiteScheduledContentQueryInput {
   beginning: ContentBeginningInput = {}
   "For types with a endDate field: Limit results to items with a endDate matching the criteria."
   ending: ContentEndingInput = {}
+  "Limit results using the updated (modified) date."
+  updated: ContentUpdatedInput = {}
 }
 
 input RelatedPublishedContentQueryInput {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1369,6 +1369,7 @@ module.exports = {
         after,
         beginning,
         ending,
+        updated,
       } = input;
 
       if (sectionId && sectionAlias) throw new UserInputError('You cannot provide both sectionId and sectionAlias as input.');
@@ -1438,6 +1439,8 @@ module.exports = {
       if (beginning.after) query.$and.push({ startDate: { $gte: beginning.after } });
       if (ending.before) query.$and.push({ endDate: { $lte: ending.before } });
       if (ending.after) query.$and.push({ endDate: { $gte: ending.after } });
+      if (updated.before) query.$and.push({ updated: { $lte: updated.before } });
+      if (updated.after) query.$and.push({ updated: { $gte: updated.after } });
 
       const projection = connectionProjection(info);
       const sort = input.sort.field ? input.sort : { field: 'sectionQuery.0.start', order: 'desc' };


### PR DESCRIPTION
Ref #213, add `updated` filter support to scheduled content query

```graphql
query getContent ($input: WebsiteScheduledContentQueryInput ){
  websiteScheduledContent(input: $input) {
    totalCount
    edges {
      node {
        id
        name
        type
        publishedDate
        body
        statusText
        slug
        updatedDate
        teaser: teaser(input: { maxLength: 1000, truncatedSuffix: "" })
        primaryImage { id src }
        createdBy {
          id
          name
          email
        }
        companies: relatedContent(input: { includeContentTypes: [Company] }){
          totalCount
          edges { node { id name } }
        }
        articles: relatedContent(input: { includeContentTypes: [Article] }){
          totalCount
          edges { node { id name } }
        }
        products: relatedContent(input: { includeContentTypes: [Product] }){
          totalCount
          edges { node { id name } }
        }
        siteContext { canonicalUrl }
        tags: taxonomy(input: { type: Tag, pagination: { limit: 100 } }){
          totalCount
          edges { node { id name } }
        }
      }
    }
  }
}
```

```json
{
  "input": {
    "includeContentTypes": ["Article"],
    "sort": {
      "field": "updated",
      "order": "desc"
    },
    "pagination": {
      "limit": 100
    },
    "updated": {
      "after": 1647820800000
    },
    "sectionId": 82254
  }
}
```