### PR TITLE
Allow override of country label on Profile form

### DIFF
--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -73,6 +73,7 @@
             <country
               v-model="user.countryCode"
               :required="countryCodeSettings.required"
+              :label="defaultFieldLabels.country"
             />
           </div>
         </div>


### PR DESCRIPTION
See https://github.com/parameter1/base-cms/pull/454 simply adds this to the Country field as well