### PR TITLE
Pass custom components through omedaIdX to IdX

### DIFF
--- a/packages/marko-web-omeda-identity-x/browser/index.js
+++ b/packages/marko-web-omeda-identity-x/browser/index.js
@@ -2,8 +2,8 @@ import IdentityX from '@parameter1/base-cms-marko-web-identity-x/browser';
 
 const RapidIdentify = () => import(/* webpackChunkName: "omeda-identity-x-rapid-identify" */ './rapid-identify.vue');
 
-export default (Browser) => {
-  IdentityX(Browser);
+export default (Browser, CustomComponents) => {
+  IdentityX(Browser, CustomComponents);
 
   const { EventBus } = Browser;
   EventBus.$on('identity-x-authenticated', ({ user = {} } = {}) => {


### PR DESCRIPTION
The normal Idx package supports the passing of 
```
{
  CustomLoginComponent,
  CustomAuthenticateComponent,
  CustomLogoutComponent,
  CustomProfileComponent,
  CustomCommentStreamComponent,
}
```
This allows you to call the Omeda version and pass the object of components through