### PR TITLE
Include the right peer dep for `@parameter1/base-cms-marko-web-theme-monorail`

### DIFF
--- a/packages/marko-web-theme-monorail-magazine/package.json
+++ b/packages/marko-web-theme-monorail-magazine/package.json
@@ -22,7 +22,7 @@
     "object-path": "^0.11.8"
   },
   "peerDependencies": {
-    "@parameter1/base-cms-marko-web-monorail": "^2.101.1"
+    "@parameter1/base-cms-marko-web-theme-monorail": "^2.101.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
 - "@parameter1/base-cms-marko-web-**theme**-monorail": "^2.101.1" vs     "@parameter1/base-cms-marko-web-monorail": "^2.101.1"