### PR TITLE
Add sponsored search support to search page and site-navbar

### DIFF
--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -5,6 +5,8 @@ $ const { config, site } = out.global;
 $ const newsletterConfig = site.getAsObject('newsletter.pushdown');
 $ const blockName = input.blockName || "site-header";
 $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true);
+$ const showSearchIcon = defaultValue(input.showSearchIcon, false);
+$ const menuBtnPosition = defaultValue(input.menuBtnPosition, 'left');
 
 $ const navigation = {
   primary: site.getAsArray("navigation.primary.items"),
@@ -21,13 +23,15 @@ $ const navigation = {
 >
   <${input.aboveNav} />
   <theme-site-navbar modifiers=["secondary"] attrs={ "aria-label": "Secondary Navigation" }>
-    <theme-menu-toggle-button
-      class="site-navbar__toggler"
-      targets=[".site-menu", "body"]
-      toggle-class="site-menu--open"
-      icon-modifiers=["lg"]
-      icon-name="three-bars"
-    />
+    <if(menuBtnPosition === 'left')>
+      <theme-menu-toggle-button
+        class="site-navbar__toggler"
+        targets=[".site-menu", "body"]
+        toggle-class="site-menu--open"
+        icon-modifiers=["lg"]
+        icon-name="three-bars"
+      />
+    </if>
 
     <theme-site-navbar-brand title=`${config.website("name")} Homepage`>
       <theme-site-navbar-logo
@@ -45,12 +49,26 @@ $ const navigation = {
       reg-enabled=input.regEnabled
       has-user=input.hasUser
     />
-    <if(!newsletterConfig.disabled && useIdxNewsletterSignup)>
-      <marko-web-browser-component name="IdentityXNewsletterToggleButton" ssr=true />
-    </if>
-    <else-if(!newsletterConfig.disabled)>
-      <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />
-    </else-if>
+    <marko-web-element block-name="site-navbar" name="icon-wrapper">
+      <if(showSearchIcon)>
+        <theme-site-navbar-search-icon />
+      </if>
+      <if(!newsletterConfig.disabled && useIdxNewsletterSignup)>
+        <marko-web-browser-component name="IdentityXNewsletterToggleButton" ssr=true />
+      </if>
+      <else-if(!newsletterConfig.disabled)>
+        <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />
+      </else-if>
+      <if(menuBtnPosition === 'right')>
+        <theme-menu-toggle-button
+          class="site-navbar__toggler"
+          targets=[".site-menu", "body"]
+          toggle-class="site-menu--open"
+          icon-modifiers=["lg"]
+          icon-name="three-bars"
+        />
+      </if>
+    </marko-web-element>
   </theme-site-navbar>
 
   <theme-site-navbar modifiers=["primary"] attrs={ "aria-label": "Primary Navigation" }>

--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -50,15 +50,20 @@ $ const navigation = {
       has-user=input.hasUser
     />
     <marko-web-element block-name="site-navbar" name="icon-wrapper">
-      <if(showSearchIcon)>
-        <theme-site-navbar-search-icon />
-      </if>
+      <!-- Newsletter Menue Toggler -->
       <if(!newsletterConfig.disabled && useIdxNewsletterSignup)>
         <marko-web-browser-component name="IdentityXNewsletterToggleButton" ssr=true />
       </if>
       <else-if(!newsletterConfig.disabled)>
         <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />
       </else-if>
+
+      <!-- Site Navbar Search Icon -->
+      <if(showSearchIcon)>
+        <theme-site-navbar-search-icon />
+      </if>
+
+      <!-- Site Menu Toggle(when positioned right) -->
       <if(menuBtnPosition === 'right')>
         <theme-menu-toggle-button
           class="site-navbar__toggler"

--- a/packages/marko-web-theme-monorail/components/site-menu/components/search.marko
+++ b/packages/marko-web-theme-monorail/components/site-menu/components/search.marko
@@ -1,6 +1,8 @@
 import { randomElementId } from "@parameter1/base-cms-utils";
 
 $ const inputId = randomElementId({ prefix: "site-menu-search" });
+$ const { site } = out.global;
+$ const sponsor = site.getAsObject("searchSponsor");
 
 <marko-web-element block-name=input.blockName name="section" modifiers=["search"]>
   <form method="GET" action="/search">
@@ -12,6 +14,14 @@ $ const inputId = randomElementId({ prefix: "site-menu-search" });
           <marko-web-icon name="search" modifiers=["light"] />
         </button>
       </div>
+      <if(sponsor.siteMenuLogo)>
+        <marko-web-img
+          alt=sponsor.siteMenuLogo.alt
+          src=sponsor.siteMenuLogo.src
+          srcset=sponsor.siteMenuLogo.srcset
+          class="search-sponsor__logo lazyload"
+        />
+      </if>
     </div>
   </form>
 </marko-web-element>

--- a/packages/marko-web-theme-monorail/components/site-menu/components/search.marko
+++ b/packages/marko-web-theme-monorail/components/site-menu/components/search.marko
@@ -2,7 +2,7 @@ import { randomElementId } from "@parameter1/base-cms-utils";
 
 $ const inputId = randomElementId({ prefix: "site-menu-search" });
 $ const { site } = out.global;
-$ const sponsor = site.getAsObject("searchSponsor");
+$ const sponsorLogo = site.getAsObject("search.sponsorLogos.siteMenu");
 
 <marko-web-element block-name=input.blockName name="section" modifiers=["search"]>
   <form method="GET" action="/search">
@@ -14,12 +14,12 @@ $ const sponsor = site.getAsObject("searchSponsor");
           <marko-web-icon name="search" modifiers=["light"] />
         </button>
       </div>
-      <if(sponsor.siteMenuLogo)>
+      <if(sponsorLogo)>
         <marko-web-img
-          alt=sponsor.siteMenuLogo.alt
-          src=sponsor.siteMenuLogo.src
-          srcset=sponsor.siteMenuLogo.srcset
-          class="search-sponsor__logo lazyload"
+          alt=sponsorLogo.alt
+          src=sponsorLogo.src
+          srcset=sponsorLogo.srcset
+          class="search-sponsor__logo"
         />
       </if>
     </div>

--- a/packages/marko-web-theme-monorail/components/site-navbar/marko.json
+++ b/packages/marko-web-theme-monorail/components/site-navbar/marko.json
@@ -13,5 +13,8 @@
   },
   "<theme-site-navbar-item>": {
     "template": "./item.marko"
+  },
+  "<theme-site-navbar-search-icon>": {
+    "template": "./search.marko"
   }
 }

--- a/packages/marko-web-theme-monorail/components/site-navbar/search.marko
+++ b/packages/marko-web-theme-monorail/components/site-navbar/search.marko
@@ -5,15 +5,15 @@ $ const inputId = randomElementId({ prefix: elementName });
 $ const { site } = out.global;
 $ const sponsor = site.getAsObject("searchSponsor");
 $ const classes = [elementName, "btn"];
-$ if (sponsor.headerLogo) classes.push(`${elementName}--sponsored`);
+$ if (sponsor.navbarLogo) classes.push(`${elementName}--sponsored`);
 
 <marko-web-link class=classes.join(" ") title="Search" href="/search">
   <marko-web-icon name="search" modifiers=["dark", "lg"] />
-  <if(sponsor.headerLogo)>
+  <if(sponsor.navbarLogo)>
     <marko-web-img
-      alt=sponsor.headerLogo.alt
-      src=sponsor.headerLogo.src
-      srcset=sponsor.headerLogo.srcset
+      alt=sponsor.navbarLogo.alt
+      src=sponsor.navbarLogo.src
+      srcset=sponsor.navbarLogo.srcset
       class="search-sponsor__logo lazyload"
     />
   </if>

--- a/packages/marko-web-theme-monorail/components/site-navbar/search.marko
+++ b/packages/marko-web-theme-monorail/components/site-navbar/search.marko
@@ -1,0 +1,20 @@
+import { randomElementId } from "@parameter1/base-cms-utils";
+
+$ const elementName = "site-navbar__search";
+$ const inputId = randomElementId({ prefix: elementName });
+$ const { site } = out.global;
+$ const sponsor = site.getAsObject("searchSponsor");
+$ const classes = [elementName, "btn"];
+$ if (sponsor.headerLogo) classes.push(`${elementName}--sponsored`);
+
+<marko-web-link class=classes.join(" ") title="Search" href="/search">
+  <marko-web-icon name="search" modifiers=["dark", "lg"] />
+  <if(sponsor.headerLogo)>
+    <marko-web-img
+      alt=sponsor.headerLogo.alt
+      src=sponsor.headerLogo.src
+      srcset=sponsor.headerLogo.srcset
+      class="search-sponsor__logo lazyload"
+    />
+  </if>
+</marko-web-link>

--- a/packages/marko-web-theme-monorail/components/site-navbar/search.marko
+++ b/packages/marko-web-theme-monorail/components/site-navbar/search.marko
@@ -3,18 +3,18 @@ import { randomElementId } from "@parameter1/base-cms-utils";
 $ const elementName = "site-navbar__search";
 $ const inputId = randomElementId({ prefix: elementName });
 $ const { site } = out.global;
-$ const sponsor = site.getAsObject("searchSponsor");
+$ const sponsorLogo = site.getAsObject("search.sponsorLogos.navbar");
 $ const classes = [elementName, "btn"];
-$ if (sponsor.navbarLogo) classes.push(`${elementName}--sponsored`);
+$ if (sponsorLogo) classes.push(`${elementName}--sponsored`);
 
 <marko-web-link class=classes.join(" ") title="Search" href="/search">
   <marko-web-icon name="search" modifiers=["dark", "lg"] />
-  <if(sponsor.navbarLogo)>
+  <if(sponsorLogo)>
     <marko-web-img
-      alt=sponsor.navbarLogo.alt
-      src=sponsor.navbarLogo.src
-      srcset=sponsor.navbarLogo.srcset
-      class="search-sponsor__logo lazyload"
+      alt=sponsorLogo.alt
+      src=sponsorLogo.src
+      srcset=sponsorLogo.srcset
+      class="search-sponsor__logo"
     />
   </if>
 </marko-web-link>

--- a/packages/marko-web-theme-monorail/scss/components/_search-page.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_search-page.scss
@@ -152,3 +152,26 @@
     margin-right: 4px;
   }
 }
