### PR TITLE
Set default newsletter signup colors to grayscale

### DIFF
--- a/packages/marko-web-theme-monorail/scss/_variables.scss
+++ b/packages/marko-web-theme-monorail/scss/_variables.scss
@@ -76,8 +76,8 @@ $secondary: $gray-800 !default;
 $skin-primary-hover-color: darken($primary, 13%) !default;
 $skin-secondary-hover-color: $gray-900 !default;
 // Newsletter signup colors
-$skin-newsletter-signup-inline-btn-color: #103a57 !default;
-$skin-newsletter-signup-bg-color: #0d9dc9 !default;
+$skin-newsletter-signup-inline-btn-color: $gray-900 !default;
+$skin-newsletter-signup-bg-color: $gray-100 !default;
 
 // Ad background colors
 $skin-ad-bg-color: $gray-100 !default;


### PR DESCRIPTION
Set newsletter signup box bg to $gray-100(#f0f1f2) & btn-bg to $gray-900(#232325) by default.  The packages & sites using this package can override it if need be.
<img width="729" alt="Screen Shot 2022-06-07 at 1 39 37 PM" src="https://user-images.githubusercontent.com/3845869/172457918-7d8d50ed-4860-4829-9328-27115383b4f9.png">

