### PR TITLE
Only send writeIn input when present

### DIFF
--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -99,7 +99,8 @@ module.exports = asyncRoute(async (req, res) => {
       fieldId: fieldAnswer.field.id,
       optionIds: fieldAnswer.answers.map(({ id }) => id),
       writeInValues: fieldAnswer.answers.reduce((arr, { id, writeInValue }) => ([
-        ...arr, { optionId: id, value: writeInValue },
+        ...arr,
+        ...(writeInValue ? [{ optionId: id, value: writeInValue }] : []),
       ]), []),
     }));
     await identityX.client.mutate({


### PR DESCRIPTION
Prevents thrown error when other select inputs without write-in answers exist on the same form.