### PR TITLE
Add disabled check to newsletter-menu pushdown inclusion.

### DIFF
--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -6,7 +6,13 @@ $ const { config, site } = out.global;
 $ const newsletterConfig = site.getAsObject('newsletter.pushdown');
 $ const newsletterMenuBlockProps = getAsObject(input, "newsletterMenuBlockProps");
 $ const blockName = input.blockName || "site-header";
+
+// Newsletter Signup block display logic
 $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true);
+$ const newsletterSignupDisabled = newsletterConfig.disabled;
+$ const showIdxNewsletterSignup = !newsletterSignupDisabled && useIdxNewsletterSignup && !input.hasUser;
+$ const showNewsletterSignup = !newsletterSignupDisabled && !showIdxNewsletterSignup;
+
 $ const showSearchIcon = defaultValue(input.showSearchIcon, false);
 $ const menuBtnPosition = defaultValue(input.menuBtnPosition, 'left');
 
@@ -53,10 +59,10 @@ $ const navigation = {
     />
     <marko-web-element block-name="site-navbar" name="icon-wrapper">
       <!-- Newsletter Menue Toggler -->
-      <if(!input.hasUser && !newsletterConfig.disabled && useIdxNewsletterSignup)>
+      <if(showIdxNewsletterSignup)>
         <marko-web-browser-component name="IdentityXNewsletterToggleButton" ssr=true />
       </if>
-      <else-if(!newsletterConfig.disabled && !useIdxNewsletterSignup)>
+      <else-if(showNewsletterSignup)>
         <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />
       </else-if>
 
@@ -89,9 +95,9 @@ $ const navigation = {
   <${input.belowNav} />
 </marko-web-block>
 
-<if(!input.hasUser && !newsletterConfig.disabled && useIdxNewsletterSignup)>
-    <identity-x-newsletter-form-pushdown ...newsletterMenuBlockProps />
+<if(showIdxNewsletterSignup)>
+  <identity-x-newsletter-form-pushdown ...newsletterMenuBlockProps />
 </if>
-<else-if(!newsletterConfig.disabled && !useIdxNewsletterSignup)>
+<else-if(showNewsletterSignup)>
   <theme-site-newsletter-menu ...newsletterMenuBlockProps />
 </else-if>

--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -9,9 +9,8 @@ $ const blockName = input.blockName || "site-header";
 
 // Newsletter Signup block display logic
 $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true);
-$ const newsletterSignupDisabled = newsletterConfig.disabled;
-$ const showIdxNewsletterSignup = !newsletterSignupDisabled && useIdxNewsletterSignup && !input.hasUser;
-$ const showNewsletterSignup = !newsletterSignupDisabled && !showIdxNewsletterSignup;
+$ const enableIdxNewsletterSignup = !newsletterConfig.disabled && useIdxNewsletterSignup && !input.hasUser;
+$ const enableNewsletterSignup = !newsletterConfig.disabled && !enableIdxNewsletterSignup;
 
 $ const showSearchIcon = defaultValue(input.showSearchIcon, false);
 $ const menuBtnPosition = defaultValue(input.menuBtnPosition, 'left');
@@ -59,10 +58,10 @@ $ const navigation = {
     />
     <marko-web-element block-name="site-navbar" name="icon-wrapper">
       <!-- Newsletter Menue Toggler -->
-      <if(showIdxNewsletterSignup)>
+      <if(enableIdxNewsletterSignup)>
         <marko-web-browser-component name="IdentityXNewsletterToggleButton" ssr=true />
       </if>
-      <else-if(showNewsletterSignup)>
+      <else-if(enableNewsletterSignup)>
         <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />
       </else-if>
 
@@ -95,9 +94,9 @@ $ const navigation = {
   <${input.belowNav} />
 </marko-web-block>
 
-<if(showIdxNewsletterSignup)>
+<if(enableIdxNewsletterSignup)>
   <identity-x-newsletter-form-pushdown ...newsletterMenuBlockProps />
 </if>
-<else-if(showNewsletterSignup)>
+<else-if(enableNewsletterSignup)>
   <theme-site-newsletter-menu ...newsletterMenuBlockProps />
 </else-if>

--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -89,9 +89,9 @@ $ const navigation = {
   <${input.belowNav} />
 </marko-web-block>
 
-<if(useIdxNewsletterSignup)>
+<if(!input.hasUser && !newsletterConfig.disabled && useIdxNewsletterSignup)>
     <identity-x-newsletter-form-pushdown ...newsletterMenuBlockProps />
 </if>
-<else>
+<else-if(!newsletterConfig.disabled && !useIdxNewsletterSignup)>
   <theme-site-newsletter-menu ...newsletterMenuBlockProps />
-</else>
+</else-if>

--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -9,8 +9,9 @@ $ const blockName = input.blockName || "site-header";
 
 // Newsletter Signup block display logic
 $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true);
-$ const enableIdxNewsletterSignup = !newsletterConfig.disabled && useIdxNewsletterSignup && !input.hasUser;
-$ const enableNewsletterSignup = !newsletterConfig.disabled && !enableIdxNewsletterSignup;
+$ const enableIdxNewsletterSignup = !newsletterConfig.disabled && useIdxNewsletterSignup;
+$ const showIdxNewsletterSignup = enableIdxNewsletterSignup && !input.hasUser;
+$ const showNewsletterSignup = !newsletterConfig.disabled && !enableIdxNewsletterSignup;
 
 $ const showSearchIcon = defaultValue(input.showSearchIcon, false);
 $ const menuBtnPosition = defaultValue(input.menuBtnPosition, 'left');
@@ -58,10 +59,10 @@ $ const navigation = {
     />
     <marko-web-element block-name="site-navbar" name="icon-wrapper">
       <!-- Newsletter Menue Toggler -->
-      <if(enableIdxNewsletterSignup)>
+      <if(showIdxNewsletterSignup)>
         <marko-web-browser-component name="IdentityXNewsletterToggleButton" ssr=true />
       </if>
-      <else-if(enableNewsletterSignup)>
+      <else-if(showNewsletterSignup)>
         <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />
       </else-if>
 
@@ -94,9 +95,9 @@ $ const navigation = {
   <${input.belowNav} />
 </marko-web-block>
 
-<if(enableIdxNewsletterSignup)>
+<if(showIdxNewsletterSignup)>
   <identity-x-newsletter-form-pushdown ...newsletterMenuBlockProps />
 </if>
-<else-if(enableNewsletterSignup)>
+<else-if(showNewsletterSignup)>
   <theme-site-newsletter-menu ...newsletterMenuBlockProps />
 </else-if>


### PR DESCRIPTION
Only add this component when the newsletter signup is enabled.  This will prevent the newsletter signup middleware from displaying the signup bock when a user first visit the site.  I also added the user check to match the menu toggle button inclusion on line 56/59