### PR TITLE
Add companyInquiryFormBlock to monorail

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/company-inquiry-form.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/company-inquiry-form.marko
@@ -1,0 +1,26 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { content } = input;
+$ const initiallyExpanded = defaultValue(input.initiallyExpanded, true)
+$ const modifiers = initiallyExpanded ? ["open"] : [];
+
+<marko-web-node-list class="node-list" block-name="inquiry-form" modifiers=modifiers collapsible=false>
+  <@header>
+    <marko-web-browser-component
+      name="ThemeMenuToggleButton"
+      props={
+        className: 'inquiry-form-button btn btn-primary',
+        before: 'Request More Info',
+        targets: ['.node-list.inquiry-form'],
+        toggleClass: 'inquiry-form--open',
+        iconName: 'chevron-down',
+        initiallyExpanded,
+        expandedIconName: 'chevron-up',
+      }
+      ssr=true
+    />
+  </@header>
+  <@body>
+    <marko-web-inquiry-form content=content with-header=false />
+  </@body>
+</marko-web-node-list>

--- a/packages/marko-web-theme-monorail/components/blocks/marko.json
+++ b/packages/marko-web-theme-monorail/components/blocks/marko.json
@@ -13,6 +13,11 @@
     "@section": "object",
     "@view-more": "boolean"
   },
+  "<theme-company-inquiry-form-block>": {
+    "template": "./company-inquiry-form.marko",
+    "@content": {},
+    "@initially-expanded": "boolean"
+  },
   "<theme-full-width-native-ad-block>": {
     "template": "./full-width-native-ad.marko"
   },

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_company-inquiry-form.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_company-inquiry-form.scss
@@ -1,0 +1,27 @@
+.node-list {
+  $self: &;
+  &__header {
+    .inquiry-form-button {
+      &:focus,
+      &:hover {
+        background-color: $primary;
+      }
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+  &__body {
+    display: none;
+  }
+  &.inquiry-form {
+    .marko-web-icon svg {
+      fill: $white;
+    }
+    &--open {
+      #{ $self }__body {
+        display: block;
+      }
+    }
+  }
+}

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_company-inquiry-form.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_company-inquiry-form.scss
@@ -1,22 +1,22 @@
 .node-list {
   $self: &;
-  &__header {
-    .inquiry-form-button {
-      &:focus,
-      &:hover {
-        background-color: $primary;
-      }
-      width: 100%;
-      display: flex;
-      justify-content: space-between;
-    }
-  }
-  &__body {
-    display: none;
-  }
   &.inquiry-form {
     .marko-web-icon svg {
       fill: $white;
+    }
+    #{ $self }__header {
+      .inquiry-form-button {
+        &:focus,
+        &:hover {
+          background-color: $primary;
+        }
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+      }
+    }
+    #{ $self }__body {
+      display: none;
     }
     &--open {
       #{ $self }__body {

--- a/packages/marko-web-theme-monorail/scss/core.scss
+++ b/packages/marko-web-theme-monorail/scss/core.scss
@@ -35,6 +35,7 @@
 // theme component blocks
 @import "./components/blocks/callout-cards";
 @import "./components/blocks/content-card-deck";
+@import "./components/blocks/company-inquiry-form";
 @import "./components/blocks/hero-card";
 @import "./components/blocks/latest-content-list";
 @import "./components/blocks/latest-podcast";


### PR DESCRIPTION
Add new company-inquiry-form.marko compoent to monorail that allows for the form to be collapsed/expanded
<img width="856" alt="Screen Shot 2022-08-03 at 11 25 54 AM" src="https://user-images.githubusercontent.com/3845869/182660252-dbd28572-1761-4e7c-9e41-6d5885c19647.png">
<img width="882" alt="Screen Shot 2022-08-03 at 11 26 00 AM" src="https://user-images.githubusercontent.com/3845869/182660271-3e3eb3be-aa4a-4b06-b024-81db5b27ae71.png">

