### PR TITLE
Switch out newsletter toggle icon & pushdown title/description base on presence of user

### DIFF
--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/toggle-button.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/toggle-button.vue
@@ -5,22 +5,39 @@
     aria-label="Newsletter Menu Toggle"
     @click="toggle"
   >
-    <icon-mail :modifiers="['lg']" />
+    <component :is="icon" :modifiers="['lg']" />
   </button>
 </template>
 
 <script>
 import IconMail from '@parameter1/base-cms-marko-web-icons/browser/mail.vue';
+import IconPerson from '@parameter1/base-cms-marko-web-icons/browser/person.vue';
+
+const validateIcon = v => ['mail', 'person'].includes(v);
 
 export default {
   inject: ['EventBus'],
   components: {
     IconMail,
+    IconPerson,
+  },
+  props: {
+    iconName: {
+      type: String,
+      default: 'mail',
+      validator: validateIcon,
+    },
   },
 
   data: () => ({
     expanded: false,
   }),
+
+  computed: {
+    icon() {
+      return `icon-${this.iconName}`;
+    },
+  },
 
   methods: {
     toggle() {

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
@@ -13,10 +13,12 @@ $ const configName = defaultValue(input.configName, 'pushdown');
 $ const {
   name,
   description,
+  withUserName,
+  withUserDescription,
   imagePath,
   disabled,
 } = site.getAsObject(`newsletter.${configName}`);
-
+$ console.log(name, withUserName, description, withUserDescription);
 $ const lang = site.config.lang || "en";
 $ const { initiallyExpanded } = getAsObject(out.global, "newsletterState");
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 280, auto: "format,compress" }) : null;
@@ -29,8 +31,8 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
         name="IdentityXNewsletterFormPushdown"
         props={
           siteName: config.website("name"),
-          name,
-          description,
+          name: (user && withUserName) ? withUserName : name,
+          description: (user && withUserDescription) ? withUserDescription : description,
           disabled,
           imageSrc,
           imageSrcset,

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
@@ -18,7 +18,6 @@ $ const {
   imagePath,
   disabled,
 } = site.getAsObject(`newsletter.${configName}`);
-$ console.log(name, withUserName, description, withUserDescription);
 $ const lang = site.config.lang || "en";
 $ const { initiallyExpanded } = getAsObject(out.global, "newsletterState");
 $ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 280, auto: "format,compress" }) : null;

--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -10,9 +10,9 @@ $ const blockName = input.blockName || "site-header";
 // Newsletter Signup block display logic
 $ const useIdxNewsletterSignup = defaultValue(input.useIdxNewsletterSignup, true);
 $ const enableIdxNewsletterSignup = !newsletterConfig.disabled && useIdxNewsletterSignup;
-$ const showIdxNewsletterSignup = enableIdxNewsletterSignup && !input.hasUser;
+$ const showIdxNewsletterSignup = enableIdxNewsletterSignup;
+$ const idxNesletterSignupIcon = (input.hasUser) ? 'person' : 'mail';
 $ const showNewsletterSignup = !newsletterConfig.disabled && !enableIdxNewsletterSignup;
-
 $ const showSearchIcon = defaultValue(input.showSearchIcon, false);
 $ const menuBtnPosition = defaultValue(input.menuBtnPosition, 'left');
 
@@ -60,7 +60,7 @@ $ const navigation = {
     <marko-web-element block-name="site-navbar" name="icon-wrapper">
       <!-- Newsletter Menue Toggler -->
       <if(showIdxNewsletterSignup)>
-        <marko-web-browser-component name="IdentityXNewsletterToggleButton" ssr=true />
+        <marko-web-browser-component name="IdentityXNewsletterToggleButton" props={ iconName: idxNesletterSignupIcon } ssr=true />
       </if>
       <else-if(showNewsletterSignup)>
         <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />

--- a/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
@@ -447,3 +447,13 @@
     }
   }
 }
+
+.site-navbar {
+  &__idx-newsletter-toggler {
+    .marko-web-icon {
+      &--person svg {
+        fill: $primary;
+      }
+    }
+  }
+}


### PR DESCRIPTION
When there is no user it will display the envelope icon with the pushdown name & description field.  After a user is logged in it will switch the icon to the person icon and set the title and description to the withUserTitle & withUserDescription set in the config, if set.  

example pushdown config: 
```
pushdown: {
  name: 'Join thousands of your peers!',
  description: 'Automation intelligence and updates from <strong>Automation World</strong> delivered to your inbox.',
  withUserName: 'Manage your newsletter preferences!',
  withUserDescription: ' ',
  imagePath: 'files/base/pmmi/all/image/static/newsletter-pushdown/aw-iphone-Cropped.png',
},
```
### Logged out Screenshot:
<img width="877" alt="Screen Shot 2022-08-02 at 11 25 37 AM" src="https://user-images.githubusercontent.com/3845869/182425191-7fc14ded-95bd-4b94-a8db-8635f0119bb2.png">

### Logged in Screenshot: 
<img width="869" alt="Screen Shot 2022-08-02 at 11 24 00 AM" src="https://user-images.githubusercontent.com/3845869/182425120-a3d1cd26-454a-4f93-8d7f-40347fea58ee.png">

