### PR TITLE
Strip oly_enc_id from query param URL.

### DIFF
--- a/packages/marko-web-p1-fii/browser/omeda-alchemer-form.vue
+++ b/packages/marko-web-p1-fii/browser/omeda-alchemer-form.vue
@@ -89,7 +89,13 @@ export default {
         });
         const json = await res.json();
         if (!res.ok) throw new Error(json.message);
-        return json.data.url;
+        const rootUrl = new URL(json.data.url);
+        const urlParams = new URLSearchParams(rootUrl.search);
+        const paramUrl = new URL(urlParams.get('url'));
+        const paramUrlParams = new URLSearchParams(paramUrl.search);
+        paramUrlParams.delete('oly_enc_id');
+        urlParams.set('url', String(paramUrl));
+        return String(rootUrl);
       } catch (e) {
         const { error } = console;
         this.error = e;

--- a/packages/marko-web-p1-fii/browser/omeda-alchemer-form.vue
+++ b/packages/marko-web-p1-fii/browser/omeda-alchemer-form.vue
@@ -94,8 +94,8 @@ export default {
         const paramUrl = new URL(urlParams.get('url'));
         const paramUrlParams = new URLSearchParams(paramUrl.search);
         paramUrlParams.delete('oly_enc_id');
-        urlParams.set('url', String(paramUrl));
-        return String(rootUrl);
+        urlParams.set('url', `${paramUrl}`);
+        return `${rootUrl}`;
       } catch (e) {
         const { error } = console;
         this.error = e;


### PR DESCRIPTION
This only happens on production in non-incognito windows, I can’t figure out a way of testing this without just putting it on production.

I seemed to recall something about this being done deliberately, however on production in an incognito window the query parameter is properly stripped so I don't entirely know what’s going on here.

(Screenshot from production where it is an issue)
<img width="1442" alt="Screen Shot 2022-05-27 at 12 19 27 PM" src="https://user-images.githubusercontent.com/46794001/170760243-0a884364-3535-4428-bccf-754c90539ef8.png">
