### PR TITLE
Add isLogo support to section-feed-content block

### DIFF
--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -81,10 +81,10 @@ $ const blockName = "section-feed-content-node";
   <if(displayImage)>
     <marko-web-element block-name=blockName name="image-wrapper">
       <if(primaryImage.src)>
-        $ const src = buildImgixUrl(primaryImage.src, { w: 250, h: 167, fit: "crop" });
+        $ const src = buildImgixUrl(primaryImage.src, { w: 250, h: 167, fit: "crop" }, null, get(primaryImage, 'isLogo'));
         $ const srcset = [src, `${buildImgixUrl(src, { dpr: 2 })} 2x`];
 
-        $ const srcMobile = buildImgixUrl(primaryImage.src, { w: 112, h: 112, fit: "crop" });
+        $ const srcMobile = buildImgixUrl(primaryImage.src, { w: 112, h: 112, fit: "crop" }, null, get(primaryImage, 'isLogo'));
         $ const srcsetMobile = [srcMobile, `${buildImgixUrl(srcMobile, { dpr: 2 })} 2x`];
 
         <marko-web-picture>


### PR DESCRIPTION
<img width="796" alt="Screen Shot 2022-08-21 at 3 09 56 PM" src="https://user-images.githubusercontent.com/2855198/185809141-e8bfac7c-bb3b-4cdd-9b22-9550ef34597d.png">
