### PR TITLE
Ad injection logic modification for when images are contained within a paragraph.

### DIFF
--- a/packages/marko-web-gam/browser/inject-ads.vue
+++ b/packages/marko-web-gam/browser/inject-ads.vue
@@ -93,11 +93,14 @@ export default {
                 $child.before(cleaned);
               } else if (!$next.hasClass('ad-container')) {
                 let hasInParagraphImage = false;
-                $child.children().each(function injectAdsChild() {
+                $child.children().each(function checkForChildEmbeds() {
                   if ($(this).attr('data-embed-type')) hasInParagraphImage = true;
                 });
-                if (hasInParagraphImage) $next.after(cleaned);
-                else $child.after(cleaned);
+                if (hasInParagraphImage) {
+                  $next.after(cleaned);
+                } else {
+                  $child.after(cleaned);
+                }
               } else {
                 const [toInsert] = $.parseHTML(cleaned);
                 if (!toInsert) return;

--- a/packages/marko-web-gam/browser/inject-ads.vue
+++ b/packages/marko-web-gam/browser/inject-ads.vue
@@ -92,7 +92,12 @@ export default {
               } else if ($child.is(headlineTags)) {
                 $child.before(cleaned);
               } else if (!$next.hasClass('ad-container')) {
-                $child.after(cleaned);
+                let hasInParagraphImage = false;
+                $child.children().each(function injectAdsChild() {
+                  if ($(this).attr('data-embed-type')) hasInParagraphImage = true;
+                });
+                if (hasInParagraphImage) $next.after(cleaned);
+                else $child.after(cleaned);
               } else {
                 const [toInsert] = $.parseHTML(cleaned);
                 if (!toInsert) return;


### PR DESCRIPTION
PROD:
![Ad-Injection-PROD](https://user-images.githubusercontent.com/46794001/189712333-6a980893-2ef0-4f11-b42c-bff5d17013cf.png)

DEV:
![Ad-Injection-DEV](https://user-images.githubusercontent.com/46794001/189712363-c8a6168c-badc-49c4-a264-5dff3e9e4741.png)


This somewhat resolves the issue of "floating images" coming from when ad's are injected into the body copy. It's imperfect due to the nature of how this is already being handled as there is not an easy way to indicate when a paragraph or subsequent element in long enough to pull up to slot alongside the image.