### PR TITLE
Add ability to put label above custom boolean question on profile form.

### DIFF
--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -14,6 +14,7 @@
       :required-client-fields="requiredClientFields"
       :hidden-fields="hiddenFields"
       :default-country-code="defaultCountryCode"
+      :boolean-questions-label="booleanQuestionsLabel"
       :consent-policy="consentPolicy"
       :email-consent-request="emailConsentRequest"
       :regional-consent-policies="regionalConsentPolicies"
@@ -105,6 +106,10 @@ export default {
       default: 'Submit',
     },
     defaultCountryCode: {
+      type: String,
+      default: null,
+    },
+    booleanQuestionsLabel: {
       type: String,
       default: null,
     },

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -100,6 +100,11 @@
 
         <div v-if="customBooleanFieldAnswers.length" class="row">
           <div
+            v-if="booleanQuestionsLabel"
+            class="col-12 boolean-questions-label"
+            v-html="booleanQuestionsLabel"
+          />
+          <div
             v-for="fieldAnswer in customBooleanFieldAnswers"
             :key="fieldAnswer.id"
             class="col-12"
@@ -277,6 +282,10 @@ export default {
       default: () => [],
     },
     defaultCountryCode: {
+      type: String,
+      default: null,
+    },
+    booleanQuestionsLabel: {
       type: String,
       default: null,
     },

--- a/packages/marko-web-identity-x/components/form-authenticate.marko
+++ b/packages/marko-web-identity-x/components/form-authenticate.marko
@@ -15,6 +15,7 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       requiredServerFields: identityX.config.getRequiredServerFields(),
       requiredClientFields: identityX.config.getRequiredClientFields(),
       defaultCountryCode: identityX.config.get('defaultCountryCode'),
+      booleanQuestionsLabel: identityX.config.get('booleanQuestionsLabel'),
       hiddenFields: identityX.config.getHiddenFields(),
       endpoints: identityX.config.getEndpoints(),
       callToAction: input.callToAction,

--- a/packages/marko-web-identity-x/components/form-profile.marko
+++ b/packages/marko-web-identity-x/components/form-profile.marko
@@ -15,6 +15,7 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       requiredClientFields: identityX.config.getRequiredClientFields(),
       hiddenFields: identityX.config.getHiddenFields(),
       defaultCountryCode: identityX.config.get('defaultCountryCode'),
+      booleanQuestionsLabel: identityX.config.get('booleanQuestionsLabel'),
       callToAction: input.callToAction,
       reloadPageOnSubmit: input.reloadPageOnSubmit,
       endpoints: identityX.config.getEndpoints(),

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -23,6 +23,7 @@ class IdentityXConfiguration {
     requiredClientFields = [],
     hiddenFields = ['city', 'street', 'addressExtra', 'phoneNumber'],
     defaultCountryCode,
+    booleanQuestionsLabel,
     onHookError,
     ...rest
   } = {}) {
@@ -34,6 +35,7 @@ class IdentityXConfiguration {
       requiredClientFields,
       hiddenFields,
       defaultCountryCode,
+      booleanQuestionsLabel,
       onHookError: (e) => {
         if (process.env.NODE_ENV === 'development') {
           log('ERROR IN IDENTITY-X HOOK', e);

--- a/packages/marko-web-theme-monorail/scss/components/_identity-x.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_identity-x.scss
@@ -1,0 +1,14 @@
+.page {
+  &--profile, &--authenticate {
+    .custom-control {
+      padding-left: 2rem;
+    }
+    .custom-control-label {
+      line-height: 1.4;
+    }
+    .boolean-questions-label {
+      @include skin-typography($style: "header-2", $link-style: "primary");
+      margin-bottom: map-get($spacers, 2)
+    }
+  }
+}

--- a/packages/marko-web-theme-monorail/scss/core.scss
+++ b/packages/marko-web-theme-monorail/scss/core.scss
@@ -20,6 +20,7 @@
 @import "./components/author-published-node";
 @import "./components/comments";
 @import "./components/content-page";
+@import "./components/identity-x";
 @import "./components/page-wrapper";
 @import "./components/pagination-controls";
 @import "./components/search-page";

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -7,7 +7,7 @@ module.exports = new IdentityXConfiguration({
   apiToken: process.env.IDENTITYX_API_TOKEN,
   requiredServerFields: ['givenName', 'familyName', 'countryCode'],
   requiredClientFields: ['regionCode', 'countryCode'],
-  booleanQuestionsLabel: 'Choose your subscriptions: ',
+  booleanQuestionsLabel: 'Choose your subscriptions:',
   hiddenFields: [],
   onHookError: (e) => {
     log('IDENTITY-X HOOK ERROR!', e);

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -7,6 +7,7 @@ module.exports = new IdentityXConfiguration({
   apiToken: process.env.IDENTITYX_API_TOKEN,
   requiredServerFields: ['givenName', 'familyName', 'countryCode'],
   requiredClientFields: ['regionCode', 'countryCode'],
+  booleanQuestionsLabel: 'Choose your subscriptions: ',
   hiddenFields: [],
   onHookError: (e) => {
     log('IDENTITY-X HOOK ERROR!', e);


### PR DESCRIPTION
Add the ability to configure a label to display above the list of custom boolean fields.  By default nothing is set.

When configured for PMMI & specifically set within MUNDO you will get the following:

<img width="1203" alt="Screen Shot 2022-07-11 at 11 12 11 AM" src="https://user-images.githubusercontent.com/3845869/178311683-0bd8760d-8b60-4588-87d6-877f386389a9.png">

<img width="1176" alt="Screen Shot 2022-07-11 at 11 12 01 AM" src="https://user-images.githubusercontent.com/3845869/178311669-5f529392-f065-4a32-b772-fd0870d70d24.png">

