### PR TITLE
Support for passing promo codes as event data

### DIFF
--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -102,6 +102,14 @@ export default {
     },
 
     /**
+     * Additional data to send along with the emitted event.
+     */
+    additionalEventData: {
+      type: Object,
+      default: () => ({}),
+    },
+
+    /**
      * Regional consent polices to display (if/when a user selects a country on login)
      * if enabled.
      */
@@ -175,11 +183,12 @@ export default {
           redirectTo: this.redirectTo,
           authUrl: this.authUrl,
           appContextId: this.appContextId,
+          additionalEventData: this.additionalEventData,
         });
         const data = await res.json();
         if (!res.ok) throw new FormError(data.message, res.status);
         this.complete = true;
-        this.$emit('login-link-sent', data);
+        this.$emit('login-link-sent', { ...this.additionalEventData, ...data });
       } catch (e) {
         this.error = e;
       } finally {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -238,6 +238,13 @@ export default {
       type: Array,
       default: () => [],
     },
+    /**
+     * Additional data to send along with the emitted event.
+     */
+    additionalEventData: {
+      type: Object,
+      default: () => ({}),
+    },
   },
 
   /**
@@ -472,7 +479,7 @@ export default {
 
         this.user = data.user;
         this.didSubmit = true;
-        this.$emit('submit', data);
+        this.$emit('submit', { ...this.additionalEventData, ...data });
 
         if (this.reloadPageOnSubmit) {
           this.isReloadingPage = true;

--- a/packages/marko-web-identity-x/components/form-login.marko
+++ b/packages/marko-web-identity-x/components/form-login.marko
@@ -1,7 +1,9 @@
 import { get } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { req } = out.global;
 $ const { identityX } = req;
+$ const additionalEventData = defaultValue(input.additionalEventData, {});
 
 <if(Boolean(identityX))>
   <marko-web-identity-x-context|{ user, isEnabled, application }|>
@@ -14,6 +16,7 @@ $ const { identityX } = req;
       consentPolicy: get(application, "organization.consentPolicy"),
       regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
       appContextId: identityX.config.get("appContextId"),
+      additionalEventData: additionalEventData,
     };
     <if(isEnabled)>
       <marko-web-browser-component name="IdentityXLogin" props=props />

--- a/packages/marko-web-identity-x/components/form-profile.marko
+++ b/packages/marko-web-identity-x/components/form-profile.marko
@@ -1,7 +1,9 @@
 import { get } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { req } = out.global;
 $ const { identityX } = req;
+$ const additionalEventData = defaultValue(input.additionalEventData, {});
 
 <if(Boolean(identityX))>
   <marko-web-identity-x-context|{ user, isEnabled, application }|>
@@ -17,6 +19,7 @@ $ const { identityX } = req;
       emailConsentRequest: get(application, "organization.emailConsentRequest"),
       appContextId: identityX.config.get("appContextId"),
       regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
+      additionalEventData: additionalEventData,
     };
     <if(isEnabled)>
       <marko-web-browser-component name="IdentityXProfile" props=props />

--- a/packages/marko-web-identity-x/components/form-register.marko
+++ b/packages/marko-web-identity-x/components/form-register.marko
@@ -1,1 +1,1 @@
-<marko-web-identity-x-form-login />
+<marko-web-identity-x-form-login ...input />

--- a/packages/marko-web-identity-x/components/marko.json
+++ b/packages/marko-web-identity-x/components/marko.json
@@ -17,6 +17,7 @@
   },
   "<marko-web-identity-x-form-login>": {
     "template": "./form-login.marko",
+    "@additional-event-data": "object",
     "@button-labels": "object",
     "@login-email-placeholder": "string",
     "@redirect": "string"
@@ -26,12 +27,14 @@
   },
   "<marko-web-identity-x-form-register>": {
     "template": "./form-register.marko",
+    "@additional-event-data": "object",
     "@button-labels": "object",
     "@login-email-placeholder": "string",
     "@redirect": "string"
   },
   "<marko-web-identity-x-form-profile>": {
     "template": "./form-profile.marko",
+    "@additional-event-data": "object",
     "@call-to-action": "string",
     "@reload-page-on-submit": "boolean",
     "@button-label": "string"

--- a/packages/marko-web-identity-x/components/marko.json
+++ b/packages/marko-web-identity-x/components/marko.json
@@ -25,7 +25,10 @@
     "template": "./form-logout.marko"
   },
   "<marko-web-identity-x-form-register>": {
-    "template": "./form-register.marko"
+    "template": "./form-register.marko",
+    "@button-labels": "object",
+    "@login-email-placeholder": "string",
+    "@redirect": "string"
   },
   "<marko-web-identity-x-form-profile>": {
     "template": "./form-profile.marko",

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -34,6 +34,7 @@ module.exports = asyncRoute(async (req, res) => {
     authUrl,
     redirectTo,
     appContextId,
+    additionalEventData = {},
   } = body;
   const variables = { email };
   const query = buildQuery();
@@ -59,6 +60,10 @@ module.exports = asyncRoute(async (req, res) => {
       },
     },
   });
-  await callHooksFor(identityX, 'onLoginLinkSent', { req, user: appUser });
+  await callHooksFor(identityX, 'onLoginLinkSent', {
+    ...(additionalEventData || {}),
+    req,
+    user: appUser,
+  });
   return res.json({ ok: true });
 });

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -55,6 +55,7 @@ module.exports = asyncRoute(async (req, res) => {
     regionalConsentAnswers,
     customBooleanFieldAnswers,
     customSelectFieldAnswers,
+    additionalEventData = {},
   } = body;
   const input = {
     givenName,
@@ -106,6 +107,10 @@ module.exports = asyncRoute(async (req, res) => {
 
   const { data } = await identityX.client.mutate({ mutation, variables: { input } });
   const { updateOwnAppUser: user } = data;
-  await callHooksFor(identityX, 'onUserProfileUpdate', { req, user });
+  await callHooksFor(identityX, 'onUserProfileUpdate', {
+    ...(additionalEventData || {}),
+    req,
+    user,
+  });
   res.json({ ok: true, user });
 });

--- a/packages/marko-web-omeda-identity-x/add-integration-hooks.js
+++ b/packages/marko-web-omeda-identity-x/add-integration-hooks.js
@@ -22,14 +22,15 @@ module.exports = ({
   idxConfig.addHook({
     name: 'onLoginLinkSent',
     shouldAwait: false,
-    fn: async ({ req, service, user }) => onLoginLinkSent({
+    fn: async args => onLoginLinkSent({
+      ...args,
       brandKey,
       omedaGraphQLProp,
       idxOmedaRapidIdentifyProp,
 
-      req,
-      service,
-      user,
+      req: args.req,
+      service: args.service,
+      user: args.user,
     }),
   });
 
@@ -53,10 +54,11 @@ module.exports = ({
   idxConfig.addHook({
     name: 'onUserProfileUpdate',
     shouldAwait: false,
-    fn: async ({ user, req }) => onUserProfileUpdate({
+    fn: async args => onUserProfileUpdate({
+      ...args,
       idxOmedaRapidIdentifyProp,
-      req,
-      user,
+      req: args.req,
+      user: args.user,
     }),
   });
 

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -30,6 +30,14 @@ module.exports = (app, {
   // consistently pass brand key
   const brandKey = brand.trim().toLowerCase();
 
+  // strip `oly_enc_id` when identity-x user is logged-in
+  app.use(stripOlyticsParam());
+
+  // set `omeda_promo_code` when the URL parameter is present
+  app.use(setPromoSourceCookie({
+    omedaPromoCodeCookieName,
+  }));
+
   // install omeda middleware
   omeda(app, {
     brandKey,
@@ -66,13 +74,5 @@ module.exports = (app, {
   app.use('/__idx/omeda-rapid-ident', rapidIdentifyRouter({
     brandKey,
     idxOmedaRapidIdentifyProp,
-  }));
-
-  // strip `oly_enc_id` when identity-x user is logged-in
-  app.use(stripOlyticsParam());
-
-  // set `omeda_promo_code` when the URL parameter is present
-  app.use(setPromoSourceCookie({
-    omedaPromoCodeCookieName,
   }));
 };

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
@@ -225,6 +225,7 @@ module.exports = async ({
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
   omedaPromoCodeCookieName = 'omeda_promo_code',
   omedaPromoCodeDefault,
+  promoCode: hookDataPromoCode,
 
   req,
   service: identityX,
@@ -236,6 +237,7 @@ module.exports = async ({
   if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
 
   const promoCode = extractPromoCode({
+    promoCode: hookDataPromoCode,
     omedaPromoCodeCookieName,
     omedaPromoCodeDefault,
     cookies: req.cookies,

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
@@ -6,10 +6,12 @@ module.exports = async ({
   omedaPromoCodeDefault,
   req,
   user,
+  promoCode: hookDataPromoCode,
 }) => {
   const idxOmedaRapidIdentify = req[idxOmedaRapidIdentifyProp];
   if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
   const promoCode = extractPromoCode({
+    promoCode: hookDataPromoCode,
     omedaPromoCodeCookieName,
     omedaPromoCodeDefault,
     cookies: req.cookies,

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
@@ -1,9 +1,22 @@
+const extractPromoCode = require('../utils/extract-promo-code');
+
 module.exports = async ({
   idxOmedaRapidIdentifyProp = '$idxOmedaRapidIdentify',
+  omedaPromoCodeCookieName = 'omeda_promo_code',
+  omedaPromoCodeDefault,
   req,
   user,
 }) => {
   const idxOmedaRapidIdentify = req[idxOmedaRapidIdentifyProp];
   if (!idxOmedaRapidIdentify) throw new Error(`Unable to find the IdentityX+Omeda rapid identifier on the request using ${idxOmedaRapidIdentifyProp}`);
-  return idxOmedaRapidIdentify({ user });
+  const promoCode = extractPromoCode({
+    omedaPromoCodeCookieName,
+    omedaPromoCodeDefault,
+    cookies: req.cookies,
+  });
+
+  return idxOmedaRapidIdentify({
+    user,
+    ...(promoCode && { promoCode }),
+  });
 };


### PR DESCRIPTION
Ref #257, this PR adds support for specifying the promo code at runtime by passing it as part of an `additionalEventData` object. When present, the keys of this object will be passed to subscribing hooks (and added to the events emitted on the frontend event bus)

Users can specify a promocode for the login component by adding it to their marko component call:
```diff
 <marko-web-identity-x-login
  login-email-placeholder="foo@bar.baz"
+ additional-event-data={ promoCode: "my_super_promo" }
  redirect: req.url
 />
```

or by sending the prop directly to the Vue component:
```marko
<marko-web-browser-component
  name="IdentityXLogin"
  props={
    endpoints: identityX.config.getEndpoints(),
    redirect: input.redirect,
    additionalEventData: { promoCode: "my_super_promo" },
} />
```