### PR TITLE
Ensure countryCode is a visible field before applying  the default value when set.

### DIFF
--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -289,7 +289,8 @@ export default {
       user: {
         ...this.activeUser,
         ...(
-          this.defaultCountryCode
+          !this.hiddenFields.includes('countryCode')
+          && this.defaultCountryCode
           && !this.activeUser.countryCode
           && { countryCode: this.defaultCountryCode }
         ),


### PR DESCRIPTION
Add visibility check on spread of the default country code value.  Meaning only spread the default value if the countryCode field is visible.  