### PR TITLE
Add more address info to standard directory node in monorail theme

### DIFF
--- a/packages/marko-web-theme-monorail/components/nodes/directory-section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/directory-section-feed-content.marko
@@ -74,10 +74,12 @@ $ const blockName = "section-feed-content-node";
           </marko-web-block>
         </marko-web-block>
       </if>
-      <else-if(content.city && content.state)>
-        <marko-web-content-city-state-zip block-name=blockName obj=content>
-          ${content.city}, ${content.state}
-        </marko-web-content-city-state-zip>
+      <else-if(content.address1 || content.address2 || content.cityStateZip)>
+        <marko-web-block name=blockName modifiers=["contact-info"] >
+          <marko-web-content-address1 block-name=blockName obj=content />
+          <marko-web-content-address2 block-name=blockName obj=content />
+          <marko-web-content-city-state-zip block-name=blockName obj=content />
+        </marko-web-block>
       </else-if>
     </marko-web-element>
   </marko-web-element>


### PR DESCRIPTION
Add display of address1, address2 & cityStateZip to non-featured nodes.

<img width="959" alt="Screen Shot 2022-08-25 at 7 41 07 AM" src="https://user-images.githubusercontent.com/3845869/186668325-fda39117-c500-4ec3-8bec-ffa54ce66fa7.png">

