### PR TITLE
Add reveal ad to monorail

### DIFF
--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -17,6 +17,7 @@ const NewsletterToggleButton = () => import(/* webpackChunkName: "theme-newslett
 const SiteNewsletterMenu = () => import(/* webpackChunkName: "theme-site-newsletter-menu" */ './site-newsletter-menu.vue');
 const WufooForm = () => import(/* webpackChunkName: "theme-wufoo-form" */ './wufoo-form.vue');
 const TopStoriesMenu = () => import(/* webpackChunkName: "theme-top-stories-menu" */ './top-stories-menu.vue');
+const RevealAdHandler = () => import(/* webpackChunkName: "reveal-ad-handler" */ './reveal-ad-handler.vue');
 
 const setP1EventsIdentity = ({ p1events, brandKey, encryptedId }) => {
   if (!p1events || !brandKey || !encryptedId) return;
@@ -112,4 +113,5 @@ export default (Browser, config = {
   });
   Browser.register('ThemeTopStoriesMenu', TopStoriesMenu);
   Browser.register('WufooForm', WufooForm);
+  Browser.register('RevealAdHandler', RevealAdHandler);
 };

--- a/packages/marko-web-theme-monorail/browser/reveal-ad-handler.vue
+++ b/packages/marko-web-theme-monorail/browser/reveal-ad-handler.vue
@@ -1,0 +1,178 @@
+<template>
+  <div id="marko-web-reveal-ad-handler" />
+</template>
+
+<script>
+import $ from '@parameter1/base-cms-marko-web/browser/jquery';
+
+const parseJSON = (value) => {
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    return null;
+  }
+};
+
+const parseMessagePayload = (event) => {
+  const obj = parseJSON(event.data);
+  if (!obj) return null;
+  if (['adImagePath', 'adTitle', 'backgroundImagePath', 'adClickUrl'].every(k => obj[k])) {
+    return obj;
+  }
+  return null;
+};
+
+const target = '_blank';
+const rel = 'noopener noreferrer';
+
+const { warn } = console;
+
+export default {
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    path: {
+      type: String,
+      required: true,
+    },
+    target: {
+      type: String,
+      default: '.document-container > .page',
+    },
+    displayFrequency: {
+      type: Number,
+      default: 2,
+    },
+    defaults: {
+      type: Object,
+      default: () => ({ backgroundColor: 'transparent' }),
+    },
+    selectAllTargets: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data: () => ({
+    observed: 0,
+    observer: null,
+    payload: {},
+  }),
+
+  mounted() {
+    if (!this.id || !this.path) {
+      this.warn('The Ad Unit ID and path are required. Bailing early.');
+      return;
+    }
+
+    const { googletag } = window;
+    if (!googletag) {
+      warn('The googletag object was not found. Bailing early.');
+    }
+
+    window.addEventListener('message', this.listener);
+    googletag.cmd.push(() => {
+      const slot = googletag.defineOutOfPageSlot(this.path, this.id).addService(googletag.pubads());
+      const div = document.createElement('div');
+      div.id = this.id;
+      div.dataset.path = this.path;
+      this.$el.appendChild(div);
+      googletag.pubads().refresh([slot], { changeCorrelator: false });
+    });
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('message', this.listener);
+    if (this.observer) this.observer.disconnect();
+  },
+
+  methods: {
+    displayBackground() {
+      const {
+        adClickUrl,
+        backgroundColor,
+        backgroundImagePath,
+      } = this.payload;
+
+      const backgroundImage = `url("${backgroundImagePath}")`;
+      const revealBackground = $('<a>', { href: adClickUrl, target, rel }).addClass('reveal-ad-background').css({ backgroundImage });
+      $('body').css({ backgroundColor }).prepend(revealBackground);
+      $('body').addClass('with-reveal-ad');
+    },
+    displayAd(element) {
+      if (!element) return;
+      const {
+        adClickUrl,
+        adImagePath,
+        adTitle,
+        boxShadow,
+      } = this.payload;
+
+      const adContainer = $('<div>').addClass('reveal-ad');
+      if (boxShadow) adContainer.addClass(`reveal-ad--${boxShadow}-shadow`);
+      adContainer.html($('<a>', {
+        href: adClickUrl,
+        title: adTitle,
+        target,
+        rel,
+      }).append($('<img>', { src: adImagePath, alt: adTitle })));
+      $(element).before(adContainer);
+    },
+    shouldDisplay() {
+      const { displayFrequency } = this;
+      this.observed += 1;
+      return this.observed % displayFrequency > 0;
+    },
+    observeMutations() {
+      if (!window.MutationObserver) return;
+      this.observer = new MutationObserver((mutationList) => {
+        for (let i = 0; i < mutationList.length; i += 1) {
+          const mutation = mutationList[i];
+          if (mutation.type === 'childList') {
+            for (let x = 0; x < mutation.addedNodes.length; x += 1) {
+              const added = mutation.addedNodes[x];
+              if (added.matches && added.matches(this.target)) {
+                if (this.shouldDisplay()) this.displayAd(added);
+              }
+            }
+          }
+        }
+      });
+      const node = document.querySelector(this.target);
+      if (node && node.parentNode) {
+        this.observer.observe(node.parentNode, { childList: true, subtree: true });
+      }
+    },
+
+    listener(event) {
+      const payload = parseMessagePayload(event);
+      if (!payload) return;
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function fn() {
+          document.removeEventListener('DOMContentLoaded', fn);
+          this.execute(payload);
+        });
+      } else {
+        this.execute(payload);
+      }
+    },
+    execute(payload) {
+      const elements = this.selectAllTargets
+        ? document.querySelectorAll(this.target) : [document.querySelector(this.target)];
+      this.payload = { ...this.defaults, ...payload };
+      this.displayBackground();
+      for (let i = 0; i < elements.length; i += 1) {
+        this.displayAd(elements[i]);
+      }
+      this.observeMutations();
+      window.removeEventListener('message', this.listener);
+    },
+
+    warn(...args) {
+      warn('Reveal Ad Listener:', ...args);
+    },
+  },
+};
+</script>

