### PR TITLE
Retrieve/modify website section related ids

### DIFF
--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -78,6 +78,9 @@ type WebsiteSection {
   "Website sections that are directly related to this section. Primarily used for Leaders Program context mapping."
   relatedSections(input: WebsiteSectionRelatedSectionsInput = {}): WebsiteSectionConnection! @projection @refMany(model: "website.Section")
   relatedSectionIds: [Int]! @projection(localField: "relatedSections")
+  "Taxonomy items that are directly related to this section. Primarily used for Leaders Program context mapping."
+  relatedTaxonomy(input: WebsiteSectionRelatedTaxonomyInput = {}): TaxonomyConnection! @projection @refMany(model: "platform.Taxonomy", using: { type: "type" })
+  relatedTaxonomyIds: [Int]! @projection(localField: "relatedTaxonomy")
 
   # fields from trait.platform::Content\SeoFields
 
@@ -203,6 +206,11 @@ input WebsiteSectionChildrenInput {
 input WebsiteSectionRelatedSectionsInput {
   status: ModelStatus = active
   sort: WebsiteSectionSortInput = {}
+  pagination: PaginationInput = {}
+}
+
+input WebsiteSectionRelatedTaxonomyInput {
+  sort: TaxonomySortInput = {}
   pagination: PaginationInput = {}
 }
 

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -75,6 +75,9 @@ type WebsiteSection {
   children(input: WebsiteSectionChildrenInput = {}): WebsiteSectionConnection! @projection(localField: "_id") @refMany(model: "website.Section", localField: "_id", foreignField: "parent.$id")
   logo: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
   coverImage: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
+  "Website sections that are directly related to this section. Primarily used for Leaders Program context mapping."
+  relatedSections(input: WebsiteSectionRelatedSectionsInput = {}): WebsiteSectionConnection! @projection @refMany(model: "website.Section")
+  relatedSectionIds: [Int]! @projection(localField: "relatedSections")
 
   # fields from trait.platform::Content\SeoFields
 
@@ -192,6 +195,12 @@ input WebsiteSectionParentInput {
 }
 
 input WebsiteSectionChildrenInput {
+  status: ModelStatus = active
+  sort: WebsiteSectionSortInput = {}
+  pagination: PaginationInput = {}
+}
+
+input WebsiteSectionRelatedSectionsInput {
   status: ModelStatus = active
   sort: WebsiteSectionSortInput = {}
   pagination: PaginationInput = {}

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -227,6 +227,7 @@ input CreateWebsiteSectionMutationInput {
   site: ObjectID!
   parent: Int
   logo: ObjectID
+  relatedSectionIds: [Int]
 }
 
 input UpdateWebsiteSectionMutationInput {
@@ -247,6 +248,7 @@ input UpdateWebsiteSectionMutationPayloadInput {
   site: ObjectID
   parent: Int
   logo: ObjectID
+  relatedSectionIds: [Int]
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -228,6 +228,7 @@ input CreateWebsiteSectionMutationInput {
   parent: Int
   logo: ObjectID
   relatedSectionIds: [Int]
+  relatedTaxonomyIds: [Int]
 }
 
 input UpdateWebsiteSectionMutationInput {
@@ -249,6 +250,7 @@ input UpdateWebsiteSectionMutationPayloadInput {
   parent: Int
   logo: ObjectID
   relatedSectionIds: [Int]
+  relatedTaxonomyIds: [Int]
 }
 
 `;

--- a/services/graphql-server/src/graphql/definitions/website/section.js
+++ b/services/graphql-server/src/graphql/definitions/website/section.js
@@ -77,10 +77,10 @@ type WebsiteSection {
   coverImage: AssetImage @projection @refOne(loader: "platformAsset", criteria: "assetImage")
   "Website sections that are directly related to this section. Primarily used for Leaders Program context mapping."
   relatedSections(input: WebsiteSectionRelatedSectionsInput = {}): WebsiteSectionConnection! @projection @refMany(model: "website.Section")
-  relatedSectionIds: [Int]! @projection(localField: "relatedSections")
+  relatedSectionIds: [Int!]! @projection(localField: "relatedSections")
   "Taxonomy items that are directly related to this section. Primarily used for Leaders Program context mapping."
   relatedTaxonomy(input: WebsiteSectionRelatedTaxonomyInput = {}): TaxonomyConnection! @projection @refMany(model: "platform.Taxonomy", using: { type: "type" })
-  relatedTaxonomyIds: [Int]! @projection(localField: "relatedTaxonomy")
+  relatedTaxonomyIds: [Int!]! @projection(localField: "relatedTaxonomy")
 
   # fields from trait.platform::Content\SeoFields
 
@@ -227,8 +227,8 @@ input CreateWebsiteSectionMutationInput {
   site: ObjectID!
   parent: Int
   logo: ObjectID
-  relatedSectionIds: [Int]
-  relatedTaxonomyIds: [Int]
+  relatedSectionIds: [Int!]
+  relatedTaxonomyIds: [Int!]
 }
 
 input UpdateWebsiteSectionMutationInput {
@@ -249,8 +249,8 @@ input UpdateWebsiteSectionMutationPayloadInput {
   site: ObjectID
   parent: Int
   logo: ObjectID
-  relatedSectionIds: [Int]
-  relatedTaxonomyIds: [Int]
+  relatedSectionIds: [Int!]
+  relatedTaxonomyIds: [Int!]
 }
 
 `;

--- a/services/graphql-server/src/graphql/resolvers/website/section.js
+++ b/services/graphql-server/src/graphql/resolvers/website/section.js
@@ -184,7 +184,6 @@ module.exports = {
       }
       if (relatedTaxonomyIds) {
         const relatedTaxonomy = await basedb.find('platform.Taxonomy', { _id: { $in: relatedTaxonomyIds } }, { projection: { type: 1 } });
-        console.log(relatedTaxonomy);
         body.setLinks('relatedTaxonomy', relatedTaxonomy.map(doc => ({ id: doc._id, type: doc.type })));
       }
       const { data: { id } } = await base4rest.insertOne({ model: type, body });
@@ -217,7 +216,6 @@ module.exports = {
       }
       if (relatedTaxonomyIds) {
         const relatedTaxonomy = await basedb.find('platform.Taxonomy', { _id: { $in: relatedTaxonomyIds } }, { projection: { type: 1 } });
-        console.log(relatedTaxonomy);
         body.setLinks('relatedTaxonomy', relatedTaxonomy.map(doc => ({ id: doc._id, type: doc.type })));
       }
       body.set('id', id);

--- a/services/graphql-server/src/graphql/resolvers/website/section.js
+++ b/services/graphql-server/src/graphql/resolvers/website/section.js
@@ -2,6 +2,7 @@ const { BaseDB } = require('@parameter1/base-cms-db');
 const { Base4RestPayload } = require('@parameter1/base-cms-base4-rest-api');
 const { UserInputError } = require('apollo-server-express');
 const { websiteSection: canonicalPathFor } = require('@parameter1/base-cms-canonical-path');
+const { getAsArray } = require('@parameter1/base-cms-db/src/basedb');
 
 const validateRest = require('../../utils/validate-rest');
 const buildProjection = require('../../utils/build-projection');
@@ -64,16 +65,13 @@ module.exports = {
      * Returns the website sections directly related to this section. This is primarily used for the
      * Leaders Program to denote a contextual relationship between two website sections.
      */
-    relatedSectionIds: async ({ relatedSections }) => relatedSections || [],
+    relatedSectionIds: root => getAsArray(root, 'relatedSections'),
 
     /**
      * Returns the taxonomy terms directly related to this section. This is primarily used for the
      * Leaders Program to denote a contextual relationship.
      */
-    relatedTaxonomyIds: async ({ relatedTaxonomy }) => {
-      const refs = relatedTaxonomy || [];
-      return refs.map(BaseDB.extractRefId);
-    },
+    relatedTaxonomyIds: root => getAsArray(root, 'relatedTaxonomy').map(BaseDB.extractRefId),
 
     isRoot: section => !section.parent,
   },

--- a/services/graphql-server/src/graphql/resolvers/website/section.js
+++ b/services/graphql-server/src/graphql/resolvers/website/section.js
@@ -170,6 +170,7 @@ module.exports = {
         site,
         parent,
         logo,
+        relatedSectionIds,
         ...fields
       } = input;
       const body = new Base4RestPayload({ type });
@@ -177,6 +178,9 @@ module.exports = {
       if (site) body.setLink('site', { id: site, type: 'website/product/site' });
       if (parent) body.setLink('parent', { id: parent, type });
       if (logo) body.setLink('logo', { id: logo, type: 'platform/asset/image' });
+      if (relatedSectionIds) {
+        body.setLinks('relatedSections', relatedSectionIds.map(i => ({ id: i, type })));
+      }
       const { data: { id } } = await base4rest.insertOne({ model: type, body });
       const projection = buildProjection({ info, type: 'WebsiteSection' });
       return basedb.findOne('website.Section', { _id: id }, { projection });
@@ -193,6 +197,7 @@ module.exports = {
         site,
         parent,
         logo,
+        relatedSectionIds,
         ...fields
       } = payload;
       const body = new Base4RestPayload({ type });
@@ -200,6 +205,9 @@ module.exports = {
       if (site) body.setLink('site', { site, type: 'website/product/site' });
       if (parent) body.setLink('parent', { parent, type });
       if (logo) body.setLink('logo', { logo, type: 'platform/asset/image' });
+      if (relatedSectionIds) {
+        body.setLinks('relatedSections', relatedSectionIds.map(i => ({ id: i, type })));
+      }
       body.set('id', id);
       await base4rest.updateOne({ model: type, id, body });
       const projection = buildProjection({ info, type: 'WebsiteSection' });

--- a/services/graphql-server/src/graphql/resolvers/website/section.js
+++ b/services/graphql-server/src/graphql/resolvers/website/section.js
@@ -66,6 +66,15 @@ module.exports = {
      */
     relatedSectionIds: async ({ relatedSections }) => relatedSections || [],
 
+    /**
+     * Returns the taxonomy terms directly related to this section. This is primarily used for the
+     * Leaders Program to denote a contextual relationship.
+     */
+    relatedTaxonomyIds: async ({ relatedTaxonomy }) => {
+      const refs = relatedTaxonomy || [];
+      return refs.map(BaseDB.extractRefId);
+    },
+
     isRoot: section => !section.parent,
   },
 

--- a/services/graphql-server/src/graphql/resolvers/website/section.js
+++ b/services/graphql-server/src/graphql/resolvers/website/section.js
@@ -171,6 +171,7 @@ module.exports = {
         parent,
         logo,
         relatedSectionIds,
+        relatedTaxonomyIds,
         ...fields
       } = input;
       const body = new Base4RestPayload({ type });
@@ -180,6 +181,11 @@ module.exports = {
       if (logo) body.setLink('logo', { id: logo, type: 'platform/asset/image' });
       if (relatedSectionIds) {
         body.setLinks('relatedSections', relatedSectionIds.map(i => ({ id: i, type })));
+      }
+      if (relatedTaxonomyIds) {
+        const relatedTaxonomy = await basedb.find('platform.Taxonomy', { _id: { $in: relatedTaxonomyIds } }, { projection: { type: 1 } });
+        console.log(relatedTaxonomy);
+        body.setLinks('relatedTaxonomy', relatedTaxonomy.map(doc => ({ id: doc._id, type: doc.type })));
       }
       const { data: { id } } = await base4rest.insertOne({ model: type, body });
       const projection = buildProjection({ info, type: 'WebsiteSection' });
@@ -198,6 +204,7 @@ module.exports = {
         parent,
         logo,
         relatedSectionIds,
+        relatedTaxonomyIds,
         ...fields
       } = payload;
       const body = new Base4RestPayload({ type });
@@ -207,6 +214,11 @@ module.exports = {
       if (logo) body.setLink('logo', { logo, type: 'platform/asset/image' });
       if (relatedSectionIds) {
         body.setLinks('relatedSections', relatedSectionIds.map(i => ({ id: i, type })));
+      }
+      if (relatedTaxonomyIds) {
+        const relatedTaxonomy = await basedb.find('platform.Taxonomy', { _id: { $in: relatedTaxonomyIds } }, { projection: { type: 1 } });
+        console.log(relatedTaxonomy);
+        body.setLinks('relatedTaxonomy', relatedTaxonomy.map(doc => ({ id: doc._id, type: doc.type })));
       }
       body.set('id', id);
       await base4rest.updateOne({ model: type, id, body });

--- a/services/graphql-server/src/graphql/resolvers/website/section.js
+++ b/services/graphql-server/src/graphql/resolvers/website/section.js
@@ -60,6 +60,12 @@ module.exports = {
       return sections.reverse();
     },
 
+    /**
+     * Returns the website sections directly related to this section. This is primarily used for the
+     * Leaders Program to denote a contextual relationship between two website sections.
+     */
+    relatedSectionIds: async ({ relatedSections }) => relatedSections || [],
+
     isRoot: section => !section.parent,
   },
 


### PR DESCRIPTION
Publicizes the related section/taxonomy ids and allows them to be specified when creating or updating website sections.

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/1778222/174158063-b9368198-93ff-42e6-8f4f-d25e3fe855b6.png">
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/1778222/174161120-29eef953-0e3a-452f-81d5-8164bd0c3c67.png">
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/1778222/174161158-97291eb9-e606-44ac-82a7-19bee3976d56.png">
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/1778222/174162239-1450305b-236b-4af1-8622-005bf16f2262.png">
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/1778222/174162278-c1b7f758-a755-4f49-a384-11e5da719503.png">
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/1778222/174162435-11f20761-1dbd-4987-856f-79f93c44eb1a.png">
