### PR TITLE
Do not throw fatal error when images are missing/invalid

### DIFF
--- a/packages/image/src/create-src-for.js
+++ b/packages/image/src/create-src-for.js
@@ -6,6 +6,9 @@ module.exports = (host, image, options, defaultOptions) => {
     fileName,
     cropDimensions,
   } = image;
+  if (!fileName || !filePath) {
+    return buildImgixUrl(`https://${host}/asset-is-missing-file-name-or-path`, options, defaultOptions);
+  }
   const path = cropDimensions && cropDimensions.aspectRatio ? `${filePath}/${cropDimensions.aspectRatio}` : filePath;
   const src = `https://${host}/${path}/${fileName}`;
   return buildImgixUrl(src, options, defaultOptions);

--- a/packages/image/src/crop-rectangle.js
+++ b/packages/image/src/crop-rectangle.js
@@ -32,7 +32,7 @@ class CropRectangle {
  * the crop area.
  */
 module.exports = ({ width, height, cropDimensions }) => {
-  if (!cropDimensions) {
+  if (!cropDimensions || !width || !height) {
     return new CropRectangle({
       x: 0,
       y: 0,


### PR DESCRIPTION
Prevents the GraphQL API from fatally erroring when an image is not found