### PR TITLE
Add deploymentProductId on subscription product

### DIFF
--- a/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-customer-record.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-customer-record.js
@@ -28,7 +28,7 @@ const query = gql`
         optInStatus { deploymentTypeId status { id } }
       }
       subscriptions {
-        product { id }
+        product { id deploymentTypeId }
         receive
       }
     }


### PR DESCRIPTION
Add the deployentTypeId to be used to determine if a user has already subscribe to a given product. 

This will be used within this request https://github.com/parameter1/randall-reilly-websites/pull/478