### PR TITLE
Account for user and site props within monorail's  site-navbar, site-header & site-footer components

### DIFF
--- a/packages/marko-web-theme-monorail/components/site-footer.marko
+++ b/packages/marko-web-theme-monorail/components/site-footer.marko
@@ -36,10 +36,14 @@ $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true
       <div class="row">
         <marko-web-element block-name=blockName name="section" attrs={ "aria-label": "Newsletter Sign-Up Form Footer"}>
           <if(!newsletterConfig.disabled && useIdxNewsletterSignup)>
-            <identity-x-newsletter-form-footer config-name=newsletterSignupConfigName />
+            <identity-x-newsletter-form-footer config-name=newsletterSignupConfigName ...input.newsletterBlockProps />
           </if>
           <else-if(!newsletterConfig.disabled && newsletterConfig.action)>
-            <theme-newsletter-signup-banner-external-block block-name="site-footer-newsletter" config-name=newsletterSignupConfigName />
+            <theme-newsletter-signup-banner-external-block
+              block-name="site-footer-newsletter"
+              config-name=newsletterSignupConfigName
+              ...input.newsletterBlockProps
+            />
           </else-if>
         </marko-web-element>
         <marko-web-element block-name=blockName name="section" attrs={ "aria-label": "Social Media Links" }>

--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -88,8 +88,8 @@ $ const navigation = {
 </marko-web-block>
 
 <if(useIdxNewsletterSignup)>
-  <identity-x-newsletter-form-pushdown />
+    <identity-x-newsletter-form-pushdown ...input.newsletterMenuBlockProps />
 </if>
 <else>
-  <theme-site-newsletter-menu />
+  <theme-site-newsletter-menu ...input.newsletterMenuBlockProps />
 </else>

--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -51,10 +51,10 @@ $ const navigation = {
     />
     <marko-web-element block-name="site-navbar" name="icon-wrapper">
       <!-- Newsletter Menue Toggler -->
-      <if(!newsletterConfig.disabled && useIdxNewsletterSignup)>
+      <if(!input.hasUser && !newsletterConfig.disabled && useIdxNewsletterSignup)>
         <marko-web-browser-component name="IdentityXNewsletterToggleButton" ssr=true />
       </if>
-      <else-if(!newsletterConfig.disabled)>
+      <else-if(!newsletterConfig.disabled && !useIdxNewsletterSignup)>
         <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />
       </else-if>
 


### PR DESCRIPTION
Conditionally show hid the newsletter menu toggle button

Add ability to pass newsletterMenuBlockProps & newsletterBlockProps through the site-header & site-footer components.  This allows you to set things like button labels & login email placeholder

Example:
```
$ const continueLable = i18n("Sign Me Up!");
$ const buttonLabels = { continue: continueLable };
<theme-site-header
  has-user=hasUser
  reg-enabled=isEnabled
  show-search-icon=true
  newsletter-menu-block-props={
    buttonLabels,
    loginEmailPlaceholder: 'your@email.com'
  }
/>
```