### PR TITLE
Add support for skipping browser component rendering

### DIFF
--- a/packages/marko-web-leaders/components/index.marko
+++ b/packages/marko-web-leaders/components/index.marko
@@ -1,1 +1,1 @@
-<marko-web-browser-component name="LeadersProgram" props=input.props />
+<marko-web-browser-component name="LeadersProgram" props=input.props skip-when-exists=input.skipWhenExists />

--- a/packages/marko-web/browser/index.js
+++ b/packages/marko-web/browser/index.js
@@ -14,10 +14,13 @@ const load = async ({
   props,
   on,
   hydrate,
+  skipWhenExists,
 } = {}) => {
   if (!el || !name) throw new Error('A Vue component name and element must be provided.');
   const Component = components[name];
   if (!Component) throw new Error(`No Vue component found for '${name}'`);
+  const shouldRender = skipWhenExists ? document.querySelectorAll(`script.component[data-name="${name}"]`).length <= 1 : true;
+  if (!shouldRender) return;
   const component = new Vue({
     provide: providers[name],
     render: h => h(Component, { props, on: { ...on, ...listeners[name] } }),

--- a/packages/marko-web/components/browser-component.marko
+++ b/packages/marko-web/components/browser-component.marko
@@ -7,8 +7,9 @@ $ const tag = defaultValue(input.tag, "div");
 $ const { name } = input;
 $ const ssr = defaultValue(input.ssr, false);
 $ const hydrate = ssr ? true : defaultValue(input.hydrate, false);
+$ const skipWhenExists = defaultValue(input.skipWhenExists, false);
 $ const props = JSON.stringify(input.props || {});
-$ const contents = `CMSBrowserComponents.load({ el: '#${id}', name: '${name}', props: ${props}, hydrate: ${hydrate} });`;
+$ const contents = `CMSBrowserComponents.load({ el: '#${id}', name: '${name}', props: ${props}, hydrate: ${hydrate}, skipWhenExists: ${skipWhenExists} });`;
 
 <if(ssr)>
   $ const { compiledVueComponents } = out.global;
@@ -23,4 +24,4 @@ $ const contents = `CMSBrowserComponents.load({ el: '#${id}', name: '${name}', p
     <${input.renderBody} />
   </>
 </else>
-<script>$!{contents}</script>
+<script class="component" data-name=name>$!{contents}</script>

--- a/packages/marko-web/components/marko.json
+++ b/packages/marko-web/components/marko.json
@@ -17,6 +17,7 @@
     },
     "@hydrate": "boolean",
     "@ssr": "boolean",
+    "@skip-when-exists": "boolean",
     "@tag": "string",
     "@class": "string",
     "@attrs": "object",


### PR DESCRIPTION
When an existing instance of the component name is already present on the page.