### PR TITLE
‘Unbuild’ section query when content status is 0.

### DIFF
--- a/packages/section-query-generator/src/index.js
+++ b/packages/section-query-generator/src/index.js
@@ -112,7 +112,7 @@ module.exports = async ({
 
   const { matchedCount: unbuiltCount } = await contentColl.bulkWrite([{
     updateMany: {
-      filter: { status: 0 },
+      filter: { status: 0, sectionQuery: { $exists: true } },
       update: { $unset: { sectionQuery: '' } },
     },
   }]);

--- a/packages/section-query-generator/src/index.js
+++ b/packages/section-query-generator/src/index.js
@@ -110,6 +110,14 @@ module.exports = async ({
   const { matchedCount } = await contentColl.bulkWrite(bulkOps);
   logger('Bulk write complete.', matchedCount);
 
+  const { matchedCount: unbuiltCount } = await contentColl.bulkWrite([{
+    updateMany: {
+      filter: { status: 0 },
+      update: { $unset: { sectionQuery: '' } },
+    },
+  }]);
+  logger('Bulk unbuild complete.', unbuiltCount);
+
   if (createIndexes) {
     logger('Creating indices...');
     await Promise.all([


### PR DESCRIPTION
Previously this left sectionQuery alone if all the schedules were status 0 for a given content item (in the event a content item is programmatically deleted) this will now remove sectionQuery from deleted content items as the management interface were if you were to delete a content item there. 