+
+.page-wrapper__website-section-name {
+  &--sponsored-search{
+    display: flex;
+    justify-content: space-between;
+  }
+}
+
+.search-sponsor {
+  display: flex;
+  align-items: center;
+
+  &__label {
+    @include skin-typography($style: "input-label");
+    padding: 0;
+    margin-right: 1rem;
+    margin-bottom: 12px;
+    font-size: 17px;
+    font-weight: $font-weight-semibold;
+    color: $gray-800;
+    text-transform: uppercase;
+  }
+}

--- a/packages/marko-web-theme-monorail/scss/components/_site-menu.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-menu.scss
@@ -159,6 +159,9 @@ body.site-menu--open {
           border-top-left-radius: 0;
           border-bottom-left-radius: 0;
         }
+        .search-sponsor__logo {
+          margin-left: 1rem;
+        }
       }
     }
     &--user {

--- a/packages/marko-web-theme-monorail/scss/components/_site-navbar.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-navbar.scss
@@ -15,6 +15,9 @@
         margin-right: $theme-site-navbar-brand-margin-x / 2;
         margin-left: $theme-site-navbar-brand-margin-x / 2;
       }
+      &:first-child {
+        margin-left: $marko-web-page-wrapper-padding;
+      }
     }
 
     &__logo {
@@ -39,6 +42,8 @@
     }
 
     &__icon-wrapper {
+      display: flex;
+      flex-wrap: nowrap;
       margin-left: auto;
       #{ $self }__toggler {
         margin-left: 1rem;
@@ -47,8 +52,17 @@
 
     &__search {
       &--sponsored {
+        padding-top: 0;
+        padding-bottom: 0;
+        display: flex;
+        align-self: center;
+        @media (max-width: map-get($theme-site-header-breakpoints, small-logo)) {
+          margin-top: 0;
+          margin-bottom: 0;
+        }
         img {
           margin-left: .5rem;
+          max-height: 24px;
         }
       }
     }

--- a/packages/marko-web-theme-monorail/scss/components/_site-navbar.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-navbar.scss
@@ -38,6 +38,21 @@
       }
     }
 
