### PR TITLE
Add support for external newsletter signup and IdX newsletter config prop

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/marko.json
+++ b/packages/marko-web-theme-monorail/components/blocks/marko.json
@@ -63,6 +63,9 @@
   "<theme-newsletter-signup-banner-large-block>": {
     "template": "./newsletter-signup-banner-large.marko"
   },
+  "<theme-newsletter-signup-banner-external-block>": {
+    "template": "./newsletter-signup-banner-external.marko"
+  },
   "<theme-opinion-block>": {
     "template": "./opinion.marko",
     "@alias" : "string"

--- a/packages/marko-web-theme-monorail/components/blocks/newsletter-signup-banner-external.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/newsletter-signup-banner-external.marko
@@ -3,10 +3,10 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const { site, i18n } = out.global;
 $ const configName = defaultValue(input.configName, "signupBannerExternal");
 $ const newsletterConfig = site.getAsObject(`newsletter.${configName}`);
-$ const blockName = defaultValue(input.blockName, "newsletter-signup");
+$ const blockName = defaultValue(input.blockName, "newsletter-signup-banner-large");
 
 <marko-web-block name=blockName>
-  <marko-web-element block-name=blockName name="header">
+  <marko-web-element block-name=blockName name="name">
     $!{newsletterConfig.name}
   </marko-web-element>
   <if(newsletterConfig.description)>
@@ -14,21 +14,19 @@ $ const blockName = defaultValue(input.blockName, "newsletter-signup");
       $!{newsletterConfig.description}
     </marko-web-element>
   </if>
-  <form action=newsletterConfig.action method="GET">
-    <div class="form-group">
-      <label for="footer-newsletter-signup-email">${i18n("Email")}</label>
-      <input
-        id="footer-newsletter-signup-email"
-        class="form-control"
-        type="email"
-        placeholder="example@gmail.com"
-        name="em"
-        required
-      />
-      <for|item| of=newsletterConfig.hiddenInputs>
-        <input type="hidden" name=item.name value=item.value />
-      </for>
-    </div>
+  <form class=`${blockName}__form` action=newsletterConfig.action method="GET">
+    <label for=`${blockName}-email` class="sr-only">${i18n("Email")}</label>
+    <input
+      id=`${blockName}-email`
+      class="form-control"
+      type="email"
+      placeholder="example@gmail.com"
+      name="em"
+      required
+    />
+    <for|item| of=newsletterConfig.hiddenInputs>
+      <input type="hidden" name=item.name value=item.value />
+    </for>
     <button class="btn btn-primary" type="submit" disabled=(newsletterConfig.disabled && "disabled")>${i18n("Sign Up")}</button>
   </form>
 </marko-web-block>

--- a/packages/marko-web-theme-monorail/components/blocks/newsletter-signup-banner-external.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/newsletter-signup-banner-external.marko
@@ -1,0 +1,34 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { site } = out.global;
+$ const configName = defaultValue(input.configName, "signupBannerExternal");
+$ const newsletterConfig = site.getAsObject(`newsletter.${configName}`);
+$ const blockName = defaultValue(input.blockName, "newsletter-signup");
+
+<marko-web-block name=newsletterBlock>
+  <marko-web-element block-name=newsletterBlock name="header">
+    $!{newsletterConfig.name}
+  </marko-web-element>
+  <if(newsletterConfig.description)>
+    <marko-web-element block-name=newsletterBlock name="description">
+      $!{newsletterConfig.description}
+    </marko-web-element>
+  </if>
+  <form action=newsletterConfig.action method="GET">
+    <div class="form-group">
+      <label for="footer-newsletter-signup-email">${i18n("Email")}</label>
+      <input
+        id="footer-newsletter-signup-email"
+        class="form-control"
+        type="email"
+        placeholder="example@gmail.com"
+        name="em"
+        required
+      />
+      <for|item| of=newsletterConfig.hiddenInputs>
+        <input type="hidden" name=item.name value=item.value />
+      </for>
+    </div>
+    <button class="btn btn-primary" type="submit" disabled=(newsletterConfig.disabled && "disabled")>${i18n("Sign Up")}</button>
+  </form>
+</marko-web-block>

--- a/packages/marko-web-theme-monorail/components/blocks/newsletter-signup-banner-external.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/newsletter-signup-banner-external.marko
@@ -1,16 +1,16 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { site } = out.global;
+$ const { site, i18n } = out.global;
 $ const configName = defaultValue(input.configName, "signupBannerExternal");
 $ const newsletterConfig = site.getAsObject(`newsletter.${configName}`);
 $ const blockName = defaultValue(input.blockName, "newsletter-signup");
 
-<marko-web-block name=newsletterBlock>
-  <marko-web-element block-name=newsletterBlock name="header">
+<marko-web-block name=blockName>
+  <marko-web-element block-name=blockName name="header">
     $!{newsletterConfig.name}
   </marko-web-element>
   <if(newsletterConfig.description)>
-    <marko-web-element block-name=newsletterBlock name="description">
+    <marko-web-element block-name=blockName name="description">
       $!{newsletterConfig.description}
     </marko-web-element>
   </if>

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-footer.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-footer.marko
@@ -10,13 +10,14 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
 $ const buttonLabels = defaultValue(input.buttonLabels, { continue: 'Sign Up' })
 $ const loginEmailPlaceholder = defaultValue(input.loginEmailPlaceholder, 'example@gmail.com');
 $ const source = defaultValue(input.source, 'footer_newsletter_login');
+$ const configName = defaultValue(input.configName, 'signupFooter');
 
 $ const {
   name,
   description,
   imagePath,
   disabled,
-} = site.getAsObject("newsletter.signupFooter");
+} = site.getAsObject(`newsletter.${configName}`);
 
 $ const lang = site.config.lang || "en";
 

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
@@ -10,13 +10,14 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
 $ const buttonLabels = defaultValue(input.buttonLabels, { continue: 'Sign Up' })
 $ const loginEmailPlaceholder = defaultValue(input.loginEmailPlaceholder, 'example@gmail.com');
 $ const source = defaultValue(input.source, 'inline_newsletter_login');
