### PR TITLE
Add menu `auto` open and additional icon styles

### DIFF
--- a/packages/leaders-program/src/components/containers/columns.vue
+++ b/packages/leaders-program/src/components/containers/columns.vue
@@ -28,7 +28,7 @@ export default {
     classes() {
       const col = 'leaders-col';
       const classes = [col];
-      if (this.number > 1) classes.push(`${col}--${this.number}`);
+      if (this.number > 1 && this.sections.length > 1) classes.push(`${col}--${this.number}`);
       return classes;
     },
     columns() {

--- a/packages/leaders-program/src/components/containers/section-wrapper.vue
+++ b/packages/leaders-program/src/components/containers/section-wrapper.vue
@@ -27,6 +27,7 @@
             :promotion-limit="promotionLimit"
             :video-limit="videoLimit"
             :featured-product-label="featuredProductLabel"
+            :icon-set="iconSet"
             @action="emitAction"
           />
         </leaders-columns>
@@ -51,6 +52,7 @@
         :offset-bottom="offsetBottom"
         :promotion-limit="promotionLimit"
         :video-limit="videoLimit"
+        :icon-set="iconSet"
         @action="emitAction"
       />
     </leaders-columns>
@@ -105,6 +107,10 @@ export default {
     videoLimit: {
       type: Number,
       default: 3,
+    },
+    iconSet: {
+      type: String,
+      default: null,
     },
     featuredProductLabel: {
       type: String,

--- a/packages/leaders-program/src/components/containers/section-wrapper.vue
+++ b/packages/leaders-program/src/components/containers/section-wrapper.vue
@@ -27,7 +27,7 @@
             :promotion-limit="promotionLimit"
             :video-limit="videoLimit"
             :featured-product-label="featuredProductLabel"
-            :icon-set="iconSet"
+            :icon-style="iconStyle"
             @action="emitAction"
           />
         </leaders-columns>
@@ -52,7 +52,7 @@
         :offset-bottom="offsetBottom"
         :promotion-limit="promotionLimit"
         :video-limit="videoLimit"
-        :icon-set="iconSet"
+        :icon-style="iconStyle"
         @action="emitAction"
       />
     </leaders-columns>
@@ -108,9 +108,10 @@ export default {
       type: Number,
       default: 3,
     },
-    iconSet: {
+    iconStyle: {
       type: String,
-      default: null,
+      default: 'plus-minus',
+      validator: v => ['plus-minus', 'chevron'].includes(v),
     },
     featuredProductLabel: {
       type: String,

--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -1,8 +1,18 @@
 <template>
   <div :class="classes" :data-section-id="sectionId">
     <button class="leaders-section__toggle-button" @click="toggleExpanded">
-      <plus-icon v-show="!isExpanded" :modifiers="iconModifiers" />
-      <minus-icon v-show="isExpanded" :modifiers="iconModifiers" />
+      <chevron-plus-icon
+        v-if="iconSet === 'chevron'"
+        v-show="!isExpanded"
+        :modifiers="iconModifiers"
+      />
+      <plus-icon v-else v-show="!isExpanded" :modifiers="iconModifiers" />
+      <chevron-minus-icon
+        v-if="iconSet === 'chevron'"
+        v-show="isExpanded"
+        :modifiers="iconModifiers"
+      />
+      <minus-icon v-else v-show="isExpanded" :modifiers="iconModifiers" />
       <span class="leaders-section__toggle-button-title">{{ title }}</span>
     </button>
     <div v-if="isExpanded" class="leaders-section__list">
@@ -48,6 +58,8 @@
 <script>
 import PlusIcon from '../icons/add-circle-outline.vue';
 import MinusIcon from '../icons/remove-circle-outline.vue';
+import ChevronPlusIcon from '../icons/chevron-right.vue';
+import ChevronMinusIcon from '../icons/chevron-down.vue';
 import Loading from '../common/loading.vue';
 
 import List from '../list/index.vue';
@@ -62,6 +74,8 @@ export default {
   components: {
     PlusIcon,
     MinusIcon,
+    ChevronPlusIcon,
+    ChevronMinusIcon,
     Loading,
     List,
     Card,
@@ -108,6 +122,10 @@ export default {
     featuredProductLabel: {
       type: String,
       default: 'Featured Products',
+    },
+    iconSet: {
+      type: String,
+      default: null,
     },
   },
 

--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -1,27 +1,8 @@
 <template>
   <div :class="classes" :data-section-id="sectionId">
-    <button
-      v-if="iconStyle === 'chevron'"
-      class="leaders-section__toggle-button"
-      @click="toggleExpanded"
-    >
-      <chevron-right-icon
-        v-show="!isExpanded"
-        :modifiers="iconModifiers"
-      />
-      <chevron-down-icon
-        v-show="isExpanded"
-        :modifiers="iconModifiers"
-      />
-      <span class="leaders-section__toggle-button-title">{{ title }}</span>
-    </button>
-    <button
-      v-else
-      class="leaders-section__toggle-button"
-      @click="toggleExpanded"
-    >
-      <plus-icon v-show="!isExpanded" :modifiers="iconModifiers" />
-      <minus-icon v-show="isExpanded" :modifiers="iconModifiers" />
+    <button class="leaders-section__toggle-button"  @click="toggleExpanded">
+      <component :is="collapsedIcon" v-show="!isExpanded" :modifiers="iconModifiers" />
+      <component :is="expandedIcon" v-show="isExpanded" :modifiers="iconModifiers" />
       <span class="leaders-section__toggle-button-title">{{ title }}</span>
     </button>
     <div v-if="isExpanded" class="leaders-section__list">
@@ -165,6 +146,14 @@ export default {
     },
     hasChildren() {
       return Boolean(this.children.length);
+    },
+    expandedIcon() {
+      if (this.iconStyle === 'chevron') return ChevronDownIcon;
+      return MinusIcon;
+    },
+    collapsedIcon() {
+      if (this.iconStyle === 'chevron') return ChevronRightIcon;
+      return PlusIcon;
     },
   },
 

--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -1,18 +1,27 @@
 <template>
   <div :class="classes" :data-section-id="sectionId">
-    <button class="leaders-section__toggle-button" @click="toggleExpanded">
-      <chevron-plus-icon
-        v-if="iconSet === 'chevron'"
+    <button
+      v-if="iconStyle === 'chevron'"
+      class="leaders-section__toggle-button"
+      @click="toggleExpanded"
+    >
+      <chevron-right-icon
         v-show="!isExpanded"
         :modifiers="iconModifiers"
       />
-      <plus-icon v-else v-show="!isExpanded" :modifiers="iconModifiers" />
-      <chevron-minus-icon
-        v-if="iconSet === 'chevron'"
+      <chevron-down-icon
         v-show="isExpanded"
         :modifiers="iconModifiers"
       />
-      <minus-icon v-else v-show="isExpanded" :modifiers="iconModifiers" />
+      <span class="leaders-section__toggle-button-title">{{ title }}</span>
+    </button>
+    <button
+      v-else
+      class="leaders-section__toggle-button"
+      @click="toggleExpanded"
+    >
+      <plus-icon v-show="!isExpanded" :modifiers="iconModifiers" />
+      <minus-icon v-show="isExpanded" :modifiers="iconModifiers" />
       <span class="leaders-section__toggle-button-title">{{ title }}</span>
     </button>
     <div v-if="isExpanded" class="leaders-section__list">
@@ -58,8 +67,8 @@
 <script>
 import PlusIcon from '../icons/add-circle-outline.vue';
 import MinusIcon from '../icons/remove-circle-outline.vue';
-import ChevronPlusIcon from '../icons/chevron-right.vue';
-import ChevronMinusIcon from '../icons/chevron-down.vue';
+import ChevronRightIcon from '../icons/chevron-right.vue';
+import ChevronDownIcon from '../icons/chevron-down.vue';
 import Loading from '../common/loading.vue';
 
 import List from '../list/index.vue';
@@ -74,8 +83,8 @@ export default {
   components: {
     PlusIcon,
     MinusIcon,
-    ChevronPlusIcon,
-    ChevronMinusIcon,
+    ChevronRightIcon,
+    ChevronDownIcon,
     Loading,
     List,
     Card,
@@ -123,9 +132,10 @@ export default {
       type: String,
       default: 'Featured Products',
     },
-    iconSet: {
+    iconStyle: {
       type: String,
-      default: null,
+      default: 'plus-minus',
+      validator: v => ['plus-minus', 'chevron'].includes(v),
     },
   },
 

--- a/packages/leaders-program/src/components/icons/chevron-down.vue
+++ b/packages/leaders-program/src/components/icons/chevron-down.vue
@@ -1,0 +1,31 @@
+
+<template>
+  <icon-wrapper
+    name="chevron-down"
+    :tag="tag"
+    :modifiers="modifiers"
+  >
+    <!-- eslint-disable-next-line -->
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6l-5 5z" />
+    </svg>
+  </icon-wrapper>
+</template>
+
+<script>
+import IconWrapper from './_wrapper.vue';
+
+export default {
+  components: { IconWrapper },
+  props: {
+    modifiers: {
+      type: Array,
+      default: () => [],
+    },
+    tag: {
+      type: String,
+      default: 'span',
+    },
+  },
+};
+</script>

--- a/packages/leaders-program/src/components/icons/chevron-right.vue
+++ b/packages/leaders-program/src/components/icons/chevron-right.vue
@@ -1,0 +1,31 @@
+
+<template>
+  <icon-wrapper
+    name="chevron-right"
+    :tag="tag"
+    :modifiers="modifiers"
+  >
+    <!-- eslint-disable-next-line -->
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path fill-rule="evenodd" d="M7.5 8l-5 5L1 11.5 4.75 8 1 4.5 2.5 3l5 5z" />
+    </svg>
+  </icon-wrapper>
+</template>
+
+<script>
+import IconWrapper from './_wrapper.vue';
+
+export default {
+  components: { IconWrapper },
+  props: {
+    modifiers: {
+      type: Array,
+      default: () => [],
+    },
+    tag: {
+      type: String,
+      default: 'span',
+    },
+  },
+};
+</script>

--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -34,7 +34,7 @@
         :promotion-limit="promotionLimit"
         :video-limit="videoLimit"
         :featured-product-label="featuredProductLabel"
-        :icon-set="iconSet"
+        :icon-style="iconStyle"
         @action="emitAction"
       />
     </div>
@@ -168,9 +168,10 @@ export default {
       type: String,
       default: 'Featured Products',
     },
-    iconSet: {
+    iconStyle: {
       type: String,
-      default: null,
+      default: 'plus-minus',
+      validator: v => ['plus-minus', 'chevron'].includes(v),
     },
   },
 

--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -1,6 +1,12 @@
 <template>
   <div :class="classes" :data-taxonomy-ids="taxonomyIds.join(',') || null">
+    <div v-if="title" class="leaders__header">
+      <div class="leaders__header-title">
+        {{ title }}
+      </div>
+    </div>
     <leaders-header
+      v-else
       :display="getResponsiveValue('displayHeader')"
       :img-src="headerImgSrc"
       :img-alt="headerImgAlt"
@@ -28,11 +34,12 @@
         :promotion-limit="promotionLimit"
         :video-limit="videoLimit"
         :featured-product-label="featuredProductLabel"
+        :icon-set="iconSet"
         @action="emitAction"
       />
     </div>
     <div v-if="viewAll" class="leaders__footer">
-      <a :href="viewAll" v-html="viewAllText" />
+      <a class="btn btn-primary" :href="viewAll" v-html="viewAllText" />
     </div>
   </div>
 </template>
@@ -129,6 +136,10 @@ export default {
       type: String,
       default: 'leading suppliers',
     },
+    title: {
+      type: String,
+      default: null,
+    },
     offsetTop: {
       type: Number,
       default: 0,
@@ -156,6 +167,10 @@ export default {
     featuredProductLabel: {
       type: String,
       default: 'Featured Products',
+    },
+    iconSet: {
+      type: String,
+      default: null,
     },
   },
 

--- a/packages/leaders-program/src/components/list/dropdown.vue
+++ b/packages/leaders-program/src/components/list/dropdown.vue
@@ -26,8 +26,8 @@ export default {
     },
     open: {
       type: String,
-      default: 'below',
-      validator: v => ['above', 'below', 'left', 'right'].includes(v),
+      default: 'auto',
+      validator: v => ['above', 'below', 'left', 'right', 'auto'].includes(v),
     },
   },
 

--- a/packages/leaders-program/src/components/list/index.vue
+++ b/packages/leaders-program/src/components/list/index.vue
@@ -281,7 +281,7 @@ export default {
 
       const { open } = this;
       if (open === 'auto') {
-        this.getAutoOpenDirection(content, linkRect);
+        this.openDirection = this.getAutoOpenDirection(content, linkRect);
       } else {
         this.openDirection = open;
       }
@@ -328,11 +328,8 @@ export default {
       // Left:
       // ContentWidth + 30px can not exceed link's left position
       const canOpenLeft = shouldOpen === 'left' && (linkRect.left - content.getBoundingClientRect().width) >= 30;
-      if (canOpenRight || canOpenLeft) {
-        this.openDirection = shouldOpen;
-      } else {
-        this.openDirection = 'below';
-      }
+      if (canOpenRight || canOpenLeft) return shouldOpen;
+      return 'below';
     },
 
     closeDropdown() {

--- a/packages/leaders-program/src/components/list/index.vue
+++ b/packages/leaders-program/src/components/list/index.vue
@@ -62,7 +62,7 @@
 import { get } from 'object-path';
 import { MountingPortal } from 'portal-vue';
 
-import { buildFlags } from '../utils/link-tracking';
+import { buildFlags } from '../../utils/link-tracking';
 import ElementCalculus from './element-calculus';
 import ArrowPosition from './positions/arrow-position';
 import MenuPosition from './positions/menu-position';

--- a/packages/leaders-program/src/components/list/index.vue
+++ b/packages/leaders-program/src/components/list/index.vue
@@ -321,7 +321,7 @@ export default {
     getAutoOpenDirection(content, linkRect) {
       const avaiableRight = window.innerWidth - linkRect.right;
       const shouldOpen = (avaiableRight >= window.innerWidth / 2) ? 'right' : 'left';
-      // Check there is enought space to open the content left/right or push below
+      // Check there is enough space to open the content left/right or push below
       // Right:
       // ContentWidth + Link's Right Position can not exceed avaiable window width
       const canOpenRight = shouldOpen === 'right' && (content.getBoundingClientRect().width + linkRect.right) < window.innerWidth + 30;

--- a/packages/leaders-program/src/components/list/positions/menu-position.js
+++ b/packages/leaders-program/src/components/list/positions/menu-position.js
@@ -16,7 +16,7 @@ class MenuPosition extends AbstractPosition {
     const { calculus: calcs } = this;
     const { pageXOffset } = window;
     if (this.opensAbove || this.opensBelow) {
-      // Determin if the card will display off screen and adjust posiiton accordinly
+      // Determin if the card will display off screen and adjust position accordingly
       // If negative it add the negative offset to the left position to ensure it is not off screen
       const cardOffset = window.innerWidth - (calcs.link('left') + (calcs.link('halfW') + calcs.menu('halfW'))) < 0
         ? window.innerWidth - (calcs.link('left') + (calcs.link('halfW') + calcs.menu('halfW')))

--- a/packages/leaders-program/src/components/list/positions/menu-position.js
+++ b/packages/leaders-program/src/components/list/positions/menu-position.js
@@ -15,9 +15,17 @@ class MenuPosition extends AbstractPosition {
   get x() {
     const { calculus: calcs } = this;
     const { pageXOffset } = window;
-    if (this.opensAbove || this.opensBelow) return pageXOffset + calcs.link('left') + calcs.link('halfW') - calcs.menu('halfW');
-    if (this.opensLeft) return pageXOffset + calcs.link('left') - calcs.arrow('w') - calcs.menu('w');
-    return pageXOffset + calcs.link('right') + calcs.arrow('w');
+    if (this.opensAbove || this.opensBelow) {
+      return ((pageXOffset + calcs.link('left') + calcs.link('halfW') - calcs.menu('halfW')) > 0)
+        ? pageXOffset + calcs.link('left') + calcs.link('halfW') - calcs.menu('halfW')
+        : 0;
+    }
+    if (this.opensLeft) {
+      return ((pageXOffset + calcs.link('left') - calcs.arrow('w') - calcs.menu('w')) > 0)
+        ? pageXOffset + calcs.link('left') - calcs.arrow('w') - calcs.menu('w')
+        : 0;
+    }
+    return ((pageXOffset + calcs.link('right') + calcs.arrow('w')) > 0) ? pageXOffset + calcs.link('right') + calcs.arrow('w') : 0;
   }
 
   get y() {

--- a/packages/leaders-program/src/components/list/positions/menu-position.js
+++ b/packages/leaders-program/src/components/list/positions/menu-position.js
@@ -16,8 +16,13 @@ class MenuPosition extends AbstractPosition {
     const { calculus: calcs } = this;
     const { pageXOffset } = window;
     if (this.opensAbove || this.opensBelow) {
+      // Determin if the card will display off screen and adjust posiiton accordinly
+      // If negative it add the negative offset to the left position to ensure it is not off screen
+      const cardOffset = window.innerWidth - (calcs.link('left') + (calcs.link('halfW') + calcs.menu('halfW'))) < 0
+        ? window.innerWidth - (calcs.link('left') + (calcs.link('halfW') + calcs.menu('halfW')))
+        : 0;
       return ((pageXOffset + calcs.link('left') + calcs.link('halfW') - calcs.menu('halfW')) > 0)
-        ? pageXOffset + calcs.link('left') + calcs.link('halfW') - calcs.menu('halfW')
+        ? pageXOffset + calcs.link('left') + calcs.link('halfW') - calcs.menu('halfW') + cardOffset
         : 0;
     }
     if (this.opensLeft) {

--- a/packages/leaders-program/src/scss/_variables.scss
+++ b/packages/leaders-program/src/scss/_variables.scss
@@ -13,7 +13,7 @@ $leaders-gray-5: #f0f0f0 !default;
 
 // Base Styles
 $leaders-base-color: $leaders-black !default;
-$leaders-base-font-family: "IBM Plex Sans", sans-serif !default;
+$leaders-base-font-family: "Open Sans", sans-serif !default;
 $leaders-base-font-size: 16px !default;
 $leaders-base-font-weight: 400 !default;
 $leaders-base-line-height: 1.5 !default;

--- a/packages/leaders-program/src/scss/components/_card.scss
+++ b/packages/leaders-program/src/scss/components/_card.scss
@@ -6,7 +6,7 @@
   max-width: leaders-card-width();
   word-wrap: break-word;
   background-clip: border-box;
-  // On mobile set max width to veiwport
+  // On mobile set max width to viewport
   @media (max-width: 600px) {
     max-width: 100vw;
   }

--- a/packages/leaders-program/src/scss/components/_card.scss
+++ b/packages/leaders-program/src/scss/components/_card.scss
@@ -6,6 +6,10 @@
   max-width: leaders-card-width();
   word-wrap: break-word;
   background-clip: border-box;
+  // On mobile set max width to veiwport
+  @media (max-width: 600px) {
+    max-width: 100vw;
+  }
 
   &__header {
     display: flex;

--- a/packages/leaders-program/src/scss/components/_content-deck.scss
+++ b/packages/leaders-program/src/scss/components/_content-deck.scss
@@ -16,6 +16,7 @@
   &__body {
     display: flex;
     flex-direction: row;
+    overflow-y: scroll;
   }
 
   &__item {

--- a/packages/leaders-program/src/scss/components/_content-deck.scss
+++ b/packages/leaders-program/src/scss/components/_content-deck.scss
@@ -16,7 +16,7 @@
   &__body {
     display: flex;
     flex-direction: row;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   &__item {

--- a/packages/leaders-program/src/scss/components/_grid.scss
+++ b/packages/leaders-program/src/scss/components/_grid.scss
@@ -1,8 +1,6 @@
 .leaders-row {
   display: flex;
   flex-wrap: wrap;
-  margin-right: -$leaders-gutter-size;
-  margin-left: -$leaders-gutter-size;
 }
 
 .leaders-col {

--- a/packages/leaders-program/src/scss/components/_section.scss
+++ b/packages/leaders-program/src/scss/components/_section.scss
@@ -59,10 +59,8 @@
         font-size: $leaders-parent-section-content-title-font-size;
         font-weight: $leaders-parent-section-content-title-font-weight;
         line-height: $leaders-parent-section-content-title-line-height;
-        // color: $leaders-parent-section-content-title-color;
         color: $black;
         text-transform: $leaders-parent-section-content-title-transform;
-        // border-bottom: 1px solid $leaders-parent-section-content-title-border-color;
       }
     }
   }

--- a/packages/leaders-program/src/scss/components/_section.scss
+++ b/packages/leaders-program/src/scss/components/_section.scss
@@ -8,8 +8,10 @@
 
   &__toggle-button {
     display: inline-flex;
-    flex-direction: row;
-    padding: 0;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+    width: 100%;
+    padding: .5rem;
     margin: 0;
     font-size: $leaders-nav-link-font-size;
     font-weight: $leaders-nav-link-font-weight;
@@ -20,7 +22,7 @@
     text-transform: none;
     cursor: pointer;
     user-select: none;
-    background: none;
+    background-color: #fff;
     border: none;
     outline: none;
     -webkit-tap-highlight-color: transparent;
@@ -50,15 +52,17 @@
   &--with-parent {
     #{ $section } {
       &__title {
+        padding: 0 1rem .5rem;
         margin-right: -$leaders-body-padding-x;
         margin-bottom: 6px;
         margin-left: -$leaders-body-padding-x;
         font-size: $leaders-parent-section-content-title-font-size;
         font-weight: $leaders-parent-section-content-title-font-weight;
         line-height: $leaders-parent-section-content-title-line-height;
-        color: $leaders-parent-section-content-title-color;
+        // color: $leaders-parent-section-content-title-color;
+        color: $black;
         text-transform: $leaders-parent-section-content-title-transform;
-        border-bottom: 1px solid $leaders-parent-section-content-title-border-color;
+        // border-bottom: 1px solid $leaders-parent-section-content-title-border-color;
       }
     }
   }

--- a/packages/leaders-program/src/scss/leaders.scss
+++ b/packages/leaders-program/src/scss/leaders.scss
@@ -3,6 +3,8 @@
 @import "mixins";
 @import "components";
 
+$leaders-nav-link-width: 100%;
+$leaders-nav-link-max-width: $leaders-nav-link-width;
 // In order to use the default fonts, include the line below in the website CSS.
 // @import url("https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500,600,700&display=swap");
 
@@ -11,12 +13,16 @@
 
   &__body {
     padding: $leaders-body-padding-y $leaders-body-padding-x;
+    background-color: #f1f1f1;
     border-bottom: 2px solid $leaders-gray-5;
   }
 
   &__header {
     display: flex;
     flex-direction: row;
+    @media (max-width: 700px) {
+      flex-direction: column;
+    }
     width: 100%;
     padding: $leaders-header-padding;
     font-weight: $leaders-header-font-weight;
@@ -47,16 +53,6 @@
   &__footer {
     padding: $leaders-footer-padding-y $leaders-footer-padding-x;
     text-align: center;
-    border-bottom: 2px solid $leaders-gray-5;
-    > a {
-      font-size: $leaders-nav-link-font-size;
-      font-weight: $leaders-nav-link-font-weight;
-      line-height: $leaders-nav-link-line-height;
-      color: $leaders-nav-link-color;
-      &:hover {
-        color: $leaders-nav-link-color;
-      }
-    }
   }
 }
 
@@ -68,4 +64,6 @@
 
 .leaders-list {
   width: 100%;
+  background: #fff;
+  border-top: solid $leaders-nav-link-color 2px;
 }


### PR DESCRIPTION
This ports the new style & flyout logic from the update version setup within pmmi's theme-monorail-leaders packages.  This port will allow us to use the current version of base-cms leaders while applying the new style & flyout direction logic.  It also adds support for flyouts on mobile.  

They card flyout will not account for available space and position on page to ensure it doesn't exceed the width of the window and that the card doesn't display off screen.

This will also allow us to update both default and monorail themes

Comparison(prod || defaultThemeDev || MonoRailDev
<img width="2970" alt="Screen Shot 2022-06-09 at 9 32 50 AM" src="https://user-images.githubusercontent.com/3845869/172872833-60096c6b-7bc9-42cd-89fe-d0aeb78e805f.png">

<img width="2524" alt="Screen Shot 2022-06-09 at 9 34 56 AM" src="https://user-images.githubusercontent.com/3845869/172873476-27ff61d9-d65d-421e-a29b-85f773b435e7.png">
<img width="2955" alt="Screen Shot 2022-06-09 at 9 36 06 AM" src="https://user-images.githubusercontent.com/3845869/172873516-9ce42e1d-1c39-4f00-8c4e-ca4111bade8e.png">


