### PR TITLE
Compute aria-label for menu-toggle-button.

### DIFF
--- a/packages/marko-web-theme-monorail/browser/menu-toggle-button.vue
+++ b/packages/marko-web-theme-monorail/browser/menu-toggle-button.vue
@@ -104,7 +104,7 @@ export default {
     computedButtonLabel() {
       if (this.calcBefore) return this.calcBefore;
       if (this.calcAfter) return this.calcAfter;
-      return this.buttonLabel
+      return this.buttonLabel;
     },
     calcBefore() {
       const {

--- a/packages/marko-web-theme-monorail/browser/menu-toggle-button.vue
+++ b/packages/marko-web-theme-monorail/browser/menu-toggle-button.vue
@@ -2,7 +2,7 @@
   <button
     :class="className"
     type="button"
-    :aria-label="buttonLabel"
+    :aria-label="computedButtonLabel"
     @click="toggle"
   >
     <span v-if="calcBefore">
@@ -101,6 +101,11 @@ export default {
     expanded: false,
   }),
   computed: {
+    computedButtonLabel() {
+      if (this.calcBefore) return this.calcBefore;
+      if (this.calcAfter) return this.calcAfter;
+      return this.buttonLabel
+    },
     calcBefore() {
       const {
         before,


### PR DESCRIPTION
Currently the ```aria-label``` for the content meter is not reflective as to what visibly appears on the page thus it errors, this corrects it to use the same value in both placements when and where applicable.

![Dev-Menu-Toggle](https://user-images.githubusercontent.com/46794001/172708937-97ca1726-3297-4154-a511-e70e026047be.png)
![Prod-Menu-Toggle](https://user-images.githubusercontent.com/46794001/172708942-3e67881c-775a-40df-866d-f5a1d34f2580.png)

