### PR TITLE
Adjust inline newsletter box

### DIFF
--- a/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
@@ -170,7 +170,7 @@
     font-size: 18px;
     font-weight: 700;
     line-height: 1;
-    color: #fff;
+    color: $gray-800;
     background-color: $skin-newsletter-signup-bg-color;
 
     @include media-breakpoint-up(md) {
@@ -189,7 +189,7 @@
     svg {
       width: 20px;
       height: 20px;
-      fill: #fff;
+      fill: $gray-800;
     }
   }
 

--- a/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
@@ -149,6 +149,9 @@
 
 .complete-newsletter-signup {
   $self: &;
+  max-width: 652px;
+  margin-right: auto;
+  margin-left: auto;
 
   &__slide-out {
     animation-name: slideOutUpAndFade;
@@ -360,13 +363,16 @@
 
 .inline-newsletter-form {
   margin-bottom: 24px;
+  background-color: $skin-newsletter-signup-bg-color;
 }
 
 .inline-newsletter-form-step1 {
   display: flex;
   align-items: center;
   padding: 22px 16px;
-  background-color: $skin-newsletter-signup-bg-color;
+  margin-right: auto;
+  margin-left: auto;
+  max-width: 652px;
   border-radius: 4px;
 
   &__left-col {


### PR DESCRIPTION
Add support for the inline newsletter signup box to be called on section pages & to span full width.  This changes moves the background color to the wrapping inline element form with the form having a max width of 652px & margin left/right auto. This will force the form to appear aligned centered.  
<img width="1056" alt="Screen Shot 2022-06-14 at 10 38 26 AM" src="https://user-images.githubusercontent.com/3845869/173620302-babf915e-ef02-4e43-894a-9f460f8cd835.png">
<img width="1100" alt="Screen Shot 2022-06-14 at 10 38 35 AM" src="https://user-images.githubusercontent.com/3845869/173620314-2c0bc8b0-f503-493e-b01f-b8ccab3a8db5.png">
<img width="1124" alt="Screen Shot 2022-06-14 at 10 38 45 AM" src="https://user-images.githubusercontent.com/3845869/173620318-852d32f1-c95d-4b48-bdff-7d80e79e2a9a.png">
<img width="898" alt="Screen Shot 2022-06-14 at 10 38 57 AM" src="https://user-images.githubusercontent.com/3845869/173620322-f435185c-be22-43b9-b26c-cac76a5a452f.png">

