### PR TITLE
Add directory components/reusable parts to theme monorail

### DIFF
--- a/packages/marko-web-theme-monorail/browser/company-search.vue
+++ b/packages/marko-web-theme-monorail/browser/company-search.vue
@@ -1,0 +1,78 @@
+<template>
+  <div ref="companySearch" class="company-search">
+    <autocomplete
+      ref="autocomplete"
+      :search="searchCompanies"
+      :class="errorClass"
+      placeholder="Search Companies..."
+      aria-label="Search Companies..."
+      :get-result-value="getResultValue"
+      :debounce-time="500"
+      @submit="handleSubmit"
+    />
+  </div>
+</template>
+
+<script>
+import Autocomplete from '@trevoreyre/autocomplete-vue';
+
+const path = '/__company-search?searchQuery=';
+
+export default {
+  inject: ['EventBus'],
+  components: { Autocomplete },
+
+  data: () => ({
+    errorClass: '',
+  }),
+
+  methods: {
+    // We want to display the title
+    getResultValue(result) {
+      return result.shortName;
+    },
+    // Open the selected company in a new window
+    handleSubmit(result) {
+      // Handle when the result is an error or missing context link
+      if (!result.siteContext || !result.siteContext.path) {
+        this.$refs.autocomplete.value = '';
+        return;
+      }
+
+      this.emitAction();
+      window.location.href = result.siteContext.path;
+    },
+    searchCompanies(input) {
+      this.errorClass = '';
+      if (input.length < 3) {
+        return [];
+      }
+      return this.getCompanyResults(input);
+    },
+    async getCompanyResults(input) {
+      try {
+        const url = `${path}${encodeURI(input)}`;
+        const res = await fetch(url);
+        const json = await res.json();
+        if (!res.ok) throw new Error(json.message || res.statusText);
+        return json.nodes;
+      } catch (error) {
+        const errorNodes = [{
+          id: 'error',
+          shortName: error.message,
+        }];
+        this.errorClass = 'errors';
+        return errorNodes;
+      }
+    },
+    emitAction() {
+      const payload = {
+        category: 'Content Header Search',
+        action: 'Click',
+        label: 'Website Section Page',
+      };
+      this.EventBus.$emit('content-header-search', payload);
+    },
+  },
+};
+</script>

--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -14,6 +14,7 @@ const InlineNewsletterForm = () => import(/* webpackChunkName: "theme-inline-new
 const MenuToggleButton = () => import(/* webpackChunkName: "theme-menu-toggle-button" */ './menu-toggle-button.vue');
 const NewsletterCloseButton = () => import(/* webpackChunkName: "theme-newsletter-close-button" */ './newsletter-close-button.vue');
 const NewsletterToggleButton = () => import(/* webpackChunkName: "theme-newsletter-toggle-button" */ './newsletter-toggle-button.vue');
+const CompanySearch = () => import(/* webpackChunkName: "theme-company-search" */ './company-search.vue');
 const SiteNewsletterMenu = () => import(/* webpackChunkName: "theme-site-newsletter-menu" */ './site-newsletter-menu.vue');
 const WufooForm = () => import(/* webpackChunkName: "theme-wufoo-form" */ './wufoo-form.vue');
 const TopStoriesMenu = () => import(/* webpackChunkName: "theme-top-stories-menu" */ './top-stories-menu.vue');
