### PR TITLE
Add gatedContent check to newsletterState middleware

### DIFF
--- a/packages/marko-web-theme-monorail/middleware/newsletter-state.js
+++ b/packages/marko-web-theme-monorail/middleware/newsletter-state.js
@@ -2,7 +2,7 @@ const { asyncRoute } = require('@parameter1/base-cms-utils');
 const { get } = require('@parameter1/base-cms-object-path');
 const gql = require('graphql-tag');
 
-// Contnet is currently gated by reg fragment
+// Content is currently gated by reg fragment
 const query = gql`
   query content($input: ContentQueryInput!) {
     content(input: $input){

--- a/packages/marko-web-theme-monorail/middleware/newsletter-state.js
+++ b/packages/marko-web-theme-monorail/middleware/newsletter-state.js
@@ -17,7 +17,7 @@ const query = gql`
 /**
  * @param {object} req The Express request object.
  */
-async function isContentCurrentlyGatedByReg(req) {
+async function isContentRegistrationCurrentlyRequired(req) {
   const { apollo, params } = req;
   const id = Number(params.id);
   const variables = { input: { id } };
@@ -33,7 +33,7 @@ module.exports = () => asyncRoute(async (req, res, next) => {
   const contentRegex = new RegExp(/\d{8}/, 'i');
   const isContent = contentRegex.test(req.params.id);
   // If there is a content id see if it is a gated piece of content
-  const gatedByReg = (isContent) ? await isContentCurrentlyGatedByReg(req) : false;
+  const gatedByReg = (isContent) ? await isContentRegistrationCurrentlyRequired(req) : false;
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const utmMedium = get(req, 'query.utm_medium');
   const olyEncId = get(req, 'query.oly_enc_id');

--- a/packages/marko-web-theme-monorail/middleware/newsletter-state.js
+++ b/packages/marko-web-theme-monorail/middleware/newsletter-state.js
@@ -1,16 +1,47 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
 const { get } = require('@parameter1/base-cms-object-path');
+const gql = require('graphql-tag');
+
+// Contnet is currently gated by reg fragment
+const query = gql`
+  query content($input: ContentQueryInput!) {
+    content(input: $input){
+      id
+      userRegistration {
+        isCurrentlyRequired
+      }
+    }
+  }
+`;
+
+/**
+ * @param {object} req The Express request object.
+ */
+async function isContentCurrentlyGatedByReg(req) {
+  const { apollo, params } = req;
+  const id = Number(params.id);
+  const variables = { input: { id } };
+  const { data } = await apollo.query({ query, variables });
+  const { content } = data;
+  return get(content, 'userRegistration.isCurrentlyRequired');
+}
 
 const cookieName = 'enlPrompted';
 
-module.exports = () => (req, res, next) => {
+module.exports = () => asyncRoute(async (req, res, next) => {
+  // check if there is a content id in the request
+  const contentRegex = new RegExp(/\d{8}/, 'i');
+  const isContent = contentRegex.test(req.params.id);
+  // If there is a content id see if it is a gated piece of content
+  const gatedByReg = (isContent) ? await isContentCurrentlyGatedByReg(req) : false;
   const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
   const utmMedium = get(req, 'query.utm_medium');
   const olyEncId = get(req, 'query.oly_enc_id');
   const disabled = get(req, 'query.newsletterDisabled');
   const fromEmail = utmMedium === 'email' || olyEncId || false;
-  const initiallyExpanded = !(hasCookie || fromEmail || disabled);
+  const initiallyExpanded = !gatedByReg && !(hasCookie || fromEmail || disabled);
 
-  if (!hasCookie) {
+  if (initiallyExpanded) {
     // Expire in 14 days (2yr if already signed up)
     const days = fromEmail ? 365 * 2 : 14;
     const maxAge = days * 24 * 60 * 60 * 1000;
@@ -19,4 +50,4 @@ module.exports = () => (req, res, next) => {
 
   res.locals.newsletterState = { hasCookie, fromEmail, initiallyExpanded };
   next();
-};
+});


### PR DESCRIPTION
Update the newsletterState middleware to check the incoming request for the presece of a content id/\d{8}/ off of request.params.id.  This will required the inclusion of this middleware to be moved from withing start-server to the individual route that this is need to be applied to.  This will also prevent this newsletter state from being falsely triggered on routes like __idx & other random backend routes.

I also adjusted when the setting of the coockie happens to only be when the initiallyExpanded value is true instead only checking to see if the coockie exsits.  No point in setting until we actually want to display it.