### PR TITLE
Allow the deploymentTypes prop to be passed through the omedaRapidIdentify middleware

### DIFF
--- a/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/middleware/rapid-identify.js
@@ -20,6 +20,7 @@ module.exports = ({
     const handler = async ({
       user,
       promoCode,
+      deploymentTypes,
       appendBehaviors,
       appendDemographics,
       appendPromoCodes,
@@ -36,6 +37,7 @@ module.exports = ({
       }),
 
       // Custom behaviors, demos, or codes to append to the API call
+      deploymentTypes,
       appendBehaviors,
       appendDemographics,
       appendPromoCodes,

--- a/packages/marko-web-omeda-identity-x/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/rapid-identify.js
@@ -36,6 +36,8 @@ module.exports = async ({
 
   promoCode,
 
+  deploymentTypes = [],
+
   appendBehaviors,
   appendDemographics,
   appendPromoCodes,
@@ -78,7 +80,6 @@ module.exports = async ({
     };
   });
 
-  const deploymentTypes = [];
   const subscriptions = [];
   getAsArray(appUser, 'customBooleanFieldAnswers').forEach((boolean) => {
     const { field, hasAnswered } = boolean;

--- a/services/example-website/config/omeda-identity-x.js
+++ b/services/example-website/config/omeda-identity-x.js
@@ -141,14 +141,13 @@ module.exports = {
         id => !subscriptions.some(({ product }) => product.deploymentTypeId === id),
       );
       if (newSubscriptions) {
-        const deploymentTypeIds = payload.deploymentTypeIds
-          ? [...payload.deploymentTypeIds, ...newSubscriptions]
-          : [...newSubscriptions];
+        const deploymentTypes = newSubscriptions.map(id => ({ id, optedIn: true }));
         return ({
           ...payload,
-          deploymentTypeIds,
+          deploymentTypes,
+          promoCode,
           appendPromoCodes: [
-            promoCode,
+            { promoCode },
           ],
         });
       }


### PR DESCRIPTION
Allow the idxOmedaRapidIdentifyto pass through the deploymentTypes prop through  to the omedaRapidIdentify function.

Example Payload that will now hit omedaRapidIdent 
```js
{
  productId: 19,
  email: 'brian@parameter1.com',
  firstName: 'Brian',
  companyName: 'Parameter1',
  title: 'Developer',
  countryCode: 'USA',
  postalCode: '53538',
  deploymentTypes: [ { id: 90, optedIn: true } ],
  demographics: [ { id: 241, values: [Array] } ],
  behaviors: [ { id: 89, attributes: [Array] } ],
  promoCode: 'OV_registration_meter'
}
```