@@ -109,6 +110,9 @@ export default (Browser, config = {
   Browser.register('ThemeNewsletterCloseButton', NewsletterCloseButton);
 
   Browser.register('ThemeNewsletterToggleButton', NewsletterToggleButton, {
+    provide: { EventBus },
+  });
+  Browser.register('ThemeCompanySearch', CompanySearch, {
     provide: { EventBus },
   });
   Browser.register('ThemeTopStoriesMenu', TopStoriesMenu);

--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -15,6 +15,7 @@ const MenuToggleButton = () => import(/* webpackChunkName: "theme-menu-toggle-bu
 const NewsletterCloseButton = () => import(/* webpackChunkName: "theme-newsletter-close-button" */ './newsletter-close-button.vue');
 const NewsletterToggleButton = () => import(/* webpackChunkName: "theme-newsletter-toggle-button" */ './newsletter-toggle-button.vue');
 const CompanySearch = () => import(/* webpackChunkName: "theme-company-search" */ './company-search.vue');
+const SectionSearch = () => import(/* webpackChunkName: "theme-section-search" */ './section-search.vue');
 const SiteNewsletterMenu = () => import(/* webpackChunkName: "theme-site-newsletter-menu" */ './site-newsletter-menu.vue');
 const WufooForm = () => import(/* webpackChunkName: "theme-wufoo-form" */ './wufoo-form.vue');
 const TopStoriesMenu = () => import(/* webpackChunkName: "theme-top-stories-menu" */ './top-stories-menu.vue');
@@ -113,6 +114,9 @@ export default (Browser, config = {
     provide: { EventBus },
   });
   Browser.register('ThemeCompanySearch', CompanySearch, {
+    provide: { EventBus },
+  });
+  Browser.register('ThemeSectionSearch', SectionSearch, {
     provide: { EventBus },
   });
   Browser.register('ThemeTopStoriesMenu', TopStoriesMenu);

--- a/packages/marko-web-theme-monorail/browser/section-search.vue
+++ b/packages/marko-web-theme-monorail/browser/section-search.vue
@@ -1,0 +1,89 @@
+<template>
+  <div ref="search" class="section-search" :class="{'open':openSuggestion}">
+    <input
+      v-model="selection"
+      class="form-control"
+      type="text"
+      placeholder="Search Categories..."
+    >
+    <div v-if="selection" class="list-group">
+      <div v-for="suggestion in matches" :key="suggestion" class="list-group-item">
+        <a :href="'/'+suggestion.alias" @click="emitAction()">
+          {{ suggestion.name }}
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  inject: ['EventBus'],
+  props: {
+    sections: {
+      type: Array,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      open: false,
+      current: 0,
+      selection: '',
+    };
+  },
+
+  computed: {
+    matches() {
+      return this.sections.filter((section) => {
+        const match = section.name.toLowerCase().indexOf(this.selection.toLowerCase()) >= 0;
+        return match;
+      });
+      // return this.sectionNames.filter((str) => {
+      //   const match = str.toLowerCase().indexOf(this.selection.toLowerCase()) >= 0;
+      //   return match;
+      // });
+    },
+    openSuggestion() {
+      return this.selection !== ''
+      && this.matches.length !== 0
+      && this.open === true;
+    },
+  },
+
+  mounted() {
+    this.addListeners();
+  },
+
+  beforeDestroy() {
+    this.removeListeners();
+  },
+
+  methods: {
+    detectOutclick(event) {
+      const el = this.$refs.search;
+      if (!el.contains(event.target) && el !== event.target) {
+        this.selection = '';
+      }
+    },
+
+    addListeners() {
+      document.addEventListener('click', this.detectOutclick.bind(this));
+      document.addEventListener('touchstart', this.detectOutclick.bind(this));
+    },
+    removeListeners() {
+      document.removeEventListener('click', this.detectOutclick.bind(this));
+      document.removeEventListener('touchstart', this.detectOutclick.bind(this));
+    },
+    emitAction() {
+      const payload = {
+        category: 'Content Header Search',
+        action: 'Click',
+        label: 'Website Section Page',
+      };
+      this.EventBus.$emit('content-header-search', payload);
+    },
+  },
+};
+</script>

--- a/packages/marko-web-theme-monorail/components/blocks/company-search.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/company-search.marko
@@ -1,0 +1,1 @@
+<marko-web-browser-component name="ThemeCompanySearch" />

--- a/packages/marko-web-theme-monorail/components/blocks/marko.json
+++ b/packages/marko-web-theme-monorail/components/blocks/marko.json
@@ -19,6 +19,9 @@
     "@consent-checkboxes": "array",
     "@initially-expanded": "boolean"
   },
+  "<theme-company-search-block>": {
+    "template": "./company-search.marko"
+  },
   "<theme-full-width-native-ad-block>": {
     "template": "./full-width-native-ad.marko"
   },

--- a/packages/marko-web-theme-monorail/components/blocks/marko.json
+++ b/packages/marko-web-theme-monorail/components/blocks/marko.json
@@ -145,6 +145,9 @@
   "<theme-section-list-block>": {
     "template": "./section-list.marko"
   },
