### PR TITLE
Add support for passing eventLabel to IdentityX authenticate route

### DIFF
--- a/packages/marko-web-identity-x/browser/comments/stream.vue
+++ b/packages/marko-web-identity-x/browser/comments/stream.vue
@@ -37,7 +37,7 @@
         <login
           :class="element('login-form')"
           :additional-event-data="additionalEventData"
-          :event-label="eventLabel"
+          :event-label="eventLabel + '-login'"
           :active-user="activeUser"
           :endpoints="endpoints"
           :consent-policy="consentPolicy"

--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -182,6 +182,7 @@ export default {
         this.loading = true;
         const res = await post('/login', {
           email: this.email,
+          eventLabel: this.eventLabel,
           redirectTo: this.redirectTo,
           authUrl: this.authUrl,
           appContextId: this.appContextId,

--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -182,7 +182,7 @@ export default {
         this.loading = true;
         const res = await post('/login', {
           email: this.email,
-          eventLabel: this.eventLabel,
+          source: this.eventLabel,
           redirectTo: this.redirectTo,
           authUrl: this.authUrl,
           appContextId: this.appContextId,

--- a/packages/marko-web-identity-x/components/form-authenticate.marko
+++ b/packages/marko-web-identity-x/components/form-authenticate.marko
@@ -3,13 +3,14 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { req } = out.global;
 $ const { identityX, query } = req;
+$ const source = get(query, 'source');
 $ const isEnabled = Boolean(req.identityX);
 $ const additionalEventData = defaultValue(input.additionalEventData, {});
 
 <if(isEnabled)>
   <marko-web-identity-x-context|{ application }|>
     $ const props = {
-      additionalEventData: additionalEventData,
+      additionalEventData: { ...additionalEventData, source },
       eventLabel: input.eventLabel,
       token: query.token,
       redirectTo: query.redirectTo,

--- a/packages/marko-web-identity-x/components/marko.json
+++ b/packages/marko-web-identity-x/components/marko.json
@@ -68,7 +68,7 @@
     "@additional-event-data": "object",
     "@event-label": {
       "type": "string",
-      "default-value": "logout"
+      "default-value": "comment-stream"
     },
     "@identifier": {
       "type": "string",

--- a/packages/marko-web-identity-x/components/marko.json
+++ b/packages/marko-web-identity-x/components/marko.json
@@ -46,7 +46,7 @@
     "@additional-event-data": "object",
     "@event-label": {
       "type": "string",
-      "default-value": "logout"
+      "default-value": "register"
     },
     "@button-labels": "object",
     "@login-email-placeholder": "string",
@@ -57,7 +57,7 @@
     "@additional-event-data": "object",
     "@event-label": {
       "type": "string",
-      "default-value": "logout"
+      "default-value": "profile"
     },
     "@call-to-action": "string",
     "@reload-page-on-submit": "boolean",

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -31,6 +31,7 @@ module.exports = asyncRoute(async (req, res) => {
   const { identityX, body } = req;
   const {
     email,
+    source,
     authUrl,
     redirectTo,
     appContextId,
@@ -54,6 +55,7 @@ module.exports = asyncRoute(async (req, res) => {
     variables: {
       input: {
         email: appUser.email,
+        source,
         authUrl,
         redirectTo,
         appContextId,


### PR DESCRIPTION
@requires: https://github.com/parameter1/identity-x/pull/10

Pass source from login form to authenticate form.

On login set source to eventLabel(login||commet-stream-login||content-meter-login). On sendLoginLinkMutation set souce as a query param to be able to be read by the authenticate components.