### PR TITLE
Add custom formatter support to Omeda+IdX rapid identification calls

### DIFF
--- a/packages/marko-web-omeda-identity-x/add-integration-hooks.js
+++ b/packages/marko-web-omeda-identity-x/add-integration-hooks.js
@@ -30,6 +30,9 @@ module.exports = (params = {}) => {
     idxOmedaRapidIdentifyProp,
     omedaPromoCodeCookieName,
     omedaPromoCodeDefault,
+    onLoginLinkSentFormatter,
+    onAuthenticationSuccessFormatter,
+    onUserProfileUpdateFormatter,
   } = validate(Joi.object({
     appendBehaviorToHook: Joi.array().items(schemas.hookBehavior).default([]),
     appendDemographicToHook: Joi.array().items(schemas.hookDemographic).default([]),
@@ -42,6 +45,9 @@ module.exports = (params = {}) => {
     omedaGraphQLClientProp: Joi.string().required(),
     omedaPromoCodeCookieName: Joi.string().required(),
     omedaPromoCodeDefault: Joi.string(),
+    onLoginLinkSentFormatter: Joi.function().required(),
+    onAuthenticationSuccessFormatter: Joi.function().required(),
+    onUserProfileUpdateFormatter: Joi.function().required(),
   }), params);
 
   const buildBehaviorFor = behaviorFactory({ behaviors, behaviorAttributes });
@@ -61,6 +67,7 @@ module.exports = (params = {}) => {
       omedaGraphQLClient: get(args, `req.${omedaGraphQLClientProp}`),
       omedaPromoCodeCookieName,
       omedaPromoCodeDefault,
+      formatter: onLoginLinkSentFormatter,
       ...appendDataFor('onLoginLinkSent'),
       behavior: buildBehaviorFor('onLoginLinkSent', {
         actionSource: get(args, 'actionSource'),
@@ -79,6 +86,7 @@ module.exports = (params = {}) => {
       idxOmedaRapidIdentify: get(args, `req.${idxOmedaRapidIdentifyProp}`),
       omedaPromoCodeCookieName,
       omedaPromoCodeDefault,
+      formatter: onAuthenticationSuccessFormatter,
       ...appendDataFor('onAuthenticationSuccess'),
       behavior: buildBehaviorFor('onAuthenticationSuccess', {
         actionSource: get(args, 'actionSource'),
@@ -96,6 +104,7 @@ module.exports = (params = {}) => {
       idxOmedaRapidIdentify: get(args, `req.${idxOmedaRapidIdentifyProp}`),
       omedaPromoCodeCookieName,
       omedaPromoCodeDefault,
+      formatter: onUserProfileUpdateFormatter,
       ...appendDataFor('onUserProfileUpdate'),
       behavior: buildBehaviorFor('onUserProfileUpdate', {
         actionSource: get(args, 'actionSource'),

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -30,6 +30,9 @@ module.exports = (app, params = {}) => {
     omedaPromoCodeCookieName,
     omedaPromoCodeDefault,
     omedaRapidIdentifyProp,
+    onLoginLinkSentFormatter = (async ({ payload }) => ({ ...payload })),
+    onAuthenticationSuccessFormatter = (async ({ payload }) => ({ ...payload })),
+    onUserProfileUpdateFormatter = (async ({ payload }) => ({ ...payload })),
     rapidIdentProductId,
   } = validate(Joi.object({
     appendBehaviorToHook: Joi.array().items(schemas.hookBehavior),
@@ -93,6 +96,9 @@ module.exports = (app, params = {}) => {
     omedaPromoCodeCookieName: Joi.string().default('omeda_promo_code'),
     omedaPromoCodeDefault: Joi.string(),
     omedaRapidIdentifyProp: Joi.string().default('$omedaRapidIdentify'),
+    onLoginLinkSentFormatter: Joi.function(),
+    onAuthenticationSuccessFormatter: Joi.function(),
+    onUserProfileUpdateFormatter: Joi.function(),
     rapidIdentProductId: Joi.number().required(),
   }), params);
 
@@ -128,6 +134,9 @@ module.exports = (app, params = {}) => {
     omedaGraphQLClientProp,
     omedaPromoCodeCookieName,
     omedaPromoCodeDefault,
+    onLoginLinkSentFormatter,
+    onAuthenticationSuccessFormatter,
+    onUserProfileUpdateFormatter,
   });
 
   // attach the identity-x rapid identification wrapper middleware

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -12,6 +12,8 @@ const rapidIdentifyRouter = require('./routes/rapid-identify');
 const props = require('./validation/props');
 const schemas = require('./validation/schemas');
 
+const defaultFormatter = async ({ payload }) => payload;
+
 module.exports = (app, params = {}) => {
   const {
     appendBehaviorToHook,
@@ -30,9 +32,9 @@ module.exports = (app, params = {}) => {
     omedaPromoCodeCookieName,
     omedaPromoCodeDefault,
     omedaRapidIdentifyProp,
-    onLoginLinkSentFormatter = (async ({ payload }) => ({ ...payload })),
-    onAuthenticationSuccessFormatter = (async ({ payload }) => ({ ...payload })),
-    onUserProfileUpdateFormatter = (async ({ payload }) => ({ ...payload })),
+    onLoginLinkSentFormatter = defaultFormatter,
+    onAuthenticationSuccessFormatter = defaultFormatter,
+    onUserProfileUpdateFormatter = defaultFormatter,
     rapidIdentProductId,
   } = validate(Joi.object({
     appendBehaviorToHook: Joi.array().items(schemas.hookBehavior),

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-authentication-success.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-authentication-success.js
@@ -13,6 +13,7 @@ module.exports = async (params = {}) => {
     appendPromoCodes,
     behavior,
     brandKey,
+    formatter,
     idxOmedaRapidIdentify,
     omedaPromoCodeCookieName,
     omedaPromoCodeDefault,
@@ -25,6 +26,7 @@ module.exports = async (params = {}) => {
     appendPromoCodes: Joi.array().items(schemas.appendPromoCode).default([]),
     behavior: schemas.behavior.required(),
     brandKey: props.brandKey.required(),
+    formatter: Joi.function().required(),
     user: Joi.object().required(),
     res: Joi.object().required(),
   }).unknown(true), params);
@@ -39,12 +41,16 @@ module.exports = async (params = {}) => {
     cookies: res.req.cookies,
   });
 
-  await idxOmedaRapidIdentify({
-    user,
-    behavior,
-    promoCode,
-    appendBehaviors,
-    appendDemographics,
-    appendPromoCodes,
+  const payload = await formatter({
+    req,
+    payload: {
+      user,
+      behavior,
+      promoCode,
+      appendBehaviors,
+      appendDemographics,
+      appendPromoCodes,
+    },
   });
+  await idxOmedaRapidIdentify(payload);
 };

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-authentication-success.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-authentication-success.js
@@ -19,6 +19,7 @@ module.exports = async (params = {}) => {
     omedaPromoCodeDefault,
     promoCode: hookDataPromoCode,
     res,
+    req,
     user,
   } = validate(Joi.object({
     appendBehaviors: Joi.array().items(schemas.appendBehavior).default([]),
@@ -29,6 +30,7 @@ module.exports = async (params = {}) => {
     formatter: Joi.function().required(),
     user: Joi.object().required(),
     res: Joi.object().required(),
+    req: Joi.object().required(),
   }).unknown(true), params);
   const encryptedId = findEncryptedId({ externalIds: user.externalIds, brandKey });
   if (!encryptedId) return;

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-user-profile-update.js
@@ -9,6 +9,7 @@ module.exports = async (params = {}) => {
     appendDemographics,
     appendPromoCodes,
     behavior,
+    formatter,
     idxOmedaRapidIdentify,
     omedaPromoCodeCookieName,
     omedaPromoCodeDefault,
@@ -20,6 +21,7 @@ module.exports = async (params = {}) => {
     appendDemographics: Joi.array().items(schemas.appendDemographic).default([]),
     appendPromoCodes: Joi.array().items(schemas.appendPromoCode).default([]),
     behavior: schemas.behavior.required(),
+    formatter: Joi.function().required(),
     idxOmedaRapidIdentify: Joi.function().required(),
     omedaPromoCodeCookieName: Joi.string().required(),
     omedaPromoCodeDefault: Joi.string(),
@@ -35,12 +37,17 @@ module.exports = async (params = {}) => {
     cookies: req.cookies,
   });
 
-  return idxOmedaRapidIdentify({
-    user,
-    behavior,
-    promoCode,
-    appendBehaviors,
-    appendDemographics,
-    appendPromoCodes,
+  const payload = await formatter({
+    req,
+    payload: {
+      user,
+      behavior,
+      promoCode,
+      appendBehaviors,
+      appendDemographics,
+      appendPromoCodes,
+    },
   });
+
+  return idxOmedaRapidIdentify(payload);
 };

--- a/services/example-website/config/omeda-identity-x.js
+++ b/services/example-website/config/omeda-identity-x.js
@@ -1,4 +1,6 @@
-const { get } = require('@parameter1/base-cms-object-path');
+const { get, getAsArray } = require('@parameter1/base-cms-object-path');
+const { getOmedaCustomerRecord } = require('@parameter1/base-cms-marko-web-omeda-identity-x/omeda-data');
+
 const idxConfig = require('./identity-x');
 const omedaConfig = require('./omeda');
 
@@ -106,4 +108,63 @@ module.exports = {
       promoCode: 'P1FullProfile',
     },
   ],
+
+  // onLoginLinkSentFormatter: (async ({ payload }) => ({ ...payload })),
+  onAuthenticationSuccessFormatter: (async ({ payload }) => ({ ...payload, promoCode: 'ExampleWebsiteOnAuthSuccessPromo' })),
+  onUserProfileUpdateFormatter: (async ({ req, payload }) => {
+    // BAIL if omedaGraphQLCLient isnt available return payload.
+    if (!req.$omedaGraphQLClient) return payload;
+
+    const idxOnProductHooks = req.app.locals.site.getAsObject('idxOnProductHooks');
+    const omeda = req.app.locals.site.getAsObject('omeda');
+    if (idxOnProductHooks.onUserProfileUpdate) {
+      const { productIds, promoCode } = idxOnProductHooks.onUserProfileUpdate;
+      const { user } = payload;
+      // Get the encriptedCustomerId that matches the omeda brandKey
+      const encryptedCustomerId = user.externalIds.filter(({
+        identifier,
+        namespace,
+      }) => identifier.type === 'encrypted'
+      && namespace.provider === 'omeda'
+      && namespace.tenant === omeda.brandKey)[0].identifier.value;
+
+      // BAIL if no encryptedCustomerId and return payload
+      if (!encryptedCustomerId) return payload;
+
+      // Retrive the omeda customer
+      const omedaCustomer = await getOmedaCustomerRecord({
+        omedaGraphQLClient: req.$omedaGraphQLClient,
+        encryptedCustomerId,
+      });
+      // Get the current user subscriptions
+      const subscriptions = getAsArray(omedaCustomer, 'subscriptions');
+      // For each autoOptinProduct check if they have a subscription.
+      // Sign the user up if they do not
+      const newSubscriptions = productIds.filter(
+        id => !subscriptions.some(({ product }) => product.deploymentTypeId === id),
+      );
+      if (newSubscriptions) {
+        const deploymentTypeIds = payload.deploymentTypeIds
+          ? [...payload.deploymentTypeIds, ...newSubscriptions]
+          : [...newSubscriptions];
+        return ({
+          ...payload,
+          deploymentTypeIds,
+          appendPromoCodes: [
+            promoCode,
+          ],
+        });
+      }
+    }
+    return payload;
+  }),
+
+  /**
+   * Customize Omeda+IdentityX payload
+   */
+  // onAuthenticationSuccessFormatter: async payload => ({
+  //   ...payload,
+  //   // productIds: [33],
+  //   promoCode: 'onAuthenticationSuccessWithFormatter',
+  // }),
 };

--- a/services/example-website/config/omeda-identity-x.js
+++ b/services/example-website/config/omeda-identity-x.js
@@ -120,16 +120,13 @@ module.exports = {
     if (idxOnProductHooks.onUserProfileUpdate) {
       const { productIds, promoCode } = idxOnProductHooks.onUserProfileUpdate;
       const { user } = payload;
-      // Get the encriptedCustomerId that matches the omeda brandKey
-      const encryptedCustomerId = user.externalIds.filter(({
-        identifier,
-        namespace,
-      }) => identifier.type === 'encrypted'
-      && namespace.provider === 'omeda'
-      && namespace.tenant === omeda.brandKey)[0].identifier.value;
-
+      const found = getAsArray(user, 'externalIds')
+        .find(({ identifier, namespace }) => identifier.type === 'encrypted'
+          && namespace.provider === 'omeda'
+          && namespace.tenant === omeda.brandKey);
       // BAIL if no encryptedCustomerId and return payload
-      if (!encryptedCustomerId) return payload;
+      if (!found) return payload;
+      const encryptedCustomerId = get(found, 'identifier.value');
 
       // Retrive the omeda customer
       const omedaCustomer = await getOmedaCustomerRecord({

--- a/services/example-website/config/site.js
+++ b/services/example-website/config/site.js
@@ -27,6 +27,12 @@ module.exports = {
     tenant: 'p1',
     cookieDomain: 'dev.parameter1.com',
   },
+  idxOnProductHooks: {
+    onUserProfileUpdate: {
+      productIds: [33],
+      promoCode: 'OV_registration_meter',
+    },
+  },
   logos: {
     navbar: {
       src: 'https://p1-cms-assets.imgix.net/files/base/p1/sandbox/image/static/sandbox-logo.png?h=45&auto=format,compress',


### PR DESCRIPTION
Add payload formatters to the onLoginLinkSent, onAuthenticationSuccess & onUserProfileUpdate.  This allows for individual groups to manipulate the payload being sent to omeda's rapidIdent process after the user hits submit & before it is sent to the rapid Ident call.  It will allow groups to adjust stuff like promoCodes and deploymentTypeIds being sent along.  

In this example we set a new appendPromoCode and auto opted the user into the deploymentTypeIds of 63.

![Screen-Shot-2022-10-11-at-8 46 07-AM](https://user-images.githubusercontent.com/3845869/195110514-4aa1a5d4-25f1-410d-b1b1-5e63e64f70ea.jpg)
