### PR TITLE
Add product.type.id to getOmedaCustomerRecord for use with the new on${hook}formatters

### DIFF
--- a/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-customer-record.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-customer-record.js
@@ -28,7 +28,7 @@ const query = gql`
         optInStatus { deploymentTypeId status { id } }
       }
       subscriptions {
-        product { id deploymentTypeId }
+        product { id deploymentTypeId type { id } }
         receive
       }
     }

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -8,6 +8,7 @@ module.exports = new IdentityXConfiguration({
   requiredServerFields: ['givenName', 'familyName', 'countryCode'],
   requiredClientFields: ['regionCode', 'countryCode'],
   booleanQuestionsLabel: 'Choose your subscriptions:',
+  promoCode: 'registration_meter',
   hiddenFields: [],
   onHookError: (e) => {
     log('IDENTITY-X HOOK ERROR!', e);

--- a/services/example-website/config/omeda-identity-x.js
+++ b/services/example-website/config/omeda-identity-x.js
@@ -135,7 +135,6 @@ module.exports = {
     if (hasWebsiteSubscription && (payload.promoCode || payload.appendPromoCodes.length)) {
       const promoCode = !payload.promoCode.includes('registration_meter') ? payload.promoCode : undefined;
       const appendPromoCodes = payload.appendPromoCodes.filter(code => !code.includes('registration_meter'));
-      console.log(payload, { ...payload, promoCode, appendPromoCodes });
       return {
         ...payload,
         promoCode,


### PR DESCRIPTION
This will be used in conjuntion with the onLoginLinkSentFormatter to determine if the user has already been subscribed to the current website product.

The example-website example is using this to filter down the subscriptions based on current rapidIdentificationProductId set by the config.  If the user is already subscribed to the website product remove any promoCode being set for the `registration_meter`. This promoCode, or associated promoCode, should have already been set the first time they registered and subscribed to the website.