--- a/packages/marko-web-theme-monorail/components/marko.json
+++ b/packages/marko-web-theme-monorail/components/marko.json
@@ -38,5 +38,19 @@
   },
   "<theme-query-total-count>": {
     "template": "./query-total-count.marko"
+  },
+  "<theme-reveal-ad-handler>": {
+    "template": "./reveal-ad-handler.marko",
+    "@target": "string",
+    "@defaults": "object",
+    "@select-all-targets": "boolean",
+    "@id": {
+      "type": "string",
+      "required": true
+    },
+    "@path": {
+      "type": "string",
+      "required": true
+    }
   }
 }

--- a/packages/marko-web-theme-monorail/components/reveal-ad-handler.marko
+++ b/packages/marko-web-theme-monorail/components/reveal-ad-handler.marko
@@ -1,0 +1,9 @@
+$ const props = {
+  id: input.id,
+  path: input.path,
+  target: input.target,
+  defaults: input.defaults,
+  selectAllTargets: input.selectAllTargets,
+};
+
+<marko-web-browser-component name="RevealAdHandler" props=props />

--- a/packages/marko-web-theme-monorail/package.json
+++ b/packages/marko-web-theme-monorail/package.json
@@ -24,6 +24,7 @@
     "@parameter1/base-cms-marko-web-omeda": "^3.0.0",
     "@parameter1/base-cms-marko-web-omeda-identity-x": "^3.0.0",
     "@parameter1/base-cms-marko-web-p1-events": "^3.0.0",
+    "@parameter1/base-cms-marko-web-reveal-ad": "^2.75.1",
     "@parameter1/base-cms-marko-web-recaptcha": "^3.0.0",
     "@parameter1/base-cms-marko-web-search": "^3.0.0",
     "@parameter1/base-cms-marko-web-social-sharing": "^3.0.0",

--- a/packages/marko-web-theme-monorail/scss/components/_reveal-ad.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_reveal-ad.scss
@@ -1,0 +1,27 @@
+// Prevent Reveal Ad from causing CLS
+#marko-web-reveal-ad-handler {
+  display: none;
+  // remove white default bg to allow for bg image to display correctly
+   ~ .document-container {
+    background-color: transparent;;
+   }
+}
+.reveal-ad {
+  height: 298px;
+}
+body .document-container > .page:first-of-type {
+  margin-top: 298px;
+  // excluded the following page types as they dont use reskin ads
+  &.page--search,
+  &.page--authenticate,
+  &.page--login,
+  &.page--logout,
+  &.page--profile,
+  &.page--register {
+    margin-top: 60px;
+    margin-bottom: 60px;
+  }
+}
+body .document-container > .reveal-ad + .page {
+  margin-top: 0;
+}

--- a/packages/marko-web-theme-monorail/scss/core.scss
+++ b/packages/marko-web-theme-monorail/scss/core.scss
@@ -26,6 +26,7 @@
 @import "./components/identity-x";
 @import "./components/page-wrapper";
 @import "./components/pagination-controls";
+@import "./components/reveal-ad";
 @import "./components/search-page";
 @import "./components/site-footer";
 @import "./components/site-menu";
@@ -57,7 +58,6 @@
 @import "./components/blocks/related-native-x-stories";
 @import "./components/blocks/related-stories";
 @import "./components/blocks/resource-library";
-@import "./components/blocks/reveal-ad";
 @import "./components/blocks/section-card-deck-featured";
 @import "./components/blocks/section-card-list";
 @import "./components/blocks/section-feed";

--- a/packages/marko-web-theme-monorail/scss/core.scss
+++ b/packages/marko-web-theme-monorail/scss/core.scss
@@ -8,6 +8,9 @@
 @import "../../node_modules/bootstrap/scss/input-group";
 @import "../../node_modules/@parameter1/base-cms-marko-web-html-sitemap/scss/index";
 
+// Default reveal ad css
+@import "../../node_modules/@parameter1/base-cms-marko-web-reveal-ad/scss/reveal-ad";
+
 // skin mixins
 @import "./mixins";
 
@@ -54,6 +57,7 @@
 @import "./components/blocks/related-native-x-stories";
 @import "./components/blocks/related-stories";
 @import "./components/blocks/resource-library";
+@import "./components/blocks/reveal-ad";
 @import "./components/blocks/section-card-deck-featured";
 @import "./components/blocks/section-card-list";
 @import "./components/blocks/section-feed";


### PR DESCRIPTION
Add the vue, marko & css reveal/reskin ad components to the monorail theme package.  Should remove from org-theme-global packages that are currently setting/configuring these once dep upgrades are run.  