+    &__icon-wrapper {
+      margin-left: auto;
+      #{ $self }__toggler {
+        margin-left: 1rem;
+      }
+    }
+
+    &__search {
+      &--sponsored {
+        img {
+          margin-left: .5rem;
+        }
+      }
+    }
+
     &--secondary {
       #{ $self } {
         &__container {

--- a/packages/marko-web-theme-monorail/scss/components/_site-navbar.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-navbar.scss
@@ -45,6 +45,7 @@
       display: flex;
       flex-wrap: nowrap;
       margin-left: auto;
+      padding-left: 1rem;
       #{ $self }__toggler {
         margin-left: 1rem;
       }

--- a/packages/marko-web-theme-monorail/templates/search.marko
+++ b/packages/marko-web-theme-monorail/templates/search.marko
@@ -52,12 +52,6 @@ $ const sponsor = site.getAsObject('searchSponsor');
           </if>
           <div class="col-lg-3">
             <marko-web-search-filter-container modifiers=["sticky"]>
-              <@before-title|{ blockName }|>
-                <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name: title }>
-                  <if(currentPage > 1)>${value}: ${i18n("Page")} ${currentPage}</if>
-                  <else>${value}</else>
-                </marko-web-website-section-name>
-              </@before-title>
               <if(!sponsor.pageLogo)>
                 <@before-title|{ blockName }|>
                   <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name: title }>

