### PR TITLE
Add with-native-x-section support to list flow

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/latest-content-list.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/latest-content-list.marko
@@ -4,6 +4,7 @@ import queryFragment from "../../graphql/fragments/content-list";
 $ const modifiers = ["latest-content-list"];
 $ const title = defaultValue(input.title, 'Latest in');
 $ const withSection = defaultValue(input.withSection, false);
+$ const withNativeXSection = defaultValue(input.withNativeXSection, true);
 
 <if(input.nodes && input.nodes.length)>
   <theme-content-list-flow
@@ -11,6 +12,7 @@ $ const withSection = defaultValue(input.withSection, false);
     inner-justified=false
     native-x=input.nativeX
     modifiers=modifiers
+    with-native-x-section=withNativeXSection
   >
     <@header>${title}</@header>
     <@node with-teaser=false image-position="right" with-section=withSection >
@@ -35,6 +37,7 @@ $ const withSection = defaultValue(input.withSection, false);
     inner-justified=false
     native-x=input.nativeX
     modifiers=modifiers
+    with-native-x-section=withNativeXSection
   >
     <@header>${title}</@header>
     <@node with-teaser=false image-position="right" with-section=withSection >

--- a/packages/marko-web-theme-monorail/components/blocks/marko.json
+++ b/packages/marko-web-theme-monorail/components/blocks/marko.json
@@ -33,6 +33,7 @@
       "@name": "string",
       "@aliases": "array"
     },
+    "@with-native-x-section": "boolean",
     "@nodes": "array",
     "@title": "string",
     "@alias": "string",

--- a/packages/marko-web-theme-monorail/components/flows/content/list.marko
+++ b/packages/marko-web-theme-monorail/components/flows/content/list.marko
@@ -4,7 +4,12 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const { nativeX: nxConfig } = out.global;
 $ const nodes = getAsArray(input, "nodes");
 $ const nativeX = getAsObject(input, "nativeX");
-
+$ const withNativeXSection = defaultValue(input.withNativeXSection, true);
+$ const setWithSection = (node, nxNode, withNativeXSection = true) => {
+  if (node.withSection) return true;
+  if (!withNativeXSection) return false
+  return node.id !== nxNode.id;
+};
 <marko-web-node-list
   inner-justified=defaultValue(input.innerJustified, true)
   class=input.class
@@ -27,6 +32,7 @@ $ const nativeX = getAsObject(input, "nativeX");
         >
           <theme-content-node
             ...input.node
+            with-section=setWithSection(node, nxNode, withNativeXSection)
             node=nxNode
             attrs=containerAttrs
             link-attrs=linkAttrs

--- a/packages/marko-web-theme-monorail/components/flows/content/marko.json
+++ b/packages/marko-web-theme-monorail/components/flows/content/marko.json
@@ -14,6 +14,7 @@
       "@name": "string",
       "@aliases": "array"
     },
+    "@with-native-x-section": "boolean",
     "@nodes": "array",
     "@inner-justified": "boolean",
     "@flush-x": "boolean",


### PR DESCRIPTION
 - Add new with-native-x-section prop to list flow
 — New prop is used in conjunction with withSection, node.id & nxNode.id to determine if it should display the section tag(Sponsored) even when withSection is false.
 - Add pass through support from the latest-content-list block

<img width="1086" alt="Screen Shot 2022-06-15 at 2 35 08 PM" src="https://user-images.githubusercontent.com/3845869/173909877-19991b3f-6af8-464d-99bb-8693513ee9a3.png">

