### PR TITLE
Allow section renaming in list blocks, Monorail

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/section-list-deck.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-list-deck.marko
@@ -5,15 +5,22 @@ $ const aliases = getAsArray(input, "aliases");
 $ const sections = getAsArray(input, "sections")
 
 <marko-web-block name=blockName>
-  <marko-web-element block-name=blockName name="row">
-    <marko-web-element block-name=blockName name="col">
-      <theme-section-list-block alias=aliases[0] section=sections[0] />
+  <if(aliases.length)>
+    <marko-web-element block-name=blockName name="row">
+      <for|alias| of=aliases>
+        <marko-web-element block-name=blockName name="col">
+          <theme-section-list-block alias=alias />
+        </marko-web-element>
+      </for>
     </marko-web-element>
-    <marko-web-element block-name=blockName name="col">
-      <theme-section-list-block alias=aliases[1] section=sections[1] />
+  </if>
+  <else-if(sections.length)>
+    <marko-web-element block-name=blockName name="row">
+      <for|section| of=sections>
+        <marko-web-element block-name=blockName name="col">
+          <theme-section-list-block section=section />
+        </marko-web-element>
+      </for>
     </marko-web-element>
-    <marko-web-element block-name=blockName name="col">
-      <theme-section-list-block alias=aliases[2] section=sections[2] />
-    </marko-web-element>
-  </marko-web-element>
+  </else-if>
 </marko-web-block>

--- a/packages/marko-web-theme-monorail/components/blocks/section-list-deck.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-list-deck.marko
@@ -2,17 +2,18 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const blockName = "section-list-deck";
 $ const aliases = getAsArray(input, "aliases");
+$ const names = getAsArray(input, "names");
 
 <marko-web-block name=blockName>
   <marko-web-element block-name=blockName name="row">
     <marko-web-element block-name=blockName name="col">
-      <theme-section-list-block alias=aliases[0] />
+      <theme-section-list-block alias=aliases[0] name=names[0] />
     </marko-web-element>
     <marko-web-element block-name=blockName name="col">
-      <theme-section-list-block alias=aliases[1] />
+      <theme-section-list-block alias=aliases[1] name=names[1] />
     </marko-web-element>
     <marko-web-element block-name=blockName name="col">
-      <theme-section-list-block alias=aliases[2] />
+      <theme-section-list-block alias=aliases[2] name=names[2] />
     </marko-web-element>
   </marko-web-element>
 </marko-web-block>

--- a/packages/marko-web-theme-monorail/components/blocks/section-list-deck.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-list-deck.marko
@@ -2,7 +2,19 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const blockName = "section-list-deck";
 $ const aliases = getAsArray(input, "aliases");
-$ const sections = getAsArray(input, "sections")
+$ const sections = getAsArray(input, "sections");
+
+$ if (sections.length && aliases.length) {
+    process.emitWarning(
+    '<theme-section-list-deck-block />. Aliases takes precedent over sections, pick one!',
+    'UnsupportedWarning'
+  );
+} else if (sections.length > 3 || aliases.length > 3) {
+  process.emitWarning(
+    '<theme-section-list-deck-block /> is designed for at most 3 sections, use an additional theme-section-list-deck-block for additional section(s)',
+    'UnsupportedWarning'
+  );
+};
 
 <marko-web-block name=blockName>
   <if(aliases.length)>

--- a/packages/marko-web-theme-monorail/components/blocks/section-list-deck.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-list-deck.marko
@@ -2,18 +2,18 @@ import { getAsArray } from "@parameter1/base-cms-object-path";
 
 $ const blockName = "section-list-deck";
 $ const aliases = getAsArray(input, "aliases");
-$ const names = getAsArray(input, "names");
+$ const sections = getAsArray(input, "sections")
 
 <marko-web-block name=blockName>
   <marko-web-element block-name=blockName name="row">
     <marko-web-element block-name=blockName name="col">
-      <theme-section-list-block alias=aliases[0] name=names[0] />
+      <theme-section-list-block alias=aliases[0] section=sections[0] />
     </marko-web-element>
     <marko-web-element block-name=blockName name="col">
-      <theme-section-list-block alias=aliases[1] name=names[1] />
+      <theme-section-list-block alias=aliases[1] section=sections[1] />
     </marko-web-element>
     <marko-web-element block-name=blockName name="col">
-      <theme-section-list-block alias=aliases[2] name=names[2] />
+      <theme-section-list-block alias=aliases[2] section=sections[2] />
     </marko-web-element>
   </marko-web-element>
 </marko-web-block>

--- a/packages/marko-web-theme-monorail/components/blocks/section-list.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-list.marko
@@ -6,17 +6,18 @@ import sectionFragment from "../../graphql/fragments/section-info";
 
 $ const { i18n } = out.global;
 
-$ const { alias, name } = input;
+$ const { alias, section: inputSection } = input;
 
 $ const withSection = defaultValue(input.withSection, true);
 $ const withViewMore = defaultValue(input.withViewMore, true);
+$ const sectionAlias = inputSection && inputSection.alias ? inputSection.alias : alias;
 
 $ const queryParams = {
   limit: 4,
   ...getAsObject(input, "queryParams"),
   queryFragment: listFragment,
   sectionFragment,
-  sectionAlias: alias,
+  sectionAlias,
 };
 $ const heroParams = {
   ...queryParams,
@@ -43,7 +44,7 @@ $ const blockName = "section-list";
       modifiers=[blockName]
     >
       <@header>
-        $ const obj = { ...section, ...(name && { name })};
+        $ const obj = { ...section, ...inputSection };
         <marko-web-website-section-name obj=obj link=true />
       </@header>
       <@nodes nodes=nodes>

--- a/packages/marko-web-theme-monorail/components/blocks/section-list.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-list.marko
@@ -6,7 +6,7 @@ import sectionFragment from "../../graphql/fragments/section-info";
 
 $ const { i18n } = out.global;
 
-$ const { alias } = input;
+$ const { alias, name } = input;
 
 $ const withSection = defaultValue(input.withSection, true);
 $ const withViewMore = defaultValue(input.withViewMore, true);
@@ -43,7 +43,8 @@ $ const blockName = "section-list";
       modifiers=[blockName]
     >
       <@header>
-        <marko-web-website-section-name obj=section link=true />
+        $ const obj = { ...section, ...(name && { name })};
+        <marko-web-website-section-name obj=obj link=true />
       </@header>
       <@nodes nodes=nodes>
         <@slot|{ node, index }|>


### PR DESCRIPTION
![podcasts-section-homepage](https://user-images.githubusercontent.com/46794001/182157319-2b77a6df-4ad5-463a-87dd-826e702011cc.png)

(The podcasts section shown here is actually called AW Podcasts for clarify from the editorial/management side so the name needs to be adjusted on site to only show "Podcasts")