### PR TITLE
Return the function vs isFn check in i18n middleware

### DIFF
--- a/packages/marko-web-theme-monorail/middleware/i18n.js
+++ b/packages/marko-web-theme-monorail/middleware/i18n.js
@@ -7,6 +7,6 @@ const isFn = f => typeof f === 'function';
  */
 module.exports = (app, fn) => {
   const defaultFn = v => v;
-  const i18n = isFn(fn) || defaultFn;
+  const i18n = isFn(fn) ? fn : defaultFn;
   set(app.locals, 'i18n', i18n);
 };


### PR DESCRIPTION
Return the function instead of returning the isFn() instead of true when a function is sent