### PR TITLE
Add nativeX support to section-feed block calls

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/marko.json
+++ b/packages/marko-web-theme-monorail/components/blocks/marko.json
@@ -126,7 +126,14 @@
     "@with-section": "boolean",
     "@lazyload": "boolean",
     "@modifiers": "array",
-    "@query-name": "string"
+    "@query-name": "string",
+    "<native-x>": {
+      "@index": "number",
+      "@indexes": "array",
+      "@name": "string",
+      "@aliases": "array"
+    },
+    "@with-native-x-section": "boolean"
   },
   "<theme-section-list-deck-block>": {
     "template": "./section-list-deck.marko"

--- a/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
@@ -16,6 +16,15 @@ $ const modifiers = defaultValue(input.modifiers, []);
 $ const lazyload = defaultValue(input.lazyload, true);
 $ const withSection = defaultValue(input.withSection, true);
 
+$ const { nativeX: nxConfig } = out.global;
+$ const nativeX = getAsObject(input, "nativeX");
+$ const withNativeXSection = defaultValue(input.withNativeXSection, true);
+$ const setWithSection = (node, nxNode, withNativeXSection = true) => {
+  if (node.withSection) return true;
+  if (!withNativeXSection) return false
+  return node.id !== nxNode.id;
+};
+
 <if(countOnly)>
   <theme-query-total-count|data| name=queryName params=queryParams>
     <${input.renderBody} ...data />
@@ -32,13 +41,32 @@ $ const withSection = defaultValue(input.withSection, true);
       ...input.nodeList
     >
       <@nodes nodes=nodes>
-        <@slot|{ node }|>
-          <theme-section-feed-content-node
-            node=node
-            display-image=input.displayImage
-            with-section=withSection
-            lazyload=lazyload
-          />
+        <@slot|{ node, index }|>
+          <if(nxConfig)>
+            <marko-web-native-x-render|{ node: nxNode, linkAttrs, containerAttrs }|
+              ...nativeX
+              when=(index === nativeX.index || (nativeX.indexes && nativeX.indexes.includes(index)))
+              node=node
+              config=nxConfig
+            >
+              <theme-section-feed-content-node
+                display-image=input.displayImage
+                with-section=setWithSection(node, nxNode, withNativeXSection)
+                lazyload=lazyload
+                node=nxNode
+                attrs=containerAttrs
+                link-attrs=linkAttrs
+              />
+            </marko-web-native-x-render>
+          </if>
+          <else>
+            <theme-section-feed-content-node
+              node=node
+              display-image=input.displayImage
+              with-section=withSection
+              lazyload=lazyload
+            />
+          </else>
         </@slot>
       </@nodes>
     </marko-web-node-list>


### PR DESCRIPTION
New call to make this work should look something like 
```marko.js
<theme-section-feed-block alias=input.alias>
    <@query-params limit=3 skip=p.skip({ perPage, skip: 3 }) query-params=queryParams />
    <@node-list innerJustified=false ...input.nodeList />
    <@native-x indexes=[0] name="default" aliases=[input.alias] />
</theme-section-feed-block>
```