### PR TITLE
```requiresIndexed``` field on ```AllPublishedContentQuery```

### DIFF
--- a/packages/marko-web-html-sitemap/templates/day.marko
+++ b/packages/marko-web-html-sitemap/templates/day.marko
@@ -30,6 +30,7 @@ $ const pageNode = {
         <marko-web-query|{ nodes }|
           name="all-published-content"
           params={
+            requiresIndexed: true,
             publishedAfter: new Date(after.toISOString()),
             since: new Date(ending.toISOString()),
             limit: perPage,
@@ -52,6 +53,7 @@ $ const pageNode = {
         <marko-web-html-sitemap-query-total-count|{ totalCount }|
           name="all-published-content"
           params={
+            requiresIndexed: true,
             after: after.toDate().getTime(),
             since: ending.toDate().getTime(),
           }

--- a/packages/web-common/src/block-loaders/all-published-content.js
+++ b/packages/web-common/src/block-loaders/all-published-content.js
@@ -56,6 +56,8 @@ module.exports = async (apolloClient, {
   requiresImage,
   sectionBubbling,
 
+  requiresIndexed,
+
   queryFragment,
   queryName,
 } = {}) => {
@@ -74,6 +76,7 @@ module.exports = async (apolloClient, {
     since: date(since),
     beginning: { after: date(beginningAfter), before: date(beginningBefore) },
     ending: { after: date(endingAfter), before: date(endingBefore) },
+    requiresIndexed,
     ...(publishedAfter && { after: date(publishedAfter) }),
   };
   if (field || order) input.sort = { field, order };

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -521,6 +521,8 @@ input AllPublishedContentQueryInput {
   sectionBubbling: Boolean = true
   "Adjusts the order items are returned in."
   sort: ContentSortInput = { field: published, order: desc }
+  "Whether or not the content needs to be indexed by a search engine"
+  requiresIndexed: Boolean = false
   "Adjust which subset of results should be returned."
   pagination: PaginationInput = {}
   "For types with a startDate field: Limit results to items with a startDate matching the criteria."

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -904,6 +904,7 @@ module.exports = {
         withSite,
         customAttributes,
         updated,
+        requiresIndexed,
       } = input;
 
       // @deprecated Prefer includeContentTypes over contentTypes.
@@ -950,6 +951,9 @@ module.exports = {
       }
       if (includeLabels.length) {
         query.labels = { $in: includeLabels };
+      }
+      if (requiresIndexed) {
+        query.$and.push({ $or: [{ 'mutations.Website.noIndex': { $exists: false } }, { 'mutations.Website.noIndex': false }] });
       }
 
       const projection = connectionProjection(info);


### PR DESCRIPTION
<img width="1920" alt="Screen Shot 2022-03-24 at 8 32 14 AM" src="https://user-images.githubusercontent.com/46794001/159928366-65d04246-351a-4756-ab2a-18578ed2cb62.png">

Adds a parameter that when set to true requires that the published content be either explicitly marked as index or not marked at all.