### PR TITLE
Display all authors, images and video embed sources

### DIFF
--- a/services/rss/src/api/content-fragment.js
+++ b/services/rss/src/api/content-fragment.js
@@ -4,7 +4,7 @@ module.exports = gql`
 
 fragment RSSItemContentFragment on Content {
   id
-  name
+  seoTitle
   teaser(input: { useFallback: false, maxLength: null })
   siteContext {
     url
@@ -16,8 +16,16 @@ fragment RSSItemContentFragment on Content {
     name
     fullName
   }
+  images(input:{ pagination: { limit: 100 }, sort: { order: values } }) {
+    edges {
+      node {
+        id
+        src(input: { options: { auto: "format,compress", q: 70 } })
+      }
+    }
+  }
   ... on Authorable {
-    authors(input: { pagination: { limit: 1 } }) {
+    authors {
       edges {
         node {
           id
@@ -27,6 +35,9 @@ fragment RSSItemContentFragment on Content {
         }
       }
     }
+  }
+  ... on ContentVideo {
+    embedSrc
   }
 }
 

--- a/services/rss/src/utils/create-item.js
+++ b/services/rss/src/utils/create-item.js
@@ -21,13 +21,15 @@ module.exports = ({
   const authorStrings = authors.reduce((arr, { node }) => {
     const { publicEmail, firstName, lastName } = node;
 
+    if (!publicEmail) return arr;
+
     const nameParts = [];
     if (firstName) nameParts.push(firstName);
-    if (lastName) nameParts.push(firstName);
+    if (lastName) nameParts.push(lastName);
 
     const authorParts = [];
     if (publicEmail) authorParts.push(publicEmail);
-    if (nameParts.length) authorParts.push(nameParts.join(' '));
+    if (nameParts.length) authorParts.push(`(${nameParts.join(' ')})`);
 
     if (authorParts.length) arr.push(authorParts.join(' '));
 

--- a/services/rss/src/utils/create-item.js
+++ b/services/rss/src/utils/create-item.js
@@ -18,32 +18,19 @@ module.exports = ({
   ];
   if (teaser) parts.push(`<description>${xml.encode(teaser)}</description>`);
   if (publishedDate) parts.push(`<pubDate>${publishedDate}</pubDate>`);
-  const authorNodes = authors.map(authorEdge => authorEdge.node);
-  let authorsString = '';
-  if (authorNodes.length) {
-    authorNodes.forEach((authorNode, index) => {
-      const currentAuthorString = `${authorNode.publicEmail} (${authorNode.firstName} ${authorNode.lastName})`;
-      if (authorNode.publicEmail) {
-        if (index) {
-          authorsString += `, ${currentAuthorString}`;
-        } else {
-          authorsString += currentAuthorString;
-        }
-      }
-    });
-    if (authorsString) parts.push(`<author>${authorsString}</author>`);
-  }
+  const authorStrings = authors.reduce(authorEdge => authorEdge.node).map((authorEdge) => {
+    const { node } = authorEdge;
+    return `${node.publicEmail} (${node.firstName} ${node.lastName})`;
+  });
+  parts.push(`<author>${authorStrings.join(', ')}</author>`);
   if (primarySection && primarySection.alias !== 'home') {
     parts.push(`<category domain="${website.origin}">${xml.encode(primarySection.fullName.replace('>', '/'))}</category>`);
   }
-  const imageNodes = images.map(imageEdge => imageEdge.node);
-  if (imageNodes.length) {
-    imageNodes.forEach((imageNode) => {
-      parts.push(`<media:content url=${imageNode.src} medium="image" />`);
-    });
-  }
-  if (embedSrc) {
-    parts.push(`<media:content url=${embedSrc} medium="video" />`);
-  }
+  const imageMediaTags = images.reduce(imageEdge => imageEdge.node).map((imageEdge) => {
+    const { node } = imageEdge;
+    return `<media:content url=${node.src} medium="image" />`;
+  });
+  parts.push(...imageMediaTags);
+  if (embedSrc) parts.push(`<media:content url=${embedSrc} medium="video" />`);
   return `<item>${parts.join('')}</item>`;
 };

--- a/services/rss/src/utils/create-item.js
+++ b/services/rss/src/utils/create-item.js
@@ -1,26 +1,49 @@
 const { xmlEntities: xml } = require('@parameter1/base-cms-html');
-const { getAsObject } = require('@parameter1/base-cms-object-path');
 
 module.exports = ({
-  name,
+  seoTitle,
   teaser,
   siteContext,
   publishedDate,
   authors,
   primarySection,
+  images,
+  embedSrc,
 }, website) => {
   const { url } = siteContext;
   const parts = [
-    `<title>${xml.encode(name)}</title>`,
+    `<title>${xml.encode(seoTitle)}</title>`,
     `<link>${url}</link>`,
     `<guid isPermaLink="true">${url}</guid>`,
   ];
   if (teaser) parts.push(`<description>${xml.encode(teaser)}</description>`);
   if (publishedDate) parts.push(`<pubDate>${publishedDate}</pubDate>`);
-  const author = getAsObject(authors, 'edges.0.node');
-  if (author.publicEmail) parts.push(`<author>${author.publicEmail} (${author.firstName} ${author.lastName})</author>`);
+  const authorNodes = authors.map(authorEdge => authorEdge.node);
+  let authorsString = '';
+  if (authorNodes.length) {
+    authorNodes.forEach((authorNode, index) => {
+      const currentAuthorString = `${authorNode.publicEmail} (${authorNode.firstName} ${authorNode.lastName})`;
+      if (authorNode.publicEmail) {
+        if (index) {
+          authorsString += `, ${currentAuthorString}`;
+        } else {
+          authorsString += currentAuthorString;
+        }
+      }
+    });
+    if (authorsString) parts.push(`<author>${authorsString}</author>`);
+  }
   if (primarySection && primarySection.alias !== 'home') {
     parts.push(`<category domain="${website.origin}">${xml.encode(primarySection.fullName.replace('>', '/'))}</category>`);
+  }
+  const imageNodes = images.map(imageEdge => imageEdge.node);
+  if (imageNodes.length) {
+    imageNodes.forEach((imageNode) => {
+      parts.push(`<media:content url=${imageNode.src} medium="image" />`);
+    });
+  }
+  if (embedSrc) {
+    parts.push(`<media:content url=${embedSrc} medium="video" />`);
   }
   return `<item>${parts.join('')}</item>`;
 };

--- a/services/rss/src/utils/create-item.js
+++ b/services/rss/src/utils/create-item.js
@@ -1,3 +1,4 @@
+const { getAsArray } = require('@parameter1/base-cms-object-path');
 const { xmlEntities: xml } = require('@parameter1/base-cms-html');
 
 module.exports = ({
@@ -18,7 +19,7 @@ module.exports = ({
   ];
   if (teaser) parts.push(`<description>${xml.encode(teaser)}</description>`);
   if (publishedDate) parts.push(`<pubDate>${publishedDate}</pubDate>`);
-  const authorStrings = authors.reduce((arr, { node }) => {
+  const authorStrings = getAsArray(authors, 'edges').reduce((arr, { node }) => {
     const { publicEmail, firstName, lastName } = node;
 
     if (!publicEmail) return arr;
@@ -39,7 +40,7 @@ module.exports = ({
   if (primarySection && primarySection.alias !== 'home') {
     parts.push(`<category domain="${website.origin}">${xml.encode(primarySection.fullName.replace('>', '/'))}</category>`);
   }
-  const imageMediaTags = images.reduce((arr, { node }) => {
+  const imageMediaTags = getAsArray(images, 'edges').reduce((arr, { node }) => {
     const { src } = node;
     if (src) arr.push(`<media:content url="${node.src}" medium="image" />`);
     return arr;

--- a/services/rss/src/utils/create-item.js
+++ b/services/rss/src/utils/create-item.js
@@ -18,19 +18,31 @@ module.exports = ({
   ];
   if (teaser) parts.push(`<description>${xml.encode(teaser)}</description>`);
   if (publishedDate) parts.push(`<pubDate>${publishedDate}</pubDate>`);
-  const authorStrings = authors.reduce(authorEdge => authorEdge.node).map((authorEdge) => {
-    const { node } = authorEdge;
-    return `${node.publicEmail} (${node.firstName} ${node.lastName})`;
-  });
-  parts.push(`<author>${authorStrings.join(', ')}</author>`);
+  const authorStrings = authors.reduce((arr, { node }) => {
+    const { publicEmail, firstName, lastName } = node;
+
+    const nameParts = [];
+    if (firstName) nameParts.push(firstName);
+    if (lastName) nameParts.push(firstName);
+
+    const authorParts = [];
+    if (publicEmail) authorParts.push(publicEmail);
+    if (nameParts.length) authorParts.push(nameParts.join(' '));
+
+    if (authorParts.length) arr.push(authorParts.join(' '));
+
+    return arr;
+  }, []);
+  if (authorStrings.length) parts.push(`<author>${authorStrings.join(', ')}</author>`);
   if (primarySection && primarySection.alias !== 'home') {
     parts.push(`<category domain="${website.origin}">${xml.encode(primarySection.fullName.replace('>', '/'))}</category>`);
   }
-  const imageMediaTags = images.reduce(imageEdge => imageEdge.node).map((imageEdge) => {
-    const { node } = imageEdge;
-    return `<media:content url=${node.src} medium="image" />`;
-  });
-  parts.push(...imageMediaTags);
-  if (embedSrc) parts.push(`<media:content url=${embedSrc} medium="video" />`);
+  const imageMediaTags = images.reduce((arr, { node }) => {
+    const { src } = node;
+    if (src) arr.push(`<media:content url="${node.src}" medium="image" />`);
+    return arr;
+  }, []);
+  if (imageMediaTags.length) parts.push(...imageMediaTags);
+  if (embedSrc) parts.push(`<media:content url="${embedSrc}" medium="video" />`);
   return `<item>${parts.join('')}</item>`;
 };


### PR DESCRIPTION
Will now use seoTitle over name (seoTitle falls back to name anyway), pull images, pull ALL authors, pull video embedSrc where applicable, utilize those fields to set applicable RSS item properties.

<img width="994" alt="Screen Shot 2022-05-26 at 11 05 12 AM" src="https://user-images.githubusercontent.com/46794001/170528605-1bd5c024-9f19-48fc-934c-133b35fab27a.png">
<img width="1051" alt="Screen Shot 2022-05-26 at 11 09 12 AM" src="https://user-images.githubusercontent.com/46794001/170528614-89a2607a-0549-4396-89bd-e460aa093f2a.png">
<img width="1033" alt="Screen Shot 2022-05-26 at 11 09 15 AM" src="https://user-images.githubusercontent.com/46794001/170528616-3c399fea-2bce-49d3-9301-afe3b2854a2a.png">


