### PR TITLE
Change sort order for custom select fields

### DIFF
--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -48,7 +48,7 @@ fragment ActiveUserFragment on AppUser {
   }
   customSelectFieldAnswers(input: {
     onlyActive: true
-    sort: { field: label, order: asc }
+    sort: { field: createdAt, order: asc }
   }) {
     id
     hasAnswered


### PR DESCRIPTION
Ref #238, update the sort order to use `createdAt` to allow manipulation of the displayed field order.