### PR TITLE
Add childCompanies fields on ContentCompany

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
@@ -38,7 +38,7 @@ type ContentCompany implements Content & PrimaryCategory & Contactable & Address
   youtubeVideos(input: ContentCompanyYoutubeVideosInput = {}): YoutubePlaylistConnection! @projection(needs: ["youtube"])
 
   # Computed relationship of companies where parentCompany is set to current _id
-  childCompanies(input: ContentCompanyChildCompaniesInput = {}): ContentCompanyConnection! @projection(localField: "_id") @refMany(model: "platform.Content", localField: "_id", foreignField: "parentCompany")
+  childern(input: ContentCompanyChildCompaniesInput = {}): ContentCompanyConnection! @projection(localField: "_id") @refMany(model: "platform.Content", localField: "_id", foreignField: "parentCompany")
 
   # fields directly on platform.model::Content\Company from mutations
   featuredCategories(input: ContentCompanyFeaturedCategoriesInput = {}): TaxonomyConnection! @projection(localField: "mutations.Website.featuredCategories") @refMany(model: "platform.Taxonomy", localField: "mutations.Website.featuredCategories", criteria: "taxonomyCategory")

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
@@ -38,7 +38,7 @@ type ContentCompany implements Content & PrimaryCategory & Contactable & Address
   youtubeVideos(input: ContentCompanyYoutubeVideosInput = {}): YoutubePlaylistConnection! @projection(needs: ["youtube"])
 
   # Computed relationship of companies where parentCompany is set to current _id
-  childern(input: ContentCompanyChildCompaniesInput = {}): ContentCompanyConnection! @projection(localField: "_id") @refMany(model: "platform.Content", localField: "_id", foreignField: "parentCompany")
+  children(input: ContentCompanyChildCompaniesInput = {}): ContentCompanyConnection! @projection(localField: "_id") @refMany(model: "platform.Content", localField: "_id", foreignField: "parentCompany")
 
   # fields directly on platform.model::Content\Company from mutations
   featuredCategories(input: ContentCompanyFeaturedCategoriesInput = {}): TaxonomyConnection! @projection(localField: "mutations.Website.featuredCategories") @refMany(model: "platform.Taxonomy", localField: "mutations.Website.featuredCategories", criteria: "taxonomyCategory")

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
@@ -37,6 +37,9 @@ type ContentCompany implements Content & PrimaryCategory & Contactable & Address
   youtube: ContentCompanyYoutube! @projection
   youtubeVideos(input: ContentCompanyYoutubeVideosInput = {}): YoutubePlaylistConnection! @projection(needs: ["youtube"])
 
+  # Computed relationship of companies where parentCompany is set to current _id
+  childCompanies(input: ContentCompanyChildCompaniesInput = {}): ContentCompanyConnection! @projection(localField: "_id") @refMany(model: "platform.Content", localField: "_id", foreignField: "parentCompany")
+
   # fields directly on platform.model::Content\Company from mutations
   featuredCategories(input: ContentCompanyFeaturedCategoriesInput = {}): TaxonomyConnection! @projection(localField: "mutations.Website.featuredCategories") @refMany(model: "platform.Taxonomy", localField: "mutations.Website.featuredCategories", criteria: "taxonomyCategory")
 }
@@ -158,6 +161,12 @@ input ContentCompanySocialLinkInput {
 }
 
 input ContentCompanyCompanyCompetitorsInput {
+  status: ModelStatus = active
+  sort: ContentCompanySortInput = {}
+  pagination: PaginationInput = {}
+}
+
+input ContentCompanyChildCompaniesInput {
   status: ModelStatus = active
   sort: ContentCompanySortInput = {}
   pagination: PaginationInput = {}

--- a/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
@@ -38,7 +38,7 @@ type ContentCompany implements Content & PrimaryCategory & Contactable & Address
   youtubeVideos(input: ContentCompanyYoutubeVideosInput = {}): YoutubePlaylistConnection! @projection(needs: ["youtube"])
 
   # Computed relationship of companies where parentCompany is set to current _id
-  children(input: ContentCompanyChildCompaniesInput = {}): ContentCompanyConnection! @projection(localField: "_id") @refMany(model: "platform.Content", localField: "_id", foreignField: "parentCompany")
+  children(input: ContentCompanyChildrenInput = {}): ContentCompanyConnection! @projection(localField: "_id") @refMany(model: "platform.Content", localField: "_id", foreignField: "parentCompany")
 
   # fields directly on platform.model::Content\Company from mutations
   featuredCategories(input: ContentCompanyFeaturedCategoriesInput = {}): TaxonomyConnection! @projection(localField: "mutations.Website.featuredCategories") @refMany(model: "platform.Taxonomy", localField: "mutations.Website.featuredCategories", criteria: "taxonomyCategory")
@@ -166,7 +166,7 @@ input ContentCompanyCompanyCompetitorsInput {
   pagination: PaginationInput = {}
 }
 
-input ContentCompanyChildCompaniesInput {
+input ContentCompanyChildrenInput {
   status: ModelStatus = active
   sort: ContentCompanySortInput = {}
   pagination: PaginationInput = {}


### PR DESCRIPTION
Add a computed field for childCompanies which returns companies where parentCompany: _id(currentCompanyModelId)

For use on company landing page to display child companies(Branches).

<img width="1194" alt="Screen Shot 2022-10-06 at 11 33 08 AM" src="https://user-images.githubusercontent.com/3845869/194368917-b0f5238c-055d-4104-b44a-13831489b2c8.png">