+$ const configName = defaultValue(input.configName, 'signupBanner');
 
 $ const {
   name,
   description,
   imagePath,
   disabled,
-} = site.getAsObject("newsletter.signupBanner");
+} = site.getAsObject(`newsletter.${configName}`);
 
 $ const lang = site.config.lang || "en";
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 120, auto: "format,compress" }) : null;

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
@@ -8,13 +8,14 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
 $ const buttonLabels = defaultValue(input.buttonLabels, { continue: "Sign Up" })
 $ const loginEmailPlaceholder = defaultValue(input.loginEmailPlaceholder, "example@gmail.com");
 $ const source = defaultValue(input.source, "pushdown_newsletter_login");
+$ const configName = defaultValue(input.configName, 'pushdown');
 
 $ const {
   name,
   description,
   imagePath,
   disabled,
-} = site.getAsObject("newsletter.pushdown");
+} = site.getAsObject(`newsletter.${configName}`);
 
 $ const lang = site.config.lang || "en";
 $ const { initiallyExpanded } = getAsObject(out.global, "newsletterState");

--- a/packages/marko-web-theme-monorail/components/site-footer.marko
+++ b/packages/marko-web-theme-monorail/components/site-footer.marko
@@ -3,8 +3,8 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { asObject } from "@parameter1/base-cms-utils";
 
 $ const { config, site, i18n } = out.global;
-
-$ const newsletterConfig = site.getAsObject('newsletter.signupFooter');
+$ const newsletterSignupConfigName = defaultValue(input.newsletterSignupConfigName, "signupFooter");
+$ const newsletterConfig = site.getAsObject(`newsletter.${newsletterSignupConfigName}`);
 $ const blockName = input.blockName || "site-footer";
 $ const tagline = site.get("tagline");
 $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true);
@@ -35,38 +35,11 @@ $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true
 
       <div class="row">
         <marko-web-element block-name=blockName name="section" attrs={ "aria-label": "Newsletter Sign-Up Form Footer"}>
-          $ const newsletterBlock = "site-footer-newsletter";
           <if(!newsletterConfig.disabled && useIdxNewsletterSignup)>
             <identity-x-newsletter-form-footer />
           </if>
           <else-if(!newsletterConfig.disabled && newsletterConfig.action)>
