### PR TITLE
Correct setLink in updateWebsiteSection mutation

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/website/section.js
+++ b/services/graphql-server/src/graphql/resolvers/website/section.js
@@ -206,9 +206,9 @@ module.exports = {
       } = payload;
       const body = new Base4RestPayload({ type });
       Object.keys(fields).forEach(k => body.set(k, fields[k]));
-      if (site) body.setLink('site', { site, type: 'website/product/site' });
-      if (parent) body.setLink('parent', { parent, type });
-      if (logo) body.setLink('logo', { logo, type: 'platform/asset/image' });
+      if (site) body.setLink('site', { id: site, type: 'website/product/site' });
+      if (parent) body.setLink('parent', { id: parent, type });
+      if (logo) body.setLink('logo', { id: logo, type: 'platform/asset/image' });
       if (relatedSectionIds) {
         body.setLinks('relatedSections', relatedSectionIds.map(i => ({ id: i, type })));
       }


### PR DESCRIPTION
Ref: https://github.com/parameter1/base-cms/blob/master/packages/base4-rest-api/src/payload.js#L23

This function was being called with an incorrect signature thus causing the mutation to fail when any of these fields were attempted to be updated using the ```updateWebsiteSection``` mutation.