### PR TITLE
Add ability to configure defaultCountryCode

### DIFF
--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -12,6 +12,7 @@
       :required-server-fields="requiredServerFields"
       :required-client-fields="requiredClientFields"
       :hidden-fields="hiddenFields"
+      :default-country-code="defaultCountryCode"
       :consent-policy="consentPolicy"
       :email-consent-request="emailConsentRequest"
       :regional-consent-policies="regionalConsentPolicies"
@@ -95,6 +96,10 @@ export default {
     buttonLabel: {
       type: String,
       default: 'Submit',
+    },
+    defaultCountryCode: {
+      type: String,
+      default: null,
     },
   },
 

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -271,6 +271,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    defaultCountryCode: {
+      type: String,
+      default: null,
+    },
   },
 
   /**
@@ -282,7 +286,14 @@ export default {
       isLoading: false,
       isReloadingPage: false,
       didSubmit: false,
-      user: { ...this.activeUser },
+      user: {
+        ...this.activeUser,
+        ...(
+          this.defaultCountryCode
+          && !this.activeUser.countryCode
+          && { countryCode: this.defaultCountryCode }
+        ),
+      },
     };
   },
 

--- a/packages/marko-web-identity-x/components/form-authenticate.marko
+++ b/packages/marko-web-identity-x/components/form-authenticate.marko
@@ -11,6 +11,7 @@ $ const isEnabled = Boolean(req.identityX);
       redirectTo: query.redirectTo,
       requiredServerFields: identityX.config.getRequiredServerFields(),
       requiredClientFields: identityX.config.getRequiredClientFields(),
+      defaultCountryCode: identityX.config.get('defaultCountryCode'),
       hiddenFields: identityX.config.getHiddenFields(),
       endpoints: identityX.config.getEndpoints(),
       callToAction: input.callToAction,

--- a/packages/marko-web-identity-x/components/form-profile.marko
+++ b/packages/marko-web-identity-x/components/form-profile.marko
@@ -12,6 +12,7 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       requiredServerFields: identityX.config.getRequiredServerFields(),
       requiredClientFields: identityX.config.getRequiredClientFields(),
       hiddenFields: identityX.config.getHiddenFields(),
+      defaultCountryCode: identityX.config.get('defaultCountryCode'),
       callToAction: input.callToAction,
       reloadPageOnSubmit: input.reloadPageOnSubmit,
       endpoints: identityX.config.getEndpoints(),

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -22,6 +22,7 @@ class IdentityXConfiguration {
     requiredServerFields = [],
     requiredClientFields = [],
     hiddenFields = ['city', 'street', 'addressExtra', 'phoneNumber'],
+    defaultCountryCode,
     onHookError,
     ...rest
   } = {}) {
@@ -32,6 +33,7 @@ class IdentityXConfiguration {
       requiredServerFields,
       requiredClientFields,
       hiddenFields,
+      defaultCountryCode,
       onHookError: (e) => {
         if (process.env.NODE_ENV === 'development') {
           log('ERROR IN IDENTITY-X HOOK', e);


### PR DESCRIPTION
 - Add config support for setting of default country code.
 - Pass default country from config to  the authenticate and profile components that use country code.