### PR TITLE
Add fixed bottom leaderboard components to monorail

### DIFF
--- a/packages/marko-web-theme-monorail/components/ads/fixed-ad-bottom.marko
+++ b/packages/marko-web-theme-monorail/components/ads/fixed-ad-bottom.marko
@@ -1,0 +1,7 @@
+$ const { GAM } = out.global;
+
+<marko-web-gam-fixed-ad-bottom
+  ...GAM.getAdUnit({ name: "lb-sticky-bottom", aliases: input.aliases })
+  refresh-interval=15
+  scroll-offset=100
+/>

--- a/packages/marko-web-theme-monorail/components/ads/marko.json
+++ b/packages/marko-web-theme-monorail/components/ads/marko.json
@@ -1,0 +1,20 @@
+{
+  "<theme-fixed-ad-bottom>": {
+    "template": "./fixed-ad-bottom.marko",
+    "@aliases": "array"
+  },
+  "<theme-reveal-ad-handler>": {
+    "template": "./reveal-ad-handler.marko",
+    "@target": "string",
+    "@defaults": "object",
+    "@select-all-targets": "boolean",
+    "@id": {
+      "type": "string",
+      "required": true
+    },
+    "@path": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/packages/marko-web-theme-monorail/components/ads/reveal-ad-handler.marko
+++ b/packages/marko-web-theme-monorail/components/ads/reveal-ad-handler.marko
@@ -1,0 +1,9 @@
+$ const props = {
+  id: input.id,
+  path: input.path,
+  target: input.target,
+  defaults: input.defaults,
+  selectAllTargets: input.selectAllTargets,
+};
+
+<marko-web-browser-component name="RevealAdHandler" props=props />

--- a/packages/marko-web-theme-monorail/components/marko.json
+++ b/packages/marko-web-theme-monorail/components/marko.json
@@ -1,5 +1,6 @@
 {
   "taglib-imports": [
+    "./ads/marko.json",
     "./breadcrumbs/marko.json",
     "./blocks/marko.json",
     "./client-side-blocks/marko.json",
@@ -38,19 +39,5 @@
   },
   "<theme-query-total-count>": {
     "template": "./query-total-count.marko"
-  },
-  "<theme-reveal-ad-handler>": {
-    "template": "./reveal-ad-handler.marko",
-    "@target": "string",
-    "@defaults": "object",
-    "@select-all-targets": "boolean",
-    "@id": {
-      "type": "string",
-      "required": true
-    },
-    "@path": {
-      "type": "string",
-      "required": true
-    }
   }
 }


### PR DESCRIPTION
In order to get css that is required include the following within your css imports(In core.scss or in an ad component css file):

``` css
@import "../../node_modules/@parameter1/base-cms-marko-web-gam/scss/fixed-ad-bottom";
```

To place the component we have been adding them to the to content/section wrappers with the follwoing calls:

**Bottom or content wrapper:**
``` js
<@foot>
    <marko-web-resolve-page|{ data: content }| node=pageNode>
      <theme-fixed-ad-bottom aliases=hierarchyAliases(content.primarySection) />
    </marko-web-resolve-page>
  </@foot>
  ```
  
  **Bottom of section layout:**
  ```js
  <@foot>
        <marko-web-resolve-page|{ data: section }| node=pageNode>
          <theme-fixed-ad-bottom aliases=hierarchyAliases(section) />
        </marko-web-resolve-page>
      </@foot>
```