--- a/packages/marko-web-theme-monorail/templates/search.marko
+++ b/packages/marko-web-theme-monorail/templates/search.marko
@@ -1,9 +1,13 @@
 import queryFragment from "../graphql/fragments/section-feed-block";
 import { get } from '@parameter1/base-cms-object-path';
 
-$ const { config, req, $markoWebSearch: search, site, i18n } = out.global;
-
-$ console.log('siteSearch vs MarkoSearch: ', site.getAsObject("search"), search);
+$ const {
+  config,
+  req,
+  $markoWebSearch: search,
+  site,
+  i18n,
+} = out.global;
 
 $ const type = "search";
 $ const title = "Search";
@@ -26,13 +30,13 @@ $ const sponsorLogo = site.getAsObject('search.sponsorLogos.page');
   </@head>
   <@page>
     <marko-web-page-wrapper>
-      <!-- <@section modifiers=["first"]>
+      <@section modifiers=["first"]>
         <theme-gam-define-display-ad
           name="leaderboard"
           position="static_page"
           modifiers=["inter-block"]
         />
-      </@section> -->
+      </@section>
       <@section|{ blockName }|>
         <div class="row">
           <if(sponsorLogo)>
@@ -129,13 +133,13 @@ $ const sponsorLogo = site.getAsObject('search.sponsorLogos.page');
           </div>
         </div>
       </@section>
-      <!-- <@section>
+      <@section>
         <theme-gam-define-display-ad
           name="rotation"
           position="static_page"
           modifiers=["inter-block"]
         />
-      </@section> -->
+      </@section>
     </marko-web-page-wrapper>
   </@page>
 </marko-web-default-page-layout>

--- a/packages/marko-web-theme-monorail/templates/search.marko
+++ b/packages/marko-web-theme-monorail/templates/search.marko
@@ -3,6 +3,8 @@ import { get } from '@parameter1/base-cms-object-path';
 
 $ const { config, req, $markoWebSearch: search, site, i18n } = out.global;
 
+$ console.log('siteSearch vs MarkoSearch: ', site.getAsObject("search"), search);
+
 $ const type = "search";
 $ const title = "Search";
 $ const description = `Search ${config.siteName()}`;
