### PR TITLE
IdentityX form classing & display logic adjustments

### DIFF
--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -11,6 +11,7 @@
       :active-user="activeUser"
       :required-server-fields="requiredServerFields"
       :required-client-fields="requiredClientFields"
+      :hidden-fields="hiddenFields"
       :consent-policy="consentPolicy"
       :email-consent-request="emailConsentRequest"
       :regional-consent-policies="regionalConsentPolicies"
@@ -62,6 +63,10 @@ export default {
     redirectTo: {
       type: String,
       default: '/',
+    },
+    hiddenFields: {
+      type: Array,
+      default: () => [],
     },
     requiredServerFields: {
       type: Array,

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -95,14 +95,13 @@ export default {
       return `col-md-${12 / fields}`;
     },
     showBlock() {
-      if (
-        this.street.visible
-        || this.addressExtra.visible
-        || this.city.visible
-        || this.regionCode.visible
-        || this.postalCode.visible
-      ) return true;
-      return false;
+      return [
+        this.street,
+        this.addressExtra,
+        this.city,
+        this.regionCode,
+        this.postalCode,
+      ].some(v => v.visible);
     },
     classNames() {
       const classNames = ['form-group'];

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -1,5 +1,5 @@
 <template>
-  <fieldset class="px-3 border mb-3">
+  <fieldset v-if="showBlock" class="px-3 border mb-3 address-block">
     <legend class="h6 w-auto">
       Address
     </legend>
@@ -17,25 +17,25 @@
       />
     </div>
 
-    <div v-if="city.visible || regionCode.visible" class="row">
+    <div v-if="city.visible || regionCode.visible || postalCode.visible" class="row">
       <city
         v-if="city.visible"
         v-model="user.city"
         :required="city.required"
-        :class-name="regionCode.visible ? 'col-md-4' : 'col-md-6'"
+        :class-name="addressLineTwoFieldClass"
       />
       <region
         v-if="regionCode.visible"
         v-model="user.regionCode"
         :country-code="user.countryCode"
         :required="regionCode.required"
-        :class-name="city.visible ? 'col-md-4' : 'col-md-6'"
+        :class-name="addressLineTwoFieldClass"
       />
       <postal-code
-        v-if="regionCode.visible"
+        v-if="postalCode.visible"
         v-model="user.postalCode"
         :required="postalCode.required"
-        :class-name="city.visible ? 'col-md-4' : 'col-md-6'"
+        :class-name="addressLineTwoFieldClass"
       />
     </div>
   </fieldset>
@@ -82,7 +82,32 @@ export default {
       required: true,
     },
   },
+  /**
+   *
+   */
   computed: {
+    addressLineTwoFieldClass() {
+      let fields = 0;
+      // eslint-disable-next-line no-plusplus
+      if (this.city.visible) fields++;
+      // eslint-disable-next-line no-plusplus
+      if (this.regionCode.visible) fields++;
+      // eslint-disable-next-line no-plusplus
+      if (this.postalCode.visible) fields++;
+      if (fields === 0 || fields === 1) return 'col-md-12';
+      return `col-md-${12 / fields}`;
+    },
+    showBlock() {
+      if (
+        this.street.visible
+        || this.addressExtra.visible
+        || this.addressExtra.visible
+        || this.city.visible
+        || this.regionCode.visible
+        || this.postalCode.visible
+      ) return true;
+      return false;
+    },
     classNames() {
       const classNames = ['form-group'];
       const { className } = this;

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -88,12 +88,9 @@ export default {
   computed: {
     addressLineTwoFieldClass() {
       let fields = 0;
-      // eslint-disable-next-line no-plusplus
-      if (this.city.visible) fields++;
-      // eslint-disable-next-line no-plusplus
-      if (this.regionCode.visible) fields++;
-      // eslint-disable-next-line no-plusplus
-      if (this.postalCode.visible) fields++;
+      if (this.city.visible) fields += 1;
+      if (this.regionCode.visible) fields += 1;
+      if (this.postalCode.visible) fields += 1;
       if (fields === 0 || fields === 1) return 'col-md-12';
       return `col-md-${12 / fields}`;
     },

--- a/packages/marko-web-identity-x/browser/form/address-block.vue
+++ b/packages/marko-web-identity-x/browser/form/address-block.vue
@@ -98,7 +98,6 @@ export default {
       if (
         this.street.visible
         || this.addressExtra.visible
-        || this.addressExtra.visible
         || this.city.visible
         || this.regionCode.visible
         || this.postalCode.visible

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -4,13 +4,21 @@
     <form @submit.prevent="handleSubmit">
       <fieldset :disabled="isLoading">
         <div class="row">
-          <div class="col-md-6">
+          <div
+            v-if="givenNameSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': familyNameSettings.visible }"
+          >
             <given-name
               v-model="user.givenName"
               :required="givenNameSettings.required"
             />
           </div>
-          <div class="col-md-6">
+          <div
+            v-if="familyNameSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': givenNameSettings.visible }"
+          >
             <family-name
               v-model="user.familyName"
               :required="familyNameSettings.required"
@@ -19,13 +27,21 @@
         </div>
 
         <div class="row">
-          <div class="col-md-6">
+          <div
+            v-if="organizationSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': organizationTitleSettings.visible }"
+          >
             <organization
               v-model="user.organization"
               :required="organizationSettings.required"
             />
           </div>
-          <div class="col-md-6">
+          <div
+            v-if="organizationTitleSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': organizationSettings.visible }"
+          >
             <organization-title
               v-model="user.organizationTitle"
               :required="organizationTitleSettings.required"
@@ -34,12 +50,21 @@
         </div>
 
         <div class="row">
-          <phone-number
+          <div
             v-if="phoneNumberSettings.visible"
-            v-model="user.phoneNumber"
-            :required="phoneNumberSettings.required"
-          />
-          <div class="col-md-6">
+            class="col-12"
+            :class="{ 'col-md-6': countryCodeSettings.visible }"
+          >
+            <phone-number
+              v-model="user.phoneNumber"
+              :required="phoneNumberSettings.required"
+            />
+          </div>
+          <div
+            v-if="countryCodeSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': phoneNumberSettings.visible }"
+          >
             <country
               v-model="user.countryCode"
               :required="countryCodeSettings.required"
@@ -62,7 +87,8 @@
             v-for="fieldAnswer in customSelectFieldAnswers"
             :id="fieldAnswer.field.id"
             :key="fieldAnswer.id"
-            class="col-md-6"
+            class="col-12"
+            :class="{ 'col-md-6': (customSelectFieldAnswers.length > 1) }"
             :label="fieldAnswer.field.label"
             :required="fieldAnswer.field.required"
             :multiple="fieldAnswer.field.multiple"

--- a/packages/marko-web-identity-x/components/form-authenticate.marko
+++ b/packages/marko-web-identity-x/components/form-authenticate.marko
@@ -11,6 +11,7 @@ $ const isEnabled = Boolean(req.identityX);
       redirectTo: query.redirectTo,
       requiredServerFields: identityX.config.getRequiredServerFields(),
       requiredClientFields: identityX.config.getRequiredClientFields(),
+      hiddenFields: identityX.config.getHiddenFields(),
       endpoints: identityX.config.getEndpoints(),
       callToAction: input.callToAction,
       buttonLabel: input.buttonLabel,


### PR DESCRIPTION
Make the col-md-6 class dynamic based on it sibling field in each row.

Add hiddenFields prop to the authenticate form components.

Update Address block visibility checks
 - add generic address-block class for css targeting purposes
 - add or for postalCode visibility check on line 2 of the address block
 - update computed class logic for line two to support full 1/2 or 1/3(col-me-12||6||4…
 - update v-if on postalCode to check itself instead of regionCode