### PR TITLE
Add nativeX story template & related story css

### DIFF
--- a/packages/marko-web-theme-monorail/routes/native-x.js
+++ b/packages/marko-web-theme-monorail/routes/native-x.js
@@ -1,0 +1,9 @@
+const withNativeXStory = require('@parameter1/base-cms-marko-web-native-x/middleware/with-story');
+const { getAsObject } = require('@parameter1/base-cms-object-path');
+const queryFragment = require('../graphql/fragments/native-x-story');
+const template = require('../templates/content/native-x-story');
+
+module.exports = (app) => {
+  const config = getAsObject(app, 'locals.nativeX');
+  app.get('/sponsored/:section/:slug/:id', withNativeXStory({ config, template, queryFragment }));
+};

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_related-native-x-stories.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_related-native-x-stories.scss
@@ -1,0 +1,14 @@
+.page-wrapper {
+  $self: &;
+  &__section {
+   &--related-native-x-stories:last-child {
+    margin-bottom: 30px;
+    @include media-breakpoint-up(md) {
+      margin-bottom: 60px;
+    }
+    #{ $self }__website-section-name {
+      margin-bottom: 20px;
+    }
+   }
+  }
+}

--- a/packages/marko-web-theme-monorail/scss/core.scss
+++ b/packages/marko-web-theme-monorail/scss/core.scss
@@ -50,6 +50,7 @@
 @import "./components/blocks/products";
 @import "./components/blocks/promo-card";
 @import "./components/blocks/read-next";
+@import "./components/blocks/related-native-x-stories";
 @import "./components/blocks/related-stories";
 @import "./components/blocks/resource-library";
 @import "./components/blocks/section-card-deck-featured";

--- a/packages/marko-web-theme-monorail/templates/content/components/presented-by.marko
+++ b/packages/marko-web-theme-monorail/templates/content/components/presented-by.marko
@@ -1,0 +1,22 @@
+import { buildImgixUrl } from "@parameter1/base-cms-image";
+import { get } from "@parameter1/base-cms-object-path";
+
+$ const { advertiser } = input;
+$ const imgDefaults = { auto: "format,compress", h: 50 };
+$ const imgSrc = get(advertiser, "logo.src");
+
+<if(imgSrc)>
+  $ const src = buildImgixUrl(imgSrc, imgDefaults);
+  $ const srcset = [`${src}&dpr=2 2x`];
+  <marko-web-block name="sponsor-logo">
+    <marko-web-element block-name="sponsor-logo" name="label">
+      Presented by
+    </marko-web-element>
+    <marko-web-img
+      class="sponsor-logo__logo"
+      src=src
+      srcset=srcset
+      alt="Sponsor Logo"
+    />
+  </marko-web-block>
+</if>

--- a/packages/marko-web-theme-monorail/templates/content/native-x-story.marko
+++ b/packages/marko-web-theme-monorail/templates/content/native-x-story.marko
@@ -1,0 +1,82 @@
+import convert from "@parameter1/base-cms-marko-web-native-x/utils/convert-story-to-content";
+
+$ const { nativeX } = out.global;
+
+$ const { story } = input;
+$ const content = convert(story);
+$ const { id, type } = content;
+$ const { primarySection } = content;
+
+<theme-default-page title=story.title description=story.teaser>
+  <@head>
+    <marko-web-native-x-gtm-init />
+  </@head>
+  <@page>
+    <marko-web-native-x-story-track-init story=story />
+    <marko-web-native-x-story-track-page-view />
+    <marko-web-native-x-story-track-social-share />
+
+    <marko-web-page-wrapper>
+      <@section|{ blockName }| modifiers=["nativex-story-header"]>
+        <div class="content-page-header">
+          <theme-breadcrumbs modifiers=["content-page"]>
+            <@item>
+              ${primarySection.name}
+            </@item>
+          </theme-breadcrumbs>
+          <marko-web-content-name tag="h1" block-name=blockName obj=content />
+          <presented-by advertiser=story.advertiser />
+        </div>
+      </@section>
+
+      <@section>
+        <div class="content-page-body" id="native-x-story-body">
+          <default-theme-page-contents|{ blockName }|>
+            <theme-primary-image-block obj=content.primaryImage />
+            <marko-web-content-body block-name=blockName obj=content />
+            <marko-web-social-sharing
+              url=content.siteContext.canonicalUrl
+              providers=["facebook", "linkedin", "twitter", "pinterest"]
+            />
+          </default-theme-page-contents>
+        </div>
+      </@section>
+
+      <@section modifiers=["related-native-x-stories"]>
+        <if(nativeX.publisherId)>
+          <marko-web-native-x-story-advertiser-related-stories|{ nodes }|
+            publisher-id=nativeX.publisherId
+            advertiser-id=story.advertiser.id
+            exclude-story-ids=[story.id]
+          >
+            <marko-web-node-list
+              inner-justified=true
+              flush-x=true
+              flush-y=false
+              modifiers=["section-feed"]
+            >
+              <@header>
+                <h2 title=`More from ${story.advertiser.name}` class="page-wrapper__website-section-name" >
+                  More from ${story.advertiser.name}
+                </h2>
+              </@header>
+              <@nodes nodes=nodes>
+                <@slot|{ node }|>
+                  <theme-section-feed-content-node
+                    node=convert(node)
+                    display-image=true
+                    with-section=false
+                    lazyload=false
+                  />
+                </@slot>
+              </@nodes>
+            </marko-web-node-list>
+          </marko-web-native-x-story-advertiser-related-stories>
+        </if>
+      </@section>
+    </marko-web-page-wrapper>
+
+    <marko-web-native-x-story-track-outbound-links container="#native-x-story-body" />
+    <marko-web-native-x-story-track-end-of-content />
+  </@page>
+</theme-default-page>


### PR DESCRIPTION
This will require the `config.publisherId = '${publication-id-from-native-x}';` be set in the site's native-x config

<img width="416" alt="Screen Shot 2022-07-14 at 8 41 27 AM" src="https://user-images.githubusercontent.com/3845869/178996247-edfacd94-0f52-4b6e-912c-835207d4d402.png">