@@ -13,7 +15,7 @@ $ const overrideSortField = get(site, 'config.setSearchSortFieldToScore');
 $ const searchQueryPresent = (search.query.searchQuery && search.query.searchQuery !== '');
 $ const setDefaultSortField = (searchQueryPresent && !search.query.sortField && overrideSortField);
 $ const sortField = setDefaultSortField ? 'SCORE' : search.input.sortField;
-$ const sponsor = site.getAsObject('searchSponsor');
+$ const sponsorLogo = site.getAsObject('search.sponsorLogos.page');
 
 <marko-web-default-page-layout type=type title=title description=description>
   <@head>
@@ -24,16 +26,16 @@ $ const sponsor = site.getAsObject('searchSponsor');
   </@head>
   <@page>
     <marko-web-page-wrapper>
-      <@section modifiers=["first"]>
+      <!-- <@section modifiers=["first"]>
         <theme-gam-define-display-ad
           name="leaderboard"
           position="static_page"
           modifiers=["inter-block"]
         />
-      </@section>
+      </@section> -->
       <@section|{ blockName }|>
         <div class="row">
-          <if(sponsor.pageLogo)>
+          <if(sponsorLogo)>
             <div class="col-lg-12 ">
               <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name: title } modifiers=["sponsored-search"]>
                 <if(currentPage > 1)>${value}: ${i18n("Page")} ${currentPage}</if>
@@ -41,10 +43,10 @@ $ const sponsor = site.getAsObject('searchSponsor');
                 <div class="search-sponsor">
                   <span class="search-sponsor__label">Sponsored by</span>
                   <marko-web-img
-                    alt=sponsor.pageLogo.alt
-                    src=sponsor.pageLogo.src
-                    srcset=sponsor.pageLogo.srcset
-                    class="search-sponsor__logo lazyload"
+                    alt=sponsorLogo.alt
+                    src=sponsorLogo.src
+                    srcset=sponsorLogo.srcset
+                    class="search-sponsor__logo"
                   />
                 </div>
               </marko-web-website-section-name>
@@ -52,7 +54,7 @@ $ const sponsor = site.getAsObject('searchSponsor');
           </if>
           <div class="col-lg-3">
             <marko-web-search-filter-container modifiers=["sticky"]>
-              <if(!sponsor.pageLogo)>
+              <if(!sponsorLogo)>
                 <@before-title|{ blockName }|>
                   <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name: title }>
                     <if(currentPage > 1)>${value}: ${i18n("Page")} ${currentPage}</if>
@@ -127,13 +129,13 @@ $ const sponsor = site.getAsObject('searchSponsor');
           </div>
         </div>
       </@section>
-      <@section>
+      <!-- <@section>
         <theme-gam-define-display-ad
           name="rotation"
           position="static_page"
           modifiers=["inter-block"]
         />
-      </@section>
+      </@section> -->
     </marko-web-page-wrapper>
   </@page>
 </marko-web-default-page-layout>

--- a/packages/marko-web-theme-monorail/templates/search.marko
+++ b/packages/marko-web-theme-monorail/templates/search.marko
@@ -13,6 +13,7 @@ $ const overrideSortField = get(site, 'config.setSearchSortFieldToScore');
 $ const searchQueryPresent = (search.query.searchQuery && search.query.searchQuery !== '');
 $ const setDefaultSortField = (searchQueryPresent && !search.query.sortField && overrideSortField);
 $ const sortField = setDefaultSortField ? 'SCORE' : search.input.sortField;
+$ const sponsor = site.getAsObject('searchSponsor');
 
 <marko-web-default-page-layout type=type title=title description=description>
   <@head>
@@ -32,6 +33,23 @@ $ const sortField = setDefaultSortField ? 'SCORE' : search.input.sortField;
       </@section>
       <@section|{ blockName }|>
         <div class="row">
