### PR TITLE
IdentityX Omeda product subscription support

### DIFF
--- a/packages/marko-web-omeda-identity-x/external-id/is-product-id.js
+++ b/packages/marko-web-omeda-identity-x/external-id/is-product-id.js
@@ -1,0 +1,8 @@
+const isOmedaNamespace = require('./is-omeda-namespace');
+
+module.exports = ({ externalId, brandKey } = {}) => isOmedaNamespace({
+  externalId,
+  brandKey,
+  type: 'product',
+  valueMatcher: id => parseInt(id, 10),
+});

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
@@ -4,6 +4,7 @@ const {
   getOmedaLinkedFields,
   setOmedaData,
   setOmedaDemographics,
+  setOmedaProducts,
   setOmedaDeploymentTypes,
   getAnsweredQuestionMap,
 } = require('../omeda-data');
@@ -46,6 +47,8 @@ module.exports = async ({
   const hasAnsweredAllOmedaQuestions = omedaLinkedFields
     .demographic.every(field => answeredQuestionMap.has(field.id))
     && omedaLinkedFields
+      .product.every(field => answeredQuestionMap.has(field.id))
+    && omedaLinkedFields
       .deploymentType.every(field => answeredQuestionMap.has(field.id));
 
   // If the user is verified and has answered all Omeda questions, do nothing.
@@ -63,15 +66,24 @@ module.exports = async ({
   if (!hasAnsweredAllOmedaQuestions) {
     await setOmedaDemographics({
       identityX,
+      brandKey,
       user,
       omedaCustomer,
       fields: omedaLinkedFields.demographic,
     });
     await setOmedaDeploymentTypes({
       identityX,
+      brandKey,
       user,
       omedaCustomer,
       fields: omedaLinkedFields.deploymentType,
+    });
+    await setOmedaProducts({
+      identityX,
+      brandKey,
+      user,
+      omedaCustomer,
+      fields: omedaLinkedFields.product,
     });
   }
 };

--- a/packages/marko-web-omeda-identity-x/middleware/resync-customer-data.js
+++ b/packages/marko-web-omeda-identity-x/middleware/resync-customer-data.js
@@ -5,8 +5,7 @@ const findEncryptedId = require('../external-id/find-encrypted-customer-id');
 const {
   getOmedaCustomerRecord,
   getOmedaLinkedFields,
-  setOmedaDemographics,
-  setOmedaDeploymentTypes,
+  updateIdentityX,
 } = require('../omeda-data');
 
 /**
@@ -38,21 +37,20 @@ module.exports = ({
     getOmedaLinkedFields({ identityX, brandKey }),
   ]);
 
-  // Update the IdentityX user record custom select fields with the Omeda customer demographics
-  await setOmedaDemographics({
-    req,
+  // Update the IdentityX user record custom select fields with the Omeda user data
+  await updateIdentityX({
     identityX,
+    brandKey,
     user,
     omedaCustomer,
-    fields: omedaLinkedFields.demographic,
-  });
-
-  // Update the IdentityX user record custom boolean fields with the Omeda deployment opt-ins
-  await setOmedaDeploymentTypes({
-    identityX,
-    user,
-    omedaCustomer,
-    fields: omedaLinkedFields.deploymentType,
+    omedaLinkedFields,
+  }, {
+    // Do not update core user fields (name, email, etc) on a verified user.
+    updateData: !user.verified,
+    // Update any linked custom fields with the relevant values from Omeda.
+    updateDemographics: true,
+    updateDeploymentTypes: true,
+    updateProducts: true,
   });
 
   // Set the cookie to prevent further resyncs until interval is reached.

--- a/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-customer-record.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-customer-record.js
@@ -27,6 +27,10 @@ const query = gql`
       primaryEmailAddress {
         optInStatus { deploymentTypeId status { id } }
       }
+      subscriptions {
+        product { id }
+        receive
+      }
     }
   }
 `;

--- a/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-linked-fields.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-linked-fields.js
@@ -2,6 +2,7 @@ const gql = require('graphql-tag');
 const { getAsArray } = require('@parameter1/base-cms-object-path');
 const isOmedaDeploymentTypeId = require('../external-id/is-deployment-type-id');
 const isOmedaDemographicId = require('../external-id/is-demographic-id');
+const isOmedaProductId = require('../external-id/is-product-id');
 
 const query = gql`
   query GetCustomFields {
@@ -44,6 +45,7 @@ module.exports = async ({
   const omedaLinkedFields = {
     demographic: [],
     deploymentType: [],
+    product: [],
   };
   getAsArray(data, 'fields.edges').forEach((edge) => {
     const { node: field } = edge;
@@ -54,6 +56,9 @@ module.exports = async ({
     }
     if (field.type === 'boolean' && isOmedaDeploymentTypeId({ externalId, brandKey })) {
       omedaLinkedFields.deploymentType.push(field);
+    }
+    if (field.type === 'boolean' && isOmedaProductId({ externalId, brandKey })) {
+      omedaLinkedFields.product.push(field);
     }
   });
 

--- a/packages/marko-web-omeda-identity-x/omeda-data/index.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/index.js
@@ -4,6 +4,7 @@ const getOmedaLinkedFields = require('./get-omeda-linked-fields');
 const setOmedaData = require('./set-omeda-data');
 const setOmedaDemographics = require('./set-omeda-demographics');
 const setOmedaDeploymentTypes = require('./set-omeda-deployment-types');
+const setOmedaProducts = require('./set-omeda-products');
 
 module.exports = {
   getAnsweredQuestionMap,
@@ -12,4 +13,5 @@ module.exports = {
   setOmedaData,
   setOmedaDemographics,
   setOmedaDeploymentTypes,
+  setOmedaProducts,
 };

--- a/packages/marko-web-omeda-identity-x/omeda-data/index.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/index.js
@@ -5,6 +5,7 @@ const setOmedaData = require('./set-omeda-data');
 const setOmedaDemographics = require('./set-omeda-demographics');
 const setOmedaDeploymentTypes = require('./set-omeda-deployment-types');
 const setOmedaProducts = require('./set-omeda-products');
+const updateIdentityX = require('./update-identity-x');
 
 module.exports = {
   getAnsweredQuestionMap,
@@ -14,4 +15,5 @@ module.exports = {
   setOmedaDemographics,
   setOmedaDeploymentTypes,
   setOmedaProducts,
+  updateIdentityX,
 };

--- a/packages/marko-web-omeda-identity-x/omeda-data/set-omeda-products.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/set-omeda-products.js
@@ -1,0 +1,50 @@
+const gql = require('graphql-tag');
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+const getAnsweredQuestionMap = require('./get-answered-question-map');
+const isOmedaProductId = require('../external-id/is-product-id');
+
+const SET_OMEDA_BOOLEAN_FIELD_ANSWERS = gql`
+mutation SetOmedaBooleanFieldAnswers($input: UpdateAppUserCustomBooleanAnswersMutationInput!) {
+  updateAppUserCustomBooleanAnswers(input: $input) { id }
+}
+`;
+
+/**
+ * Sets IdX boolean answers based on the Omeda customer's opt-in status
+ */
+module.exports = async ({
+  identityX,
+  brandKey,
+  user,
+  omedaCustomer,
+  fields = [],
+}) => {
+  const statusMap = getAsArray(omedaCustomer, 'subscriptions').reduce((map, { product, receive }) => {
+    map.set(`${product.id}`, receive);
+    return map;
+  }, new Map());
+
+  const answeredQuestionMap = getAnsweredQuestionMap(user);
+  const answerMap = fields
+    .filter(field => isOmedaProductId({ externalId: field.externalId, brandKey }))
+    .reduce((map, field) => {
+      // Only set values that haven't already been answered.
+      if (answeredQuestionMap.has(field.id)) return map;
+      const { value } = field.externalId.identifier;
+      const receive = statusMap.get(`${value}`);
+      if (receive == null) return map;
+      map.set(field.id, receive);
+      return map;
+    }, new Map());
+  if (!answerMap.size) return;
+
+  const answers = [];
+  answerMap.forEach((value, fieldId) => {
+    answers.push({ fieldId, value });
+  });
+  await identityX.client.mutate({
+    mutation: SET_OMEDA_BOOLEAN_FIELD_ANSWERS,
+    variables: { input: { id: user.id, answers } },
+    context: { apiToken: identityX.config.getApiToken() },
+  });
+};

--- a/packages/marko-web-omeda-identity-x/omeda-data/update-identity-x.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/update-identity-x.js
@@ -1,0 +1,74 @@
+const setOmedaData = require('./set-omeda-data');
+const setOmedaDemographics = require('./set-omeda-demographics');
+const setOmedaDeploymentTypes = require('./set-omeda-deployment-types');
+const setOmedaProducts = require('./set-omeda-products');
+
+/**
+ * Provides a standard interface to update IdentityX user data from Omeda. All updates to IdX user
+ * data should run through this utility.
+ *
+ * @note These updates should NEVER be run concurrently, to prevent a race condition in the IdX API.
+ *
+ * @param {object} args Arguments to pass along to update utilities
+ * @param {object} flags Keys indicate which updates should be executed.
+ * @param {object} flags.updateData            If true, update the root fields (first/last name,etc)
+ * @param {object} flags.updateDemographics    If true, update custom select fields
+ * @param {object} flags.updateDeploymentTypes If true, update boolean `deploymentType` fields
+ * @param {object} flags.updateProducts        If true, update boolean `product` fields
+ */
+module.exports = async (
+  {
+    identityX,
+    brandKey,
+    user,
+    omedaCustomer,
+    omedaLinkedFields = {},
+  } = {},
+  {
+    updateData = false,
+    updateDemographics = false,
+    updateDeploymentTypes = false,
+    updateProducts = false,
+  } = {},
+) => {
+  console.log('Updating IdentityX Data', {
+    updateData,
+    updateDemographics,
+    updateDeploymentTypes,
+    updateProducts,
+  });
+  if (updateData) {
+    await setOmedaData({
+      identityX,
+      user,
+      omedaCustomer,
+    });
+  }
+  if (updateDemographics) {
+    await setOmedaDemographics({
+      identityX,
+      brandKey,
+      user,
+      omedaCustomer,
+      fields: omedaLinkedFields.demographic,
+    });
+  }
+  if (updateDeploymentTypes) {
+    await setOmedaDeploymentTypes({
+      identityX,
+      brandKey,
+      user,
+      omedaCustomer,
+      fields: omedaLinkedFields.deploymentType,
+    });
+  }
+  if (updateProducts) {
+    await setOmedaProducts({
+      identityX,
+      brandKey,
+      user,
+      omedaCustomer,
+      fields: omedaLinkedFields.product,
+    });
+  }
+};

--- a/packages/marko-web-omeda-identity-x/omeda-data/update-identity-x.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/update-identity-x.js
@@ -31,12 +31,6 @@ module.exports = async (
     updateProducts = false,
   } = {},
 ) => {
-  console.log('Updating IdentityX Data', {
-    updateData,
-    updateDemographics,
-    updateDeploymentTypes,
-    updateProducts,
-  });
   if (updateData) {
     await setOmedaData({
       identityX,

--- a/packages/marko-web-omeda-identity-x/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/rapid-identify.js
@@ -2,6 +2,7 @@ const gql = require('graphql-tag');
 const { get, getAsArray } = require('@parameter1/base-cms-object-path');
 const isOmedaDemographicId = require('./external-id/is-demographic-id');
 const isDeploymentTypeId = require('./external-id/is-deployment-type-id');
+const isProductId = require('./external-id/is-product-id');
 
 const ALPHA3_CODE = gql`
   query GetAlpha3Code($alpha2: String!) {
@@ -71,6 +72,7 @@ module.exports = async ({
   });
 
   const deploymentTypes = [];
+  const subscriptions = [];
   getAsArray(appUser, 'customBooleanFieldAnswers').forEach((boolean) => {
     const { field, hasAnswered } = boolean;
     const { externalId } = field;
@@ -85,6 +87,10 @@ module.exports = async ({
 
     if (isDeploymentTypeId({ externalId, brandKey })) {
       deploymentTypes.push({ id, optedIn: boolean.answer });
+    }
+
+    if (isProductId({ externalId, brandKey })) {
+      subscriptions.push({ id, receive: boolean.answer });
     }
   });
 
@@ -101,6 +107,7 @@ module.exports = async ({
     ...(demographics.length && { demographics }),
     ...(deploymentTypes.length && { deploymentTypes }),
     ...(promoCode && { promoCode }),
+    ...(subscriptions.length && { subscriptions }),
   });
 
   const namespace = { provider: 'omeda', tenant: brandKey.toLowerCase(), type: 'customer' };

--- a/packages/marko-web-omeda/rapid-identify.js
+++ b/packages/marko-web-omeda/rapid-identify.js
@@ -31,6 +31,7 @@ module.exports = async (omedaGraphQLClient, {
 
   deploymentTypes,
   demographics,
+  subscriptions,
 
   promoCode,
 } = {}) => {
@@ -54,6 +55,7 @@ module.exports = async (omedaGraphQLClient, {
     ...(isArray(deploymentTypeIds) && deploymentTypeIds.length && { deploymentTypeIds }),
     ...(isArray(deploymentTypes) && deploymentTypes.length && { deploymentTypes }),
     ...(isArray(demographics) && demographics.length && { demographics }),
+    ...(isArray(subscriptions) && subscriptions.length && { subscriptions }),
 
     ...(promoCode && { promoCode }),
   };

--- a/services/example-website/config/navigation.js
+++ b/services/example-website/config/navigation.js
@@ -1,3 +1,5 @@
+const idxConfig = require('./identity-x');
+
 const topics = {
   primary: [
     { href: '/clients', label: 'Clients' },
@@ -18,14 +20,36 @@ const utilities = [
   { href: '/page/contact-us', label: 'Contact Us' },
 ];
 
+const userLinks = [
+  {
+    href: idxConfig.getEndpointFor('login'),
+    label: 'Sign In',
+    when: 'logged-out',
+    modifiers: ['user'],
+  },
+  {
+    href: idxConfig.getEndpointFor('profile'),
+    label: 'Manage Account',
+    when: 'logged-in',
+    modifiers: ['user'],
+  },
+  {
+    href: idxConfig.getEndpointFor('logout'),
+    label: 'Sign Out',
+    when: 'logged-in',
+    modifiers: ['user'],
+  },
+];
+
 const mobileMenu = {
+  user: userLinks,
   primary: topics.primary,
   secondary: topics.secondary,
 };
 
 const desktopMenu = {
   about: [...utilities],
-  user: [],
+  user: userLinks,
   sections: [
     ...topics.primary,
     ...topics.secondary,


### PR DESCRIPTION
- [x] Requires parameter1/omeda#28

Adds support for sending product subscriptions for IdentityX questions with the `product` entity type.