+  "<theme-section-search-block>": {
+    "template": "./section-search.marko"
+  },
   "<theme-section-title-feed-block>": {
     "template": "./section-title-feed.marko",
     "<query-params>": {},

--- a/packages/marko-web-theme-monorail/components/blocks/section-search.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-search.marko
@@ -1,0 +1,14 @@
+import queryFragment from "../../graphql/fragments/sections-search"
+import { getChildSectionsById } from "../../utils/get-child-sections-by-id";
+
+$ const { sectionIds, includeSelf } = input;
+
+<if(sectionIds.length)>
+  <marko-web-query|{ nodes: parent }|
+    name="website-sections"
+    params={ includeIds: sectionIds, queryFragment }
+  >
+    $ const nodesById = getChildSectionsById(parent[0], {}, includeSelf);
+    <marko-web-browser-component name="ThemeSectionSearch" props={ sections: Object.values(nodesById) } />
+  </marko-web-query>
+</if>

--- a/packages/marko-web-theme-monorail/components/directory-facets/facet-container/facet-container.marko
+++ b/packages/marko-web-theme-monorail/components/directory-facets/facet-container/facet-container.marko
@@ -1,0 +1,23 @@
+$ const { facets, title, description, aliases, initiallyExpanded, searchQuery } = input;
+
+<if(facets.length)>
+  <div class='directory-facets'>
+    <if(title)>
+      <h3 class="directory-facets__title">
+        ${title}
+      </h3>
+    </if>
+    <if(description)>
+      <div class="directory-facets__description">
+        $!{description}
+      </div>
+    </if>
+    <theme-directory-facet-list
+      facets=facets
+      aliases=aliases
+      active-id=input.activeId
+      search-query=searchQuery
+      initially-expanded=initiallyExpanded
+    />
+  </div>
+</if>

--- a/packages/marko-web-theme-monorail/components/directory-facets/facet-container/marko.json
+++ b/packages/marko-web-theme-monorail/components/directory-facets/facet-container/marko.json
@@ -1,0 +1,25 @@
+{
+  "<theme-directory-facet-container>": {
+    "template": "./facet-container.marko",
+    "@facets": {
+      "type": "array",
+      "required": true
+    },
+    "@title": "string",
+    "@description": "string",
+    "@content-type": "string",
+    "@search-query": "string",
+    "@initially-expanded": {
+      "type": "boolean",
+      "default-value": false
+    },
+    "@active-id": {
+      "type": "string",
+      "required": true
+    },
+    "@aliases": {
+      "type": "array",
+      "required": true
+    }
+  }
+}

--- a/packages/marko-web-theme-monorail/components/directory-facets/facet-list/facet-list.marko
+++ b/packages/marko-web-theme-monorail/components/directory-facets/facet-list/facet-list.marko
@@ -1,0 +1,62 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const block = "directory-facets";
+
+$ const {
+  facets,
+  activeId,
+  aliases,
+  initiallyExpanded,
+  searchQuery
+} = input;
+
+$ const isActiveId = ({id}) => (activeId && (`${activeId}` === `${id}`));
+$ facets.sort((a, b) => a.name.localeCompare(b.name));
+<if(facets && facets.length)>
+  $ const expandedClass = (initiallyExpanded) ? `${block}__list ${block}__list--open` : `${block}__list`;
+  <div class=expandedClass>
+    <for|facet| of=facets>
+      $ const children = getAsArray(facet, "children.edges").map(({ node }) => node);
+      $ const isOpen = aliases.includes(facet.alias);
+      $ const isActive = isActiveId(facet);
+
+      $ const classNames = [`${block}__item`, `${block}__item--${facet.id}`];
+      $ const linkClasses = [`${block}__link`]
+      $ if (isOpen) classNames.push(`${block}__item--open`);
+      $ if (isActive) linkClasses.push(`${block}__link--active`);
+      <div class=classNames>
+        $ const facetLink = searchQuery ? `/${facet.alias}?searchQuery=${searchQuery}` : `/${facet.alias}`;
+        <a class=linkClasses href=facetLink>
+          ${facet.name}
+        </a>
+        <if(children.length)>
+          <theme-menu-toggle-button
+            class-name=`${block}__toggle`
+            targets=[`.${block}__item--${facet.id}`]
+            toggle-class=`${block}__item--open`
+            initially-expanded=isOpen
+            icon-modifiers=["sm"]
+            icon-name="plus"
+            expanded-icon-name="dash"
+          />
+        </if>
+        <if(isActive)>
+          <marko-web-browser-component
+            name="GlobalAutoScroll"
+            props={
+              containerTarget: `.${block} > .${block}__list`,
+              elementTarget: `.${block}__link--active`,
+              offset: -12,
+            }
+          />
+        </if>
+        <theme-directory-facet-list
+          facets=children
+          active-id=activeId
+          aliases=aliases
+          search-query=searchQuery
+        />
+      </div>
+    </for>
+  </div>
+</if>

--- a/packages/marko-web-theme-monorail/components/directory-facets/facet-list/marko.json
+++ b/packages/marko-web-theme-monorail/components/directory-facets/facet-list/marko.json
@@ -1,0 +1,22 @@
+{
+  "<theme-directory-facet-list>": {
+    "template": "./facet-list.marko",
+    "@search-query": "string",
+    "@facets": {
+      "type": "array",
+      "required": true
+    },
+    "@active-id": {
+      "type": "string",
+      "required": true
+    },
+    "@aliases": {
+      "type": "array",
+      "required": true
+    },
+    "@initially-expanded": {
+      "type": "boolean",
+      "default-value": false
+    }
+  }
+}

--- a/packages/marko-web-theme-monorail/components/directory-facets/facet.marko
+++ b/packages/marko-web-theme-monorail/components/directory-facets/facet.marko
@@ -1,0 +1,14 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const facets = getAsArray(input, "facets");
+$ const aliases = getAsArray(input, "aliases");
+<theme-directory-facet-container
+  facets=facets
+  aliases=aliases
+  content-type=input.contentType
+  search-query=input.searchQuery
+  title=input.title
+  description=input.description
+  active-id=input.activeId
+  initially-expanded=input.initiallyExpanded
+/>

--- a/packages/marko-web-theme-monorail/components/directory-facets/find-active-facet.js
+++ b/packages/marko-web-theme-monorail/components/directory-facets/find-active-facet.js
@@ -1,0 +1,22 @@
+const build = (facets, total = [], entries) => {
+  facets.forEach((facet) => {
+    const { id, name, values } = facet;
+    const current = entries ? [{ id, name }, ...entries] : [{ id, name }];
+    total.push(current);
+    if (Array.isArray(values) && values.length) build(values, total, current);
+  });
+  return total;
+};
+
+module.exports = (facets, activeId) => {
+  const map = new Map();
+  const flat = build(facets);
+  flat.forEach((row) => {
+    const primary = row.shift();
+    const parentIds = row.map(r => r.id);
+    map.set(`${primary.id}`, { ...primary, parentIds, activeIds: [primary.id, ...parentIds] });
+  });
+  const active = map.get(`${activeId}`);
+  if (active) return active;
+  return { parentIds: [], activeIds: [] };
+};

--- a/packages/marko-web-theme-monorail/components/directory-facets/index.marko
+++ b/packages/marko-web-theme-monorail/components/directory-facets/index.marko
@@ -1,0 +1,27 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import categorySectionsFragment from "../../graphql/fragments/category-sections"
+
+$ const activeId = defaultValue(input.activeId, null);
+$ const aliases = defaultValue(input.aliases, []);
+$ const contentType = defaultValue(input.contentType, "");
+$ const searchQuery = defaultValue(input.searchQuery, null);
+$ const primaryAlias = defaultValue(input.primaryAlias, "directory");
+$ const title = defaultValue(input.title, "");
+$ const description = defaultValue(input.description, "");
+$ const withToggle = defaultValue(input.withToggle, false);
+<marko-web-query|{ node }|
+  name="website-section"
+  params={ alias: primaryAlias, queryFragment: categorySectionsFragment }
+>
+  $ const children = getAsArray(node, "children.edges").map(({ node }) => node);
+  <theme-directory-facet
+    title=title
+    description=description
+    facets=children
+    active-id=activeId
+    aliases=aliases
+    search-query=searchQuery
+    initially-expanded=input.initiallyExpanded
+  />
+</marko-web-query>

--- a/packages/marko-web-theme-monorail/components/directory-facets/marko.json
+++ b/packages/marko-web-theme-monorail/components/directory-facets/marko.json
@@ -1,0 +1,38 @@
+{
+  "taglib-imports": [
+    "./facet-list/marko.json",
+    "./facet-container/marko.json"
+  ],
+  "<theme-directory-facet>": {
+    "template": "./facet.marko",
+    "@facets": "array",
+    "@content-type": "string",
+    "@search-query": "string",
+    "@aliases": "array",
+    "@active-id": "expression",
+    "@title": "string",
+    "@description": "string",
+    "@initially-expanded": {
+      "type": "boolean",
+      "default-value": false
+    }
+  },
+  "<theme-directory-facet-block>": {
+    "template": "./index.marko",
+    "@aliases": "array",
+    "@active-id": "number",
+    "@content-type": "string",
+    "@search-query": "string",
+    "@primary-alias": "string",
+    "@title": "string",
+    "@description": "string",
+    "@with-toggle": {
+      "type": "boolean",
+      "default-value": false
+    },
+    "@initially-expanded": {
+      "type": "boolean",
+      "default-value": false
+    }
+  }
+}

--- a/packages/marko-web-theme-monorail/components/marko.json
+++ b/packages/marko-web-theme-monorail/components/marko.json
@@ -5,6 +5,7 @@
     "./blocks/marko.json",
     "./client-side-blocks/marko.json",
     "./content-attribution/marko.json",
+    "./directory-facets/marko.json",
     "./flows/marko.json",
     "./gam/marko.json",
     "./identity-x/marko.json",

--- a/packages/marko-web-theme-monorail/graphql/fragments/category-sections.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/category-sections.js
@@ -1,0 +1,25 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment WebsiteSectionHierarchyFragment on WebsiteSection {
+  id
+  alias
+  name
+  hierarchy {
+    id
+    name
+    alias
+    canonicalPath
+  }
+  children(input: { pagination: { limit: 0 } }) {
+    edges {
+      node {
+        id
+        alias
+        name
+      }
+    }
+  }
+}
+
+`;

--- a/packages/marko-web-theme-monorail/graphql/fragments/company-search.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/company-search.js
@@ -1,0 +1,13 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment CompanySearchFragment on Content {
+  id
+  shortName
+  siteContext {
+    path
+  }
+}
+
+`;

--- a/packages/marko-web-theme-monorail/graphql/fragments/sections-search.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/sections-search.js
@@ -1,0 +1,46 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+fragment WebsiteSectionSearchFragment on WebsiteSection {
+  id
+  alias
+  name
+  children(input: { pagination: { limit: 0 } }) {
+    edges {
+      node {
+        id
+        alias
+        name
+        children(input: { pagination: { limit: 0 } }) {
+          edges {
+            node {
+              id
+              alias
+              name
+              children(input: { pagination: { limit: 0 } }) {
+                edges {
+                  node {
+                    id
+                    alias
+                    name
+                    children(input: { pagination: { limit: 0 } }) {
+                      edges {
+                        node {
+                          id
+                          alias
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+`;

--- a/packages/marko-web-theme-monorail/package.json
+++ b/packages/marko-web-theme-monorail/package.json
@@ -32,6 +32,7 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/base-cms-web-common": "^3.0.0",
+    "@trevoreyre/autocomplete-vue": "^2.2.0",
     "bootstrap": "4.3.1",
     "cheerio": "^1.0.0-rc.10",
     "graphql-tag": "^2.12.5",

--- a/packages/marko-web-theme-monorail/routes/company-search.js
+++ b/packages/marko-web-theme-monorail/routes/company-search.js
@@ -1,0 +1,27 @@
+const loader = require('@parameter1/base-cms-marko-web-search/loaders/search');
+const jsonErrorHandler = require('@parameter1/base-cms-marko-web/express/json-error-handler');
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+
+const queryFragment = require('../graphql/fragments/company-search');
+
+module.exports = (app) => {
+  app.get('/__company-search', asyncRoute(async (req, res) => {
+    const { searchQuery } = req.query;
+    const { apollo, $baseBrowse } = res.locals;
+
+    const response = await loader(
+      {
+        apolloBaseCMS: apollo,
+        apolloBaseBrowse: $baseBrowse,
+      },
+      {
+        status: 1,
+        contentTypes: ['COMPANY'],
+        assignedToWebsiteSiteIds: [req.app.locals.config.websiteContext.id],
+        searchQuery,
+        queryFragment,
+      },
+    );
+    res.json(response);
+  }), jsonErrorHandler());
+};

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_company-search.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_company-search.scss
@@ -1,0 +1,55 @@
+.company-search {
+  position: relative;
+  &__title {
+    margin-bottom: 18px;
+    font-size: 18px;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+  .autocomplete-input{
+    display: block;
+    width: 100%;
+    height: calc(1.5em + .75rem + 2px);
+    padding: .375rem .75rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid #ced4da;
+    border-radius: 0;
+    outline: none;
+    transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+    &:focus {
+      border-color: #ebebeb;
+      box-shadow: none;
+    }
+  }
+  .autocomplete-result-list {
+    @include box-shadow($theme-card-box-shadow);
+    position: absolute;
+    z-index: 2;
+    width: 100%;
+    max-height: 10em;
+    padding: map-get($spacers, 2);
+    overflow: scroll;
+    list-style: none;
+    background: $white;
+    border: 1px solid #ebebeb;
+    li {
+      color: $primary;
+      cursor: pointer;
+      .autocomplete-result-error {
+        font-size: 40px;
+        font-weight: 700;
+
+      }
+    }
+  }
+  .errors {
+    li {
+      cursor: initial;
+    }
+  }
+}

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_directory-facets.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_directory-facets.scss
@@ -1,0 +1,112 @@
+.directory-facets-toggle {
+  display: flex;
+  padding: 20px;
+  margin-bottom: map-get($spacers, block);
+  background-color: #f1f1f1;
+  &__label {
+    align-self: center;
+  }
+
+  &__button {
+    @include theme-toggle-button();
+    align-self: center;
+    margin-left: auto;
+  }
+}
+
+.directory-facets,
+.directory-country-facets,
+.content-type-facets {
+  @include theme-card();
+  $color: $gray-200;
+  $self: &;
+
+  &--open {
+    display: block;
+  }
+
+  &__title {
+    @include theme-card-header();
+    @include border-top-radius($theme-item-list-border-radius);
+    padding: $marko-web-node-list-padding;
+    margin-bottom: 0;
+    line-height: $line-height-base;
+    &:empty {
+      display: none;
+    }
+
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    max-height: 600px;
+    padding: 0;
+    overflow: scroll;
+    #{ $self } {
+      &__list {
+        display: none;
+        max-height: 100%;
+        padding: $marko-web-node-list-padding;
+        padding-bottom: 0;
+        overflow: initial;
+      }
+    }
+  }
+
+  &__link {
+    position: relative;
+    display: inline;
+    color: #333;
+    &:hover {
+      color: #333;
+      text-decoration: underline;
+    }
+    &--active {
+      font-weight: 700;
+      color: $primary;
+    }
+  }
+
+  &__item {
+    position: relative;
+    display: block;
+    padding: ($marko-web-node-list-padding / 2);
+    font-size: 18px;
+    line-height: 1.25;
+    &--open {
+      > #{ $self } {
+        &__list {
+          display: flex;
+        }
+      }
+    }
+  }
+
+  &__toggle {
+    @include theme-toggle-button();
+    position: absolute;
+    top: .5rem;
+    right: .75rem;
+    padding: 0;
+    margin-left: auto;
+
+    & > .icon {
+      @include theme-navbar-link-color(( active: $primary, hover: $primary, default: $black ));
+    }
+  }
+}
+
+.directory-country-facets {
+  &__list {
+    max-height: 200px;
+  }
+}
+
+.breadcrumbs {
+  &--directory {
+    .breadcrumb {
+      padding-bottom: 16px;
+    }
+  }
+}

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-search.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-search.scss
@@ -1,0 +1,40 @@
+.section-search {
+  position: relative;
+  &__title {
+    margin-bottom: 18px;
+    font-size: 18px;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+  .form-control {
+    display: block;
+    width: 100%;
+    height: calc(1.5em + .75rem + 2px);
+    padding: .375rem .75rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid #ced4da;
+    border-radius: 0;
+    outline: none;
+    transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
+    &:focus {
+      border-color: #ebebeb;
+      box-shadow: none;
+    }
+  }
+  .list-group {
+    @include box-shadow($theme-card-box-shadow);
+    position: absolute;
+    z-index: 2;
+    width: 100%;
+    max-height: 10em;
+    padding: map-get($spacers, 2);
+    overflow: scroll;
+    background: $white;
+    border: 1px solid #ebebeb;
+  }
+}

--- a/packages/marko-web-theme-monorail/utils/get-child-sections-by-id.js
+++ b/packages/marko-web-theme-monorail/utils/get-child-sections-by-id.js
@@ -1,0 +1,11 @@
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+
+const getChildSectionsById = (section, childSections = {}, includeSelf = true) => {
+  const { id } = section;
+  const children = getAsArray(section, 'children.edges').map(({ node }) => node);
+  return {
+    ...children.reduce((obj, child) => getChildSectionsById(child, obj), childSections),
+    ...(includeSelf && !section[id] && { [id]: section }),
+  };
+};
+module.exports = { getChildSectionsById };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,6 +3063,27 @@
     "@octokit/openapi-types" "^2.2.0"
     "@types/node" ">= 8"
 
+"@parameter1/base-cms-marko-web-reveal-ad@^2.75.1":
+  version "2.75.1"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-marko-web-reveal-ad/-/base-cms-marko-web-reveal-ad-2.75.1.tgz#6df390011c4d6d109d86645ccca5d768a9ec0f46"
+  integrity sha512-wcT2R0HE84QZs6x18j5Fi0GgPL0wrX9McskGPnsEUveCwI22FTMY045N2BZS/+9MDy52FE0L9UBk173Yeg4+Mw==
+  dependencies:
+    "@parameter1/base-cms-object-path" "^2.75.1"
+    "@parameter1/base-cms-utils" "^2.75.1"
+
+"@parameter1/base-cms-object-path@^2.75.1":
+  version "2.75.1"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-object-path/-/base-cms-object-path-2.75.1.tgz#169c55bc7199954e46ff48e298cf5073468e2ed6"
+  integrity sha512-v9+QjzBAjqZMxdjpmZLcKukmokMxJPE1o/AOt12RWaxkvThyiHG/kqctuZjA20Eoi3DGvX5xepl1KrggH5oZiQ==
+  dependencies:
+    "@parameter1/base-cms-utils" "^2.75.1"
+    object-path "^0.11.8"
+
+"@parameter1/base-cms-utils@^2.75.1":
+  version "2.75.1"
+  resolved "https://registry.yarnpkg.com/@parameter1/base-cms-utils/-/base-cms-utils-2.75.1.tgz#1a630b97cfa8362eb47c99459407e735aac65b71"
+  integrity sha512-i2oeoufTx6CRga00pGIwQAI4A8R6VwDLQokv6MasbAEorIKYegbPVaUEPZg8XOBMnEyzKlSJaGfCX58Zt3dNkA==
+
 "@parameter1/joi@^1.2.10":
   version "1.2.10"
   resolved "https://registry.yarnpkg.com/@parameter1/joi/-/joi-1.2.10.tgz#d5ea00deffa8c48fd1d707eb39858b69aa5bfdb4"
@@ -3190,6 +3211,11 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@soda/get-current-script/-/get-current-script-1.0.2.tgz#a53515db25d8038374381b73af20bb4f2e508d87"
   integrity sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
+
+"@trevoreyre/autocomplete-vue@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@trevoreyre/autocomplete-vue/-/autocomplete-vue-2.2.0.tgz#db1fd94bc001ccba296cdd370fdae122117b311e"
+  integrity sha512-A5j986nM6htTbCpEW9BbwlqCobIMD4+uicAYGCSI8DM1ojK8meCyVI23jK+gAxi+vjhraCBneKI+vbwB8sL0ig==
 
 "@trysound/sax@0.1.1":
   version "0.1.1"


### PR DESCRIPTION
Moved directory components being used in multiple tenants into theme monorail for reusability.  
 - Search company block component with backend route for /__company-search
 - Search Section/Category block component
 - Directory facets bock for use in left hand navigation