### PR TITLE
Move i18n prop destructure to correct location.

### DIFF
--- a/packages/marko-web-theme-monorail/templates/taxonomy.marko
+++ b/packages/marko-web-theme-monorail/templates/taxonomy.marko
@@ -2,10 +2,8 @@ import hierarchyAliases from "@parameter1/base-cms-marko-web/utils/hierarchy-ali
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "../graphql/fragments/section-feed-block";
 
-$ const { id, name, type, description, i18n } = input;
-$ const { GAM, req } = out.global;
-
-$ const { pagination: p } = out.global;
+$ const { id, name, type, description } = input;
+$ const { GAM, req, i18n, pagination: p } = out.global;
 $ const perPage = 12;
 
 $ const queryParams = {


### PR DESCRIPTION
This was causing subsequent pages when paginating on taxonomy to error out and display nothing as the i18n function is not defined on input but rather app.locals (out.global).

<img width="1792" alt="Screen Shot 2022-05-11 at 9 40 30 AM" src="https://user-images.githubusercontent.com/46794001/167877513-c9f73b8d-7a2e-45b5-8829-5c9fc7ee6ec7.png">