-            <marko-web-block name=newsletterBlock>
-              <marko-web-element block-name=newsletterBlock name="header">
-                $!{newsletterConfig.name}
-              </marko-web-element>
-              <if(newsletterConfig.description)>
-                <marko-web-element block-name=newsletterBlock name="description">
-                  $!{newsletterConfig.description}
-                </marko-web-element>
-              </if>
-              <form action=newsletterConfig.action method="GET">
-                <div class="form-group">
-                  <label for="footer-newsletter-signup-email">${i18n("Email")}</label>
-                  <input
-                    id="footer-newsletter-signup-email"
-                    class="form-control"
-                    type="email"
-                    placeholder="example@gmail.com"
-                    name="em"
-                    required
-                  />
-                  <for|item| of=newsletterConfig.hiddenInputs>
-                    <input type="hidden" name=item.name value=item.value />
-                  </for>
-                </div>
-                <button class="btn btn-primary" type="submit" disabled=(newsletterConfig.disabled && "disabled")>${i18n("Sign Up")}</button>
-              </form>
-            </marko-web-block>
+            <theme-newsletter-signup-banner-external-block config-name=newsletterSignupConfigName />
           </else-if>
         </marko-web-element>
         <marko-web-element block-name=blockName name="section" attrs={ "aria-label": "Social Media Links" }>

--- a/packages/marko-web-theme-monorail/components/site-footer.marko
+++ b/packages/marko-web-theme-monorail/components/site-footer.marko
@@ -39,7 +39,7 @@ $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true
             <identity-x-newsletter-form-footer />
           </if>
           <else-if(!newsletterConfig.disabled && newsletterConfig.action)>
-            <theme-newsletter-signup-banner-external-block config-name=newsletterSignupConfigName />
+            <theme-newsletter-signup-banner-external-block block-name="site-footer-newsletter" config-name=newsletterSignupConfigName />
           </else-if>
         </marko-web-element>
         <marko-web-element block-name=blockName name="section" attrs={ "aria-label": "Social Media Links" }>

--- a/packages/marko-web-theme-monorail/components/site-footer.marko
+++ b/packages/marko-web-theme-monorail/components/site-footer.marko
@@ -36,7 +36,7 @@ $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true
       <div class="row">
         <marko-web-element block-name=blockName name="section" attrs={ "aria-label": "Newsletter Sign-Up Form Footer"}>
           <if(!newsletterConfig.disabled && useIdxNewsletterSignup)>
-            <identity-x-newsletter-form-footer />
+            <identity-x-newsletter-form-footer config-name=newsletterSignupConfigName />
           </if>
           <else-if(!newsletterConfig.disabled && newsletterConfig.action)>
             <theme-newsletter-signup-banner-external-block block-name="site-footer-newsletter" config-name=newsletterSignupConfigName />

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_newsletter-signup-site-footer.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_newsletter-signup-site-footer.scss
@@ -1,0 +1,11 @@
+.site-footer-newsletter {
+  &__name {
+    @include skin-typography($style: "footer-header-1");
+    margin-bottom: 8px;
+  }
+  &__form {
+    input {
+      margin-bottom: 1rem;
+    }
+  }
+}

--- a/packages/marko-web-theme-monorail/scss/core.scss
+++ b/packages/marko-web-theme-monorail/scss/core.scss
@@ -42,6 +42,7 @@
 @import "./components/blocks/most-popular";
 @import "./components/blocks/newsletter-signup-banner";
 @import "./components/blocks/newsletter-signup-banner-large";
+@import "./components/blocks/newsletter-signup-site-footer";
 @import "./components/blocks/node-author";
 @import "./components/blocks/opinion";
 @import "./components/blocks/primary-image";


### PR DESCRIPTION
You can now pass in configName as a prop to the idx newsletter blocks to tell it which newsletter config to use within Pushdown, inline & external newsletter components.  Also add support for this being passed into the site-footer.  

Create a new newsletter-signup-external component that can be called both inline and in the footer.


<img width="1207" alt="Screen Shot 2022-06-29 at 12 50 19 PM" src="https://user-images.githubusercontent.com/3845869/176503608-6fe4bfb1-f044-4112-b96b-4d25222ffa45.png">