+          <if(sponsor.pageLogo)>
+            <div class="col-lg-12 ">
+              <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name: title } modifiers=["sponsored-search"]>
+                <if(currentPage > 1)>${value}: ${i18n("Page")} ${currentPage}</if>
+                <else>${value}</else>
+                <div class="search-sponsor">
+                  <span class="search-sponsor__label">Sponsored by</span>
+                  <marko-web-img
+                    alt=sponsor.pageLogo.alt
+                    src=sponsor.pageLogo.src
+                    srcset=sponsor.pageLogo.srcset
+                    class="search-sponsor__logo lazyload"
+                  />
+                </div>
+              </marko-web-website-section-name>
+            </div>
+          </if>
           <div class="col-lg-3">
             <marko-web-search-filter-container modifiers=["sticky"]>
               <@before-title|{ blockName }|>
@@ -40,6 +58,14 @@ $ const sortField = setDefaultSortField ? 'SCORE' : search.input.sortField;
                   <else>${value}</else>
                 </marko-web-website-section-name>
               </@before-title>
+              <if(!sponsor.pageLogo)>
+                <@before-title|{ blockName }|>
+                  <marko-web-website-section-name|{ value }| tag="h1" block-name=blockName obj={ name: title }>
+                    <if(currentPage > 1)>${value}: ${i18n("Page")} ${currentPage}</if>
+                    <else>${value}</else>
+                  </marko-web-website-section-name>
+                </@before-title>
+              </if>
               <marko-web-search-content-types-filter />
               <marko-web-search-website-sections-filter />
             </marko-web-search-filter-container>

--- a/services/example-website/config/search.js
+++ b/services/example-website/config/search.js
@@ -1,0 +1,27 @@
+module.exports = {
+  contentTypes: ['Article', 'Blog'],
+  // assignedToWebsiteSectionIds: [],
+  sponsorLogos: {
+    navbar: {
+      alt: 'Search Sposored by ProfiNet',
+      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress',
+      srcset: [
+        'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress&dpr=2 2x',
+      ],
+    },
+    siteMenu: {
+      alt: 'Search Sposored by ProfiNet',
+      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress',
+      srcset: [
+        'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress&dpr=2 2x',
+      ],
+    },
+    page: {
+      alt: 'Search Sposored by ProfiNet',
+      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress',
+      srcset: [
+        'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress&dpr=2 2x',
+      ],
+    },
+  },
+};

--- a/services/example-website/config/site.js
+++ b/services/example-website/config/site.js
@@ -26,6 +26,22 @@ module.exports = {
       ],
     },
   },
