### PR TITLE
Auth0+IdentityX redirects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 
+/packages/marko-web-auth0 @solocommand
+/packages/marko-web-auth0-identity-x @solocommand
 /packages/marko-web-identity-x @solocommand
 /packages/marko-web-omeda @solocommand
 /packages/marko-web-omeda-identity-x @solocommand

--- a/packages/marko-web-auth0-identity-x/middleware.js
+++ b/packages/marko-web-auth0-identity-x/middleware.js
@@ -48,7 +48,7 @@ module.exports = asyncRoute(async (req, res, next) => {
     await idxSvc.logoutAppUser();
   }
 
-  if (await isInputRequired(idxSvc)) {
+  if (idxSvc.token && await isInputRequired(idxSvc)) {
     const profile = idxSvc.config.getEndpointFor('profile');
     const url = [
       profile,

--- a/packages/marko-web-auth0-identity-x/middleware.js
+++ b/packages/marko-web-auth0-identity-x/middleware.js
@@ -48,15 +48,18 @@ module.exports = asyncRoute(async (req, res, next) => {
     await idxSvc.logoutAppUser();
   }
 
-  if (idxSvc.token && await isInputRequired(idxSvc)) {
+  if (idxSvc.token && await isInputRequired(idxSvc) && req.query.isAuth0Login) {
     const profile = idxSvc.config.getEndpointFor('profile');
-    const url = [
-      profile,
-      ...(originalUrl && ![profile, '/'].includes(originalUrl) ? [
-        `?returnTo=${encodeURIComponent(originalUrl)}`,
-      ] : []),
-    ].join('');
-    res.redirect(302, url);
+    const url = new URL(`${req.protocol}://${req.get('host')}${originalUrl}`);
+    url.searchParams.delete('isAuth0Login');
+    const returnTo = `${url}`;
+
+    // If the user attempted to access the profile page, don't redirect after submission.
+    if (url.pathname === profile) {
+      res.redirect(302, profile);
+    } else {
+      res.redirect(302, `${profile}?returnTo=${encodeURIComponent(returnTo)}`);
+    }
   } else {
     next();
   }

--- a/packages/marko-web-auth0-identity-x/middleware.js
+++ b/packages/marko-web-auth0-identity-x/middleware.js
@@ -11,15 +11,16 @@ const isEmpty = v => v == null || v === '';
 const isInputRequired = async (service) => {
   const { user, application } = await service.loadActiveContext({ forceQuery: true });
 
-  // Sync fields, intercept/redirect if missing required fields? check force verify?
+  // Check that all requires fields (from IdentityX config) are set
   const requiredFields = service.config.getRequiredServerFields();
   const requiresUserInput = user ? requiredFields.some(key => isEmpty(user[key])) : false;
   if (requiresUserInput) return true;
 
-  // @todo should this be allowed to pass through on impersonation?
+  // Check that the user does not need to reverify their profile
   const mustReverify = Boolean(user.mustReVerifyProfile);
   if (mustReverify) return true;
 
+  // Check that all regional consent policies are agreed to
   const { regionalConsentPolicies } = application.organization;
   const matchingPolicies = regionalConsentPolicies.filter((policy) => {
     const countryCodes = policy.countries.map(country => country.id);

--- a/packages/marko-web-auth0-identity-x/middleware.js
+++ b/packages/marko-web-auth0-identity-x/middleware.js
@@ -48,17 +48,22 @@ module.exports = asyncRoute(async (req, res, next) => {
     await idxSvc.logoutAppUser();
   }
 
-  if (idxSvc.token && await isInputRequired(idxSvc) && req.query.isAuth0Login) {
+  if (idxSvc.token && req.query.isAuth0Login) {
     const profile = idxSvc.config.getEndpointFor('profile');
     const url = new URL(`${req.protocol}://${req.get('host')}${originalUrl}`);
     url.searchParams.delete('isAuth0Login');
     const returnTo = `${url}`;
 
-    // If the user attempted to access the profile page, don't redirect after submission.
-    if (url.pathname === profile) {
-      res.redirect(302, profile);
+    if (await isInputRequired(idxSvc)) {
+      // If the user attempted to access the profile page, don't redirect after submission.
+      if (url.pathname === profile) {
+        res.redirect(302, profile);
+      } else {
+        res.redirect(302, `${profile}?returnTo=${encodeURIComponent(returnTo)}`);
+      }
     } else {
-      res.redirect(302, `${profile}?returnTo=${encodeURIComponent(returnTo)}`);
+      // Strip the query parameter
+      res.redirect(302, returnTo);
     }
   } else {
     next();

--- a/packages/marko-web-auth0-identity-x/middleware.js
+++ b/packages/marko-web-auth0-identity-x/middleware.js
@@ -9,11 +9,12 @@ const isEmpty = v => v == null || v === '';
  * @returns Boolean
  */
 const isInputRequired = async (service) => {
-  const { user, application } = await service.loadActiveContext({ forceQuery: true });
+  const { user: activeUser, application } = await service.loadActiveContext({ forceQuery: true });
+  const user = activeUser || {};
 
   // Check that all requires fields (from IdentityX config) are set
   const requiredFields = service.config.getRequiredServerFields();
-  const requiresUserInput = user ? requiredFields.some(key => isEmpty(user[key])) : false;
+  const requiresUserInput = requiredFields.some(key => isEmpty(user[key]));
   if (requiresUserInput) return true;
 
   // Check that the user does not need to reverify their profile

--- a/packages/marko-web-auth0/index.js
+++ b/packages/marko-web-auth0/index.js
@@ -27,8 +27,10 @@ module.exports = (app, params = {}) => {
   // Redirect after login if `returnTo` URL parameter is present.
   if (config.routes.login === false) {
     app.get('/login', (req, res) => {
-      const returnTo = req.query.returnTo || req.get('referrer') || config.baseURL;
-      res.oidc.login({ returnTo });
+      const referrer = req.query.returnTo || req.get('referrer') || config.baseURL;
+      const returnTo = new URL(referrer);
+      returnTo.searchParams.append('isAuth0Login', true);
+      res.oidc.login({ returnTo: `${returnTo}` });
     });
   }
 };

--- a/packages/marko-web-auth0/index.js
+++ b/packages/marko-web-auth0/index.js
@@ -28,7 +28,12 @@ module.exports = (app, params = {}) => {
   if (config.routes.login === false) {
     app.get('/login', (req, res) => {
       const referrer = req.query.returnTo || req.get('referrer') || config.baseURL;
-      const returnTo = new URL(referrer);
+      let returnTo;
+      try {
+        returnTo = new URL(referrer);
+      } catch (e) {
+        returnTo = new URL(referrer, `${req.protocol}://${req.get('host')}`);
+      }
       returnTo.searchParams.append('isAuth0Login', true);
       res.oidc.login({ returnTo: `${returnTo}` });
     });

--- a/packages/marko-web-auth0/index.js
+++ b/packages/marko-web-auth0/index.js
@@ -27,7 +27,7 @@ module.exports = (app, params = {}) => {
   // Redirect after login if `returnTo` URL parameter is present.
   if (config.routes.login === false) {
     app.get('/login', (req, res) => {
-      const returnTo = req.query.returnTo || config.baseURL;
+      const returnTo = req.query.returnTo || req.get('referrer') || config.baseURL;
       res.oidc.login({ returnTo });
     });
   }

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -289,6 +289,10 @@ export default {
       type: String,
       default: null,
     },
+    returnTo: {
+      type: String,
+      default: null,
+    },
   },
 
   /**
@@ -299,6 +303,7 @@ export default {
       error: null,
       isLoading: false,
       isReloadingPage: false,
+      isRedirectingPage: false,
       didSubmit: false,
       user: {
         ...this.activeUser,
@@ -342,6 +347,7 @@ export default {
     submitMessage() {
       const message = 'Profile updated.';
       if (this.isReloadingPage) return `${message} Reloading page...`;
+      if (this.isRedirectingPage) return `${message} Redirecting page...`;
       return message;
     },
 
@@ -543,6 +549,11 @@ export default {
         this.didSubmit = true;
 
         this.emit('profile-updated');
+
+        if (this.returnTo) {
+          this.isRedirectingPage = true;
+          window.location = this.returnTo;
+        }
 
         if (this.reloadPageOnSubmit) {
           this.isReloadingPage = true;

--- a/packages/marko-web-identity-x/components/form-profile.marko
+++ b/packages/marko-web-identity-x/components/form-profile.marko
@@ -2,7 +2,7 @@ import { get } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { req } = out.global;
-$ const { identityX } = req;
+$ const { identityX, query } = req;
 $ const additionalEventData = defaultValue(input.additionalEventData, {});
 
 <if(Boolean(identityX))>
@@ -23,6 +23,7 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       emailConsentRequest: get(application, "organization.emailConsentRequest"),
       appContextId: identityX.config.get("appContextId"),
       regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
+      returnTo: query.returnTo,
     };
     <if(isEnabled)>
       <marko-web-browser-component name="IdentityXProfile" props=props />

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -130,6 +130,14 @@ class IdentityX {
     const { token } = data.impersonateAppUser;
     tokenCookie.setTo(this.res, token.value);
     this.token = token;
+
+    // Re-init the client because the token changed
+    this.client = createClient({
+      req: this.req,
+      token,
+      appId: this.config.getAppId(),
+      config: this.config,
+    });
   }
 
   async logoutAppUser() {

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -34,12 +34,12 @@ class IdentityX {
    *
    * @returns {Promise<object>}
    */
-  async loadActiveContext() {
+  async loadActiveContext({ forceQuery = false, useIps = false } = {}) {
     // Require a token/cookie to check active context. This disables team context from IP/CIDR.
-    if (!this.token) return {};
+    if (!this.token && !useIps) return {};
 
     // Only run the active context query once
-    if (!this.activeContextQuery) {
+    if (!this.activeContextQuery || forceQuery) {
       this.activeContextQuery = this.client.query({ query: getActiveContext });
     }
     const { data = {} } = await this.activeContextQuery;

--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -30,9 +30,11 @@ export default (Browser, config = {
   enableOmedaIdentityX: true,
   withGTM: true,
   withP1Events: true,
+  idxArgs: {},
 }) => {
   const { EventBus } = Browser;
   const { enableOmedaIdentityX } = config;
+  const idxArgs = config.idxArgs || {};
 
   if (enableOmedaIdentityX) {
     EventBus.$on('omeda-identity-x-authenticated', ({ brandKey, encryptedId }) => {
@@ -71,9 +73,9 @@ export default (Browser, config = {
   SocialSharing(Browser);
   NativeX(Browser);
   if (enableOmedaIdentityX) {
-    OmedaIdentityX(Browser);
+    OmedaIdentityX(Browser, idxArgs);
   } else {
-    IdentityX(Browser);
+    IdentityX(Browser, idxArgs);
   }
   IdentityXNewsletterForms(Browser);
   Inquiry(Browser);


### PR DESCRIPTION
Updates Auth0 middleware to redirect to referrer after login -- returning user to previous page.
Updates Auth0+IdentityX middleware to redirect to the user profile if missing required fields.
Updates IdentityX profile components to allow redirection after submission
Updates Monorail browser initialization to pass IdentityX component args through to underlying tools