### PR TITLE
Adjust when `strip-olytics-params.js` middleware should redirect & clean url.

### DIFF
--- a/packages/marko-web-omeda-identity-x/middleware/strip-olytics-param.js
+++ b/packages/marko-web-omeda-identity-x/middleware/strip-olytics-param.js
@@ -8,16 +8,12 @@ module.exports = () => (req, res, next) => {
   const { oly_enc_id: id, ...q } = req.query;
   const incomingEncId = olyticsCookie.clean(id);
 
-  // No IdentityX context, set the cookie and move on
   if (!idxUserExists && incomingEncId && incomingEncId !== currentEncId) {
+    // No IdentityX context, set the cookie and move on
     olyticsCookie.setTo(res, incomingEncId);
-    const params = (new URLSearchParams(q)).toString();
-    const redirectTo = `${req.path}${params ? `?${params}` : ''}`;
-    res.redirect(302, redirectTo);
-  }
-
-  // Incoming id conflicts!
-  if (idxUserExists && incomingEncId && incomingEncId !== currentEncId) {
+    next();
+  } else if (idxUserExists && incomingEncId && incomingEncId !== currentEncId) {
+    // Incoming id conflicts!
     const params = (new URLSearchParams(q)).toString();
     const redirectTo = `${req.path}${params ? `?${params}` : ''}`;
     res.redirect(302, redirectTo);


### PR DESCRIPTION
When no IdentityX context  is set, but there is an incoming oly_enc_id it now set the olytics cookie without forcing redirect.  It will now only redirect when there is an incoming Id conflict.  Meaning there is already an idX user context present that doesn't match the incoming request oly_enc_id.  Basically remove it and reload the page with the already set idX user context.