### PR TITLE
Adjust comment stream css to account for comment count

### DIFF
--- a/packages/marko-web-theme-monorail/scss/components/_comments.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_comments.scss
@@ -39,12 +39,17 @@ $bottom-gradient-height: 180px !default;
   .idx-comment-stream {
     &:not(.idx-comment-stream__counter--1) {
       max-height: $comment-start-height;
+      overflow: hidden;
     }
   }
   &--open {
     .idx-comment-stream {
       max-height: 100%;
       overflow: visible;
+      &:not(.idx-comment-stream__counter--1) {
+        max-height: initial;
+        overflow: visible;
+      }
     }
     height: initial;
     max-height: initial;
@@ -59,7 +64,6 @@ $bottom-gradient-height: 180px !default;
 
 .idx-comment-stream {
   $self: &;
-  overflow: hidden;
   position: relative;
   display: block;
   padding-top: map-get($spacers, block);

--- a/packages/marko-web-theme-monorail/scss/components/_comments.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_comments.scss
@@ -31,14 +31,21 @@ $bottom-gradient-height: 180px !default;
   }
 }
 .idx-comment-stream-wrapper {
-  max-height: $comment-start-height;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
   margin-top: 24px;
   border-radius: 4px;
   border: 1px solid $gray-200;
+  .idx-comment-stream {
+    &:not(.idx-comment-stream__counter--1) {
+      max-height: $comment-start-height;
+    }
+  }
   &--open {
+    .idx-comment-stream {
+      max-height: 100%;
+      overflow: visible;
+    }
     height: initial;
     max-height: initial;
     .idx-comment-stream ~ .comment-stream__toggle-btn {
@@ -52,7 +59,6 @@ $bottom-gradient-height: 180px !default;
 
 .idx-comment-stream {
   $self: &;
-  max-height: 100%;
   overflow: hidden;
   position: relative;
   display: block;


### PR DESCRIPTION
Move max-height and hiding of overflow done from the wrapper to the actual comment stream.  This allows use to account for the where there are no comments or a single comment displaying the whole stream.

By default now the $comment-start-height ~ max-height will be applied stream instead of the wrapper(stream + toggle button).  It will also not set it when there are no comments or only a single comment.

Also moved the show comments transition when the toggle button is pressed.

### Multi Comments:
<img width="544" alt="Screen Shot 2022-07-25 at 10 53 59 AM" src="https://user-images.githubusercontent.com/3845869/180823187-101b19ed-fa5d-4bf4-a392-08f137acc8b5.png">

### Single Comment:
<img width="409" alt="Screen Shot 2022-07-25 at 10 53 41 AM" src="https://user-images.githubusercontent.com/3845869/180823271-67aa054f-b4aa-4229-9377-d7c7d2fa5f6b.png">

### No Comments
<img width="413" alt="Screen Shot 2022-07-25 at 11 00 45 AM" src="https://user-images.githubusercontent.com/3845869/180823349-99c50bb9-b67d-468d-bfeb-16cb22dcaf4d.png">
:

