### PR TITLE
Allow for pass through of ```loginEmailLabel``` for newsletter signups

### DIFF
--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -34,6 +34,7 @@
         v-model="email"
         :placeholder="loginEmailPlaceholder"
         :disabled="loading"
+        :label="loginEmailLabel"
       />
       <small
         v-if="consentPolicy"
@@ -128,6 +129,10 @@ export default {
     actionText: {
       type: String,
       default: 'logging in',
+    },
+    loginEmailLabel: {
+      type: String,
+      default: 'Email Address',
     },
 
     /**

--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
@@ -23,7 +23,7 @@
             :consent-policy="consentPolicy"
             :regional-consent-policies="regionalConsentPolicies"
             :app-context-id="appContextId"
-            :login-email-label="translateEmail('emailAddress')"
+            :login-email-label="translateEmail"
             success-message-type="newsletter-signup"
             @login-link-sent="handleLoginLinkSent"
           />
@@ -145,6 +145,13 @@ export default {
     submitted: false,
   }),
 
+  computed: {
+    translateEmail() {
+      if (this.loginEmailLabel) return this.loginEmailLabel;
+      return i18n(this.lang, 'emailAddress');
+    },
+  },
+
   watch: {
     didView(value) {
       if (value) this.$emit('view', { step: 1 });
@@ -167,10 +174,6 @@ export default {
     },
     handleLoginLinkSent() {
       this.submitted = true;
-    },
-    translateEmail(key) {
-      if (this.loginEmailLabel) return this.loginEmailLabel;
-      return i18n(this.lang, key);
     },
   },
 };

--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
@@ -23,6 +23,7 @@
             :consent-policy="consentPolicy"
             :regional-consent-policies="regionalConsentPolicies"
             :app-context-id="appContextId"
+            :login-email-label="translateEmail('emailAddress')"
             success-message-type="newsletter-signup"
             @login-link-sent="handleLoginLinkSent"
           />
@@ -34,6 +35,7 @@
 
 <script>
 import LoginForm from '@parameter1/base-cms-marko-web-identity-x/browser/login.vue';
+import i18n from '../i18n-vue';
 
 export default {
   inject: ['EventBus'],
@@ -121,6 +123,10 @@ export default {
         forceProfileReVerification: true,
       }),
     },
+    loginEmailLabel: {
+      type: String,
+      default: '',
+    },
     /**
      * Regional consent polices to display (if/when a user selects a country on login)
      * if enabled.
@@ -161,6 +167,10 @@ export default {
     },
     handleLoginLinkSent() {
       this.submitted = true;
+    },
+    translateEmail(key) {
+      if (this.loginEmailLabel) return this.loginEmailLabel;
+      return i18n(this.lang, key);
     },
   },
 };

--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
@@ -29,6 +29,7 @@
             :regional-consent-policies="regionalConsentPolicies"
             :app-context-id="appContextId"
             :action-text="actionText"
+            :login-email-label="translateEmail('emailAddress')"
             @login-link-sent="handleLoginLinkSent"
           />
         </div>
@@ -47,6 +48,7 @@
 <script>
 import LoginForm from '@parameter1/base-cms-marko-web-identity-x/browser/login.vue';
 import CloseButton from '../newsletter-close-button.vue';
+import i18n from '../i18n-vue';
 
 export default {
   inject: ['EventBus'],
@@ -138,6 +140,10 @@ export default {
       type: Object,
       default: null,
     },
+    loginEmailLabel: {
+      type: String,
+      default: '',
+    },
 
     /**
      * Regional consent polices to display (if/when a user selects a country on login)
@@ -197,6 +203,10 @@ export default {
     },
     handleLoginLinkSent() {
       this.submitted = true;
+    },
+    translateEmail(key) {
+      if (this.loginEmailLabel) return this.loginEmailLabel;
+      return i18n(this.lang, key);
     },
   },
 };

--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
@@ -29,7 +29,7 @@
             :regional-consent-policies="regionalConsentPolicies"
             :app-context-id="appContextId"
             :action-text="actionText"
-            :login-email-label="translateEmail('emailAddress')"
+            :login-email-label="translateEmail"
             @login-link-sent="handleLoginLinkSent"
           />
         </div>
@@ -181,6 +181,10 @@ export default {
       if (this.currentlyExpanded) classes.push(`${blockName}--open`);
       return classes;
     },
+    translateEmail() {
+      if (this.loginEmailLabel) return this.loginEmailLabel;
+      return i18n(this.lang, 'emailAddress');
+    },
   },
 
   watch: {
@@ -203,10 +207,6 @@ export default {
     },
     handleLoginLinkSent() {
       this.submitted = true;
-    },
-    translateEmail(key) {
-      if (this.loginEmailLabel) return this.loginEmailLabel;
-      return i18n(this.lang, key);
     },
   },
 };

--- a/packages/marko-web-theme-monorail/browser/translations-vue.js
+++ b/packages/marko-web-theme-monorail/browser/translations-vue.js
@@ -1,6 +1,8 @@
 export default {
   en: {
     visitSiteLabel: 'Visit Site',
+    // Email Signup
+    emailAddress: 'Email Address',
     // Email Signup Privacy Policy
     emailProviding: 'By providing your email, you agree to our',
     protectedBy: 'This site is protected by reCAPTCHA and the Google',
@@ -23,8 +25,9 @@ export default {
   },
   es: {
     visitSiteLabel: 'Visite el sitio',
+    // Email Signup
+    emailAddress: 'Correo Electrónico',
     // Email Signup Privacy Policy
-
     emailProviding: 'Al darnos su correo electrónico usted acepta nuestra',
     protectedBy: 'Este sitio está protegido por reCAPTCHA y por la Política de Privacidad de Google',
     privacyPolicy: 'Política de Privacidad',

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-footer.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-footer.marko
@@ -40,6 +40,7 @@ $ const lang = site.config.lang || "en";
           buttonLabels,
           redirect: input.redirect,
           loginEmailPlaceholder,
+          loginEmailLabel: input.loginEmailLabel,
           consentPolicy: get(application, "organization.consentPolicy"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
           appContextId: identityX.config.get("appContextId"),

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
@@ -43,6 +43,7 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
           buttonLabels,
           redirect: input.redirect,
           loginEmailPlaceholder,
+          loginEmailLabel: input.loginEmailLabel,
           consentPolicy: get(application, "organization.consentPolicy"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
           appContextId: identityX.config.get("appContextId"),

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
@@ -43,6 +43,7 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
           buttonLabels,
           redirect: input.redirect,
           loginEmailPlaceholder,
+          loginEmailLabel: input.loginEmailLabel,
           consentPolicy: get(application, "organization.consentPolicy"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
           appContextId: identityX.config.get("appContextId"),


### PR DESCRIPTION
![Footer](https://user-images.githubusercontent.com/46794001/179813955-282d1918-7a80-4601-ae35-72940801e539.png)
![Pushdown](https://user-images.githubusercontent.com/46794001/179813964-0ea4317c-8067-4911-a080-e0a62af3d7b4.png)

Unless additionally provided, by default it will use the "translation default" for the current language (Either English or Spanish currently) found in https://github.com/Shinsina/base-cms/blob/e4aef070f3779a0ae0b0f3d6f4d402dae2ccd979/packages/marko-web-theme-monorail/browser/translations-vue.js


PMMI (who requested a different label) will need to have their forms updated accordingly in order to get the form inputs labeled correctly after having this merged and their dependencies upgraded.