### PR TITLE
Update native-x card deck styling

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/native-x-card-deck.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/native-x-card-deck.marko
@@ -57,6 +57,7 @@ $ const placement = nxConfig.getPlacement({ name: placementName, aliases });
           <marko-web-element name="node" block-name="card-deck-flow">
             <theme-content-node
               image-position="top"
+              modifiers=["content-card-deck"]
               card=true
               flush=true
               full-height=true

--- a/packages/marko-web-theme-monorail/components/blocks/native-x-card-deck.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/native-x-card-deck.marko
@@ -63,9 +63,9 @@ $ const placement = nxConfig.getPlacement({ name: placementName, aliases });
               full-height=true
               with-teaser=false
               with-dates=false
-              with-section=false
+              with-section=true
               ...input.node
-              ...convertAdToNode(ad)
+              ...convertAdToNode(ad, `Presented by ${ad.campaign.advertiserName}`)
             >
               <@image ar="3:2" fluid=true ...nodeImageInput />
             </theme-content-node>

--- a/packages/marko-web-theme-monorail/components/blocks/native-x-card-deck.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/native-x-card-deck.marko
@@ -65,7 +65,7 @@ $ const placement = nxConfig.getPlacement({ name: placementName, aliases });
               with-dates=false
               with-section=true
               ...input.node
-              ...convertAdToNode(ad, `Presented by ${ad.campaign.advertiserName}`)
+              ...convertAdToNode(ad, { sectionName: `Presented by ${ad.campaign.advertiserName}` })
             >
               <@image ar="3:2" fluid=true ...nodeImageInput />
             </theme-content-node>


### PR DESCRIPTION
Add modifier & section name to node.

**Before:**
<img width="1101" alt="Screen Shot 2022-07-13 at 9 27 54 PM" src="https://user-images.githubusercontent.com/2855198/178884957-5ea73386-1d3b-4b0b-9c90-bf0037fbed89.png">

**After:**
<img width="1109" alt="Screen Shot 2022-07-13 at 9 26 41 PM" src="https://user-images.githubusercontent.com/2855198/178884975-16dbf48c-7c43-4be4-9432-010a1239e701.png">
