### PR TITLE
Support IdentityX+Omeda write-in values

### DIFF
--- a/packages/marko-web-identity-x/browser/form/fields/custom-select-write-in.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/custom-select-write-in.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="input-group">
     <div class="input-group-prepend w-25">
-      <div class="input-group-text d-inline-block text-truncate" :title="label">
+      <div class="input-group-text d-inline-block text-truncate w-100" :title="label">
         {{ label }}
       </div>
     </div>

--- a/packages/marko-web-identity-x/browser/form/fields/custom-select-write-in.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/custom-select-write-in.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="input-group">
-    <div class="input-group-prepend">
-      <div class="input-group-text">{{ label }}</div>
+    <div class="input-group-prepend w-25">
+      <div class="input-group-text d-inline-block text-truncate" :title="label">
+        {{ label }}
+      </div>
     </div>
 
     <input

--- a/packages/marko-web-omeda-identity-x/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/rapid-identify.js
@@ -62,9 +62,11 @@ module.exports = async ({
   }).map((select) => {
     const { field } = select;
     const { identifier } = field.externalId;
+    const writeInValue = select.answers.reduce((v, answer) => (v || answer.writeInValue), null);
     return {
       id: parseInt(identifier.value, 10),
       values: select.answers.map(answer => answer.externalIdentifier).filter(v => v),
+      ...(writeInValue && { writeInValue }),
     };
   });
 


### PR DESCRIPTION
Requires parameter1/omeda#25

- Fixes display issue with long option values
- Sets existing write-in values to IdentityX when logging in
- Sends new write-in values to Omeda when updating profile/rapid ident.