### PR TITLE
Remove width: auto from embedded images

### DIFF
--- a/packages/marko-web-theme-monorail/scss/components/_content-page.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_content-page.scss
@@ -160,7 +160,6 @@
         text-align: right;
       }
       img {
-        width: auto;
         min-width: auto;
         max-width: 100%;
         max-height: 300px;
@@ -172,7 +171,6 @@
         text-align: left;
       }
       img {
-        width: auto;
         min-width: auto;
         max-width: 100%;
         max-height: 300px;


### PR DESCRIPTION
<img width="379" alt="Screen Shot 2022-10-26 at 12 21 18 PM" src="https://user-images.githubusercontent.com/2855198/198094529-076c5190-95d6-4df0-9a6d-5db8c8fe2061.png">
