### PR TITLE
Allow zero values in `x1` and `y1` crop dimensions

### DIFF
--- a/packages/image/src/crop-rectangle.js
+++ b/packages/image/src/crop-rectangle.js
@@ -4,19 +4,21 @@ class CropRectangle {
     y,
     width,
     height,
+    cropped,
   } = {}) {
     this.x = x;
     this.y = y;
     this.width = width;
     this.height = height;
+    this.cropped = cropped;
   }
 
   isCropped() {
-    return !this.notCropped();
+    return this.cropped;
   }
 
   notCropped() {
-    return this.x === 0 && this.y === 0;
+    return !this.cropped;
   }
 
   toString() {
@@ -38,6 +40,7 @@ module.exports = ({ width, height, cropDimensions }) => {
       y: 0,
       width,
       height,
+      cropped: false,
     });
   }
   // @see Cygnus\ApplicationBundle\Apps\Management\Controller::cropImageAction
@@ -57,5 +60,6 @@ module.exports = ({ width, height, cropDimensions }) => {
     y: y1,
     width: x2 - x1,
     height: y2 - y1,
+    cropped: true,
   });
 };

--- a/services/graphql-server/src/graphql/definitions/platform/asset.js
+++ b/services/graphql-server/src/graphql/definitions/platform/asset.js
@@ -72,6 +72,7 @@ type AssetImageCropRectangle {
   y: Int!
   width: Int!
   height: Int!
+  cropped: Boolean!
 }
 
 type AssetImageCrop {

--- a/services/graphql-server/src/graphql/definitions/platform/asset.js
+++ b/services/graphql-server/src/graphql/definitions/platform/asset.js
@@ -72,7 +72,6 @@ type AssetImageCropRectangle {
   y: Int!
   width: Int!
   height: Int!
-  cropped: Boolean!
 }
 
 type AssetImageCrop {

--- a/services/graphql-server/src/graphql/resolvers/platform/asset.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/asset.js
@@ -27,12 +27,8 @@ module.exports = {
 
       // otherwise, process the image width/height and create the crop rectangle
       const { width, height } = await getImageDimensions({ image, host, basedb });
-      const rect = cropRectangle({
-        width,
-        height,
-        cropDimensions: image.cropDimensions,
-      });
-      const { fileName, filePath } = image;
+      const { fileName, filePath, cropDimensions } = image;
+      const rect = cropRectangle({ width, height, cropDimensions });
 
       // when a crop is detected, set the `rect` imgix property
       const opts = rect.isCropped() ? { ...input.options, rect } : input.options;


### PR DESCRIPTION
From Trello card description: 

"Currently the logic found within https://github.com/parameter1/base-cms/blob/master/packages/image/src/crop-rectangle.js results in if a crop rectangle has coordinates of ```x = 0``` and ```y = 0``` it determines that an image has not been cropped, by default x and y are set to x1 and y1 meaning that if x1 and y1 are both 0 it determines the image has not been cropped regardless of it cropDimensions are set on the image or not.

x1 and y1 of 0 and 0 respectively are perfectly valid so this needs to be corrected to perform some other sort of logic in order to determine whether or not an image has been cropped."


Corrected Item:

- GraphQL:
<img width="1920" alt="Screen Shot 2022-06-07 at 12 10 41 PM" src="https://user-images.githubusercontent.com/46794001/172444264-169502c1-5d34-4747-8082-f0e80dcc8677.png">

- MongoDB Asset Collection:
<img width="1920" alt="Screen Shot 2022-06-07 at 12 02 36 PM" src="https://user-images.githubusercontent.com/46794001/172444110-46adcaee-517b-4367-aa31-611dcdab2d8e.png">

- Logging GraphQL Server Response:
<img width="1792" alt="Screen Shot 2022-06-07 at 12 01 51 PM" src="https://user-images.githubusercontent.com/46794001/172444113-ae91988a-af4d-4b17-8b74-6ce9c201d0fe.png">

Unaffected Item:

- GraphQL:
<img width="1920" alt="Screen Shot 2022-06-07 at 12 10 48 PM" src="https://user-images.githubusercontent.com/46794001/172444095-a08181cd-101c-429d-86ed-7db3418f94a0.png">

- MongoDB Asset Collection:
<img width="1598" alt="Screen Shot 2022-06-07 at 12 17 26 PM" src="https://user-images.githubusercontent.com/46794001/172444371-9daaf77c-fa1b-4c25-b73e-25bb37d86891.png">

