### PR TITLE
Add `Content.estimatedReadingTime` field

### DIFF
--- a/services/graphql-server/package.json
+++ b/services/graphql-server/package.json
@@ -48,6 +48,7 @@
     "newrelic": "^6.14.0",
     "node-fetch": "^2.6.5",
     "object-hash": "^1.3.1",
+    "reading-time": "^1.5.0",
     "sift": "^7.0.1",
     "uuid": "^3.4.0"
   }

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -271,6 +271,13 @@ type PublishedContentDate {
   count: Int!
 }
 
+type ContentEstimatedReadingTime {
+  text: String!
+  minutes: Float!
+  time: Int!
+  words: Int!
+}
+
 type ContentSitemapUrl {
   id: String! @value(localField: "_id")
   loc: String!
@@ -693,6 +700,11 @@ input RelatedPublishedContentQueryInput {
   requiresImage: Boolean = false
   queryTypes: [RelatedContentQueryType!] = [owned, inverse]
   pagination: PaginationInput = {}
+}
+
+input ContentEstimatedReadingTimeInput {
+  mutation: ContentMutation = Website
+  wordsPerMinute: Int = 200
 }
 
 input ContentRelatedContentInput {

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -57,6 +57,8 @@ interface Content @requiresProject(fields: ["type"]) {
   slug: String @projection(localField: "mutations.Website.slug") @value(localField: "mutations.Website.slug")
 
   # GraphQL-only fields.
+  estimatedReadingTime(input: ContentEstimatedReadingTimeInput = {}): ContentEstimatedReadingTime @projection(localField: "body", needs: ["mutations.Website.body", "mutations.Email.body", "mutations.Magazine.body"])
+
   statusText: String! @projection(localField: "status", needs: ["published", "unpublished"])
   metadata: ContentMetadata! @projection(localField: "name", needs: ["type", "company", "primaryImage", "mutations.Website.name", "mutations.Website.seoTitle", "teaser", "mutations.Website.teaser", "mutations.Website.seoDescription", "published", "updated", "unpublished"])
   createdDate(input: FormatDate = {}): String @projection(localField: "created") @momentFormat(localField: "created")

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -11,6 +11,7 @@ const moment = require('moment');
 const momentTZ = require('moment-timezone');
 const cheerio = require('cheerio');
 const fetch = require('node-fetch');
+const readingTime = require('reading-time');
 
 const newrelic = require('../../../newrelic');
 const defaults = require('../../defaults');
@@ -546,6 +547,22 @@ module.exports = {
       });
       return value;
     },
+
+    estimatedReadingTime: async (content, { input }) => {
+      const { mutation, wordsPerMinute } = input;
+      const { body } = content;
+      const mutated = get(content, `mutations.${mutation}.body`);
+
+
+      const value = mutation ? mutated || body : body;
+
+      if (!value) return null;
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+
+      return readingTime(trimmed, { wordsPerMinute });
+    },
+
 
     userRegistration: (content) => {
       const requiresRegistration = get(content, 'mutations.Website.requiresRegistration');

--- a/yarn.lock
+++ b/yarn.lock
@@ -15956,6 +15956,11 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+reading-time@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/reading-time/-/reading-time-1.5.0.tgz#d2a7f1b6057cb2e169beaf87113cc3411b5bc5bb"
+  integrity sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"


### PR DESCRIPTION
Provides estimated reading time statistics for the content body field using the `reading-time` package.

Sample output:
```json
{
  "data": {
    "content": {
      "id": 22184684,
      "estimatedReadingTime": {
        "text": "8 min read",
        "minutes": 7.135,
        "time": 428100,
        "words": 1427
      }
    }
  }
}
```