+  searchSponsor: {
+    headerLogo: {
+      alt: 'Search Sposored by ProfiNet',
+      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress',
+      srcset: [
+        'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress&dpr=2 2x',
+      ],
+    },
+    pageLogo: {
+      alt: 'Search Sposored by ProfiNet',
+      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress',
+      srcset: [
+        'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress&dpr=2 2x',
+      ],
+    },
+  },
   socialMediaLinks: [
     { provider: 'facebook', href: 'https://www.facebook.com/parameter1tech', target: '_blank' },
     { provider: 'twitter', href: 'https://www.twitter.com/parameter1tech', target: '_blank' },

--- a/services/example-website/config/site.js
+++ b/services/example-website/config/site.js
@@ -3,6 +3,7 @@ const omeda = require('./omeda');
 const nativeX = require('./native-x');
 const navigation = require('./navigation');
 const newsletter = require('./newsletter');
+const search = require('./search');
 
 module.exports = {
   identityX,
@@ -10,6 +11,7 @@ module.exports = {
   navigation,
   omeda,
   newsletter,
+  search,
   idxNavItems: { enable: true },
   company: 'Parameter1, LLC',
   logos: {
@@ -23,29 +25,6 @@ module.exports = {
       src: 'https://p1-cms-assets.imgix.net/files/base/p1/sandbox/image/static/sandbox-logo.png?h=60&auto=format,compress',
       srcset: [
         'https://p1-cms-assets.imgix.net/files/base/p1/sandbox/image/static/sandbox-logo.png?h=120&auto=format,compress 2x',
-      ],
-    },
-  },
-  searchSponsor: {
-    navbarLogo: {
-      alt: 'Search Sposored by ProfiNet',
-      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress',
-      srcset: [
-        'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress&dpr=2 2x',
-      ],
-    },
-    siteMenuLogo: {
-      alt: 'Search Sposored by ProfiNet',
-      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress',
-      srcset: [
-        'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress&dpr=2 2x',
-      ],
-    },
-    pageLogo: {
-      alt: 'Search Sposored by ProfiNet',
-      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress',
-      srcset: [
-        'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress&dpr=2 2x',
       ],
     },
   },

--- a/services/example-website/config/site.js
+++ b/services/example-website/config/site.js
@@ -27,11 +27,18 @@ module.exports = {
     },
   },
   searchSponsor: {
-    headerLogo: {
+    navbarLogo: {
       alt: 'Search Sposored by ProfiNet',
       src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress',
       srcset: [
         'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress&dpr=2 2x',
+      ],
+    },
+    siteMenuLogo: {
+      alt: 'Search Sposored by ProfiNet',
+      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress',
+      srcset: [
+        'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress&dpr=2 2x',
       ],
     },
     pageLogo: {

--- a/services/example-website/index.js
+++ b/services/example-website/index.js
@@ -23,7 +23,7 @@ const routes = config => (app) => {
   // Shared/global routes (all sites)
   contactUs(app, config);
   // Load site routes
-  siteRoutes(app);
+  siteRoutes(app, config);
 };
 
 module.exports = startServer({

--- a/services/example-website/server/components/document.marko
+++ b/services/example-website/server/components/document.marko
@@ -33,7 +33,7 @@ $ const { nativeX } = out.global;
   </@above-wrapper>
   <@above-container>
     <marko-web-identity-x-context|{ hasUser, isEnabled }|>
-      <theme-site-header has-user=hasUser reg-enabled=isEnabled />
+      <theme-site-header has-user=hasUser reg-enabled=isEnabled show-search-icon=true menu-btn-position="right"/>
       <theme-site-menu has-user=hasUser reg-enabled=isEnabled />
     </marko-web-identity-x-context>
     <marko-web-leaders-dropdown-portal />

--- a/services/example-website/server/routes/index.js
+++ b/services/example-website/server/routes/index.js
@@ -1,5 +1,6 @@
 const { withContent, withWebsiteSection } = require('@parameter1/base-cms-marko-web/middleware');
 const renderBlock = require('@parameter1/base-cms-marko-web-theme-monorail/routes/render-block');
+const search = require('@parameter1/base-cms-marko-web-theme-monorail/routes/search');
 const nativeX = require('./native-x');
 
 const index = require('../templates/index');
@@ -10,12 +11,14 @@ const leaders = require('../templates/leaders');
 const queryFragment = require('../../graphql/fragments/content-page');
 const sectionFragment = require('../../graphql/fragments/website-section-page');
 
-module.exports = (app) => {
+module.exports = (app, config) => {
   // NativeX
   nativeX(app);
 
   // Monorail
   renderBlock(app);
+
+  search(app, config);
 
   app.get('/', (_, res) => {
     res.marko(index);


### PR DESCRIPTION
 - Add support for setting a searchSponsor within the site config.
 ```js
 sponsorLogos: {
  navbar: {
    alt: 'Search Sposored by ProfiNet',
    src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress',
    srcset: [
      'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress&dpr=2 2x',
    ],
  },
  page: {
    alt: 'Search Sposored by ProfiNet',
    src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress',
    srcset: [
      'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress&dpr=2 2x',
    ],
  },
},
```
- Add support to the site-navbar call to display search icon & conditionally display the sponsor logo when set.  
- Add ability to also tell the site-menu-toggle to display left or right
- Example site call looks like `<theme-site-header has-user=hasUser reg-enabled=isEnabled show-search-icon=true menu-btn-position="right"/>`
<img width="1205" alt="Screen Shot 2022-06-30 at 8 59 41 AM" src="https://user-images.githubusercontent.com/3845869/176696676-08baa458-96d8-4fa5-8dc9-38eb3b15687f.png">

