### PR TITLE
Pass through media parsed sidebar body.

### DIFF
--- a/packages/marko-web/components/element/content/sidebar-stubs.marko
+++ b/packages/marko-web/components/element/content/sidebar-stubs.marko
@@ -20,5 +20,5 @@ $ const embedOptions = getAsObject(input, "embedOptions")
     ...value,
     body: parseEmbeddedMedia(v, res, embedOptions),
   };
-  <${input.renderBody} sidebar=value />
+  <${input.renderBody} sidebar=obj />
 </marko-web-obj-array>


### PR DESCRIPTION
Refs:
https://github.com/parameter1/base-cms/pull/135
https://github.com/parameter1/base-cms/pull/268

Apparently these were being parsed but never returned as parsed through the render slot.

<img width="1920" alt="Screen Shot 2022-04-01 at 12 40 11 PM" src="https://user-images.githubusercontent.com/46794001/161314600-6bb53de5-c351-4581-99d0-c7bfdefeaeb9.png">