### PR TITLE
Support loading leaders sections by related ids

### DIFF
--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -77,6 +77,10 @@ export default {
       type: Array,
       default: () => ([]),
     },
+    relatedSectionIds: {
+      type: Array,
+      default: () => ([]),
+    },
     open: {
       type: String,
       default: 'left',
@@ -267,7 +271,8 @@ export default {
     },
 
     async loadSections() {
-      const { sectionIds } = this;
+      const { sectionIds, relatedSectionIds } = this;
+      // Look up leadership sections by ID
       if (sectionIds && sectionIds.length) {
         const variables = { sectionIds };
         const r = await this.$graphql.query({ query: fromIdsQuery, variables });
@@ -275,6 +280,15 @@ export default {
           .filter(s => s.hierarchy.some(({ alias }) => alias === this.sectionAlias));
         if (sections.length) return sections;
       }
+      // Look up leadership sections by related IDs
+      if (relatedSectionIds && relatedSectionIds.length) {
+        const variables = { relatedSectionIds, taxonomyIds: [] };
+        const r = await this.$graphql.query({ query: fromContentQuery, variables });
+        const sections = getEdgeNodes(r, 'data.websiteSections')
+          .filter(s => s.hierarchy.some(({ alias }) => alias === this.sectionAlias));
+        if (sections.length) return sections;
+      }
+      // Look up leadership sections by content taxonomy, scheduling, and primary section
       const fromContent = await this.loadContentSections();
       if (fromContent.length) {
         this.loadType = 'contextual';

--- a/services/example-website/graphql/fragments/website-section-page.js
+++ b/services/example-website/graphql/fragments/website-section-page.js
@@ -1,0 +1,15 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment WebsiteSectionPageFragment on WebsiteSection {
+  id
+  name
+  description
+  hierarchy {
+    id
+    alias
+    name
+  }
+  descendantIds
+}
+`;

--- a/services/example-website/server/components/document.marko
+++ b/services/example-website/server/components/document.marko
@@ -53,6 +53,7 @@
       <theme-site-newsletter-menu />
       <${input.belowNav} />
     </marko-web-block>
+    <marko-web-leaders-dropdown-portal />
 
     <${input.aboveContainer} />
   </@above-container>

--- a/services/example-website/server/routes/index.js
+++ b/services/example-website/server/routes/index.js
@@ -1,8 +1,12 @@
-const { withContent } = require('@parameter1/base-cms-marko-web/middleware');
+const { withContent, withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 
-const content = require('../templates/content');
-const queryFragment = require('../../graphql/fragments/content-page');
 const index = require('../templates/index');
+const content = require('../templates/content');
+const section = require('../templates/section');
+const leaders = require('../templates/leaders');
+
+const queryFragment = require('../../graphql/fragments/content-page');
+const sectionFragment = require('../../graphql/fragments/website-section-page');
 
 module.exports = (app) => {
   app.get('/', (_, res) => {
@@ -11,5 +15,13 @@ module.exports = (app) => {
   app.get('/*?:id(\\d{8})*', withContent({
     template: content,
     queryFragment,
+  }));
+  app.get('/:alias(leaders)', withWebsiteSection({
+    template: leaders,
+    queryFragment: sectionFragment,
+  }));
+  app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
+    template: section,
+    queryFragment: sectionFragment,
   }));
 };

--- a/services/example-website/server/templates/content.marko
+++ b/services/example-website/server/templates/content.marko
@@ -1,27 +1,36 @@
 $ const { id, type, pageNode } = data;
 $ const { recaptcha } = out.global;
 
-<marko-web-default-page-layout
-  type="test"
-  title="Test Page"
-  description="This is a test page."
->
-  <@above-container>
-    <marko-web-leaders-dropdown-portal />
-  </@above-container>
+<marko-web-content-page-layout id=id type=type>
   <@page>
     <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
-      <h1>Company Page Inquiry</h1>
-      <!-- $ console.log(content); -->
+      <default-theme-website-section-breadcrumbs section=content.primarySection />
+      <marko-web-content-name obj=content tag="h1" />
+      <marko-web-content-teaser obj=content class="lead" />
 
-      <marko-web-node-list collapsible=false>
-        <@header>Request More Information</@header>
-        <@body>
-          <marko-web-inquiry-form content=content with-header=false modifiers=["node-list"] />
-        </@body>
-      </marko-web-node-list>
+      <div class="row mt-3">
+        <if(content.company)>
+          <div class="col-md-8">
+            <marko-web-content-body obj=content />
+          </div>
+          <div class="col-md-4">
+            <marko-web-node-list collapsible=false>
+              <@header>Request More Information</@header>
+              <@body>
+                <marko-web-inquiry-form content=content with-header=false modifiers=["node-list"] />
+              </@body>
+            </marko-web-node-list>
+          </div>
+        </if>
+        <else>
+          <div class="col">
+            <marko-web-content-body obj=content />
+          </div>
+        </else>
+      </div>
     </marko-web-resolve-page>
 
+    <h2>Contact Us</h2>
     <marko-web-browser-component name="ContactUsForm" props={ siteKey: recaptcha.siteKey, configName: 'general' } />
   </@page>
-</marko-web-default-page-layout>
+</marko-web-content-page-layout>

--- a/services/example-website/server/templates/index.marko
+++ b/services/example-website/server/templates/index.marko
@@ -3,9 +3,6 @@
   title="Test Page"
   description="This is a test page."
 >
-  <@above-container>
-    <marko-web-leaders-dropdown-portal />
-  </@above-container>
   <@page>
     <h1>Hello World!</h1>
     <style>
@@ -27,7 +24,7 @@
     />
 
     <marko-web-leaders props={
-      sectionAlias: "leaders-2022",
+      sectionAlias: "leaders/2022",
       open: null,
       expanded: false,
       headerImgAlt: "leaders",

--- a/services/example-website/server/templates/leaders.marko
+++ b/services/example-website/server/templates/leaders.marko
@@ -1,0 +1,36 @@
+$ const { id, alias, name, pageNode } = data;
+$ const { config } = out.global;
+
+<marko-web-website-section-page-layout id=id alias=alias name=name>
+  <@page>
+    <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
+
+      <default-theme-website-section-breadcrumbs section=section />
+      <h1>${section.name}</h1>
+
+      <div class="row">
+        <div class="col">
+          <p>Welcome to <em>${config.siteName()}'s</em> Leadership Program.</p>
+
+          <marko-web-leaders props={
+            sectionAlias: "leaders/2022",
+            open: null,
+            expanded: true,
+            contextual: true,
+            displayHeader: false,
+            columns: 3,
+            offsetTop: 50,
+            displayViewAll: false,
+            mediaQueries: [
+              { prop: "columns", value: 2, query: "(max-width: 991px)" },
+              { prop: "columns", value: 1, query: "(max-width: 700px)" },
+            ],
+            calloutPrefix: "Browse these",
+            calloutValue: "leading suppliers",
+          }/>
+        </div>
+      </div>
+    </marko-web-resolve-page>
+
+  </@page>
+</marko-web-website-section-page-layout>

--- a/services/example-website/server/templates/section.marko
+++ b/services/example-website/server/templates/section.marko
@@ -1,0 +1,38 @@
+$ const { id, alias, name, pageNode } = data;
+$ const { recaptcha } = out.global;
+
+<marko-web-website-section-page-layout id=id alias=alias name=name>
+  <@page>
+    <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
+
+      <default-theme-website-section-breadcrumbs section=section />
+      <h1>${section.name}</h1>
+
+      <div class="row">
+        <div class="col-md-4">
+          <div class="p-4 bg-light">
+            <h3>Ինչո՞ւ ենք այն</h3>
+            <p class="muted">Հայտնի է, որ ընթերցողը, կարդալով հասկանալի տեքստ, չի կարողանա կենտրոնանալ տեքստի ձևավորման օգտագործում</p>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="p-4 bg-light">
+            <h3>օգտագործում</h3>
+            <p class="muted">Lorem Ipsum օգտագործելը բացատրվում է նրանով, որ այն բաշխում է բառերը քիչ թե շատ իրականի նման վրա բաշխում է</p>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <marko-web-leaders props={
+            sectionAlias: "leaders/2022",
+            relatedSectionIds: section.descendantIds,
+            open: "left",
+            viewAllHref: "/leaders",
+            useContentPrimarySection: true,
+            columns: 1,
+          } />
+        </div>
+      </div>
+    </marko-web-resolve-page>
+
+  </@page>
+</marko-web-website-section-page-layout>

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -62,6 +62,7 @@ type WebsiteSection {
   description: String @projection
   fullName: String @projection
   labels: [String]! @projection @arrayValue
+  descendantIds: [Int]! @projection @arrayValue
 
   # fields from trait.platform::StatusEnabled
   status: Int @projection


### PR DESCRIPTION
Supports querying for leaders sections by related ids directly (for section context)
<img width="1331" alt="image" src="https://user-images.githubusercontent.com/1778222/174153294-8fbaf186-255f-4bcc-bc95-c48b74184f37.png">
<img width="1318" alt="image" src="https://user-images.githubusercontent.com/1778222/174153112-2d10910b-7bd0-470f-865c-a6f06bc13e4c.png">
<img width="1329" alt="image" src="https://user-images.githubusercontent.com/1778222/174153164-218bf605-5684-44c6-a167-bbd828e4dd86.png">

When no sections could be found by related ids, the normal/full set is returned
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/1778222/174153523-e7f7ca48-fa52-4f88-adcb-a972728c62be.png">
