### PR TITLE
Add new sideloadDataFn() to withContent & pageNode calls

### DIFF
--- a/packages/marko-web/middleware/page-node/index.js
+++ b/packages/marko-web/middleware/page-node/index.js
@@ -9,12 +9,14 @@ class PageNode {
     queryFragment,
     variables,
     resultField,
+    sideloadDataFn,
   }) {
     this.apolloClient = apolloClient;
     this.queryFactory = queryFactory;
     this.queryFragment = queryFragment;
     this.variables = variables;
     this.resultField = resultField;
+    this.sideloadDataFn = sideloadDataFn;
   }
 
   async load() {
@@ -22,8 +24,19 @@ class PageNode {
       const { queryFragment, variables, resultField } = this;
       const path = `data.${resultField}`;
       const query = this.queryFactory({ queryFragment, queryName: 'PageNode' });
-      this.promise = this.apolloClient.query({ query, variables })
-        .then(r => createNode(getAsObject(r, path)));
+      if (typeof this.sideloadDataFn === 'function') {
+        this.sideloadDataFn.bind(this);
+        this.promise = Promise.all([
+          this.apolloClient.query({ query, variables }),
+          this.sideloadDataFn(),
+        ]).then(([r, sideloadedData]) => {
+          this.sideloadedData = sideloadedData;
+          return createNode(getAsObject(r, path));
+        });
+      } else {
+        this.promise = this.apolloClient.query({ query, variables })
+          .then(r => createNode(getAsObject(r, path)));
+      }
     }
     return this.promise;
   }

--- a/packages/marko-web/middleware/page-node/index.js
+++ b/packages/marko-web/middleware/page-node/index.js
@@ -1,3 +1,4 @@
+const { isFunction: isFn } = require('@parameter1/base-cms-utils');
 const { getAsObject } = require('@parameter1/base-cms-object-path');
 const ResolvedNode = require('./resolved');
 
@@ -24,19 +25,14 @@ class PageNode {
       const { queryFragment, variables, resultField } = this;
       const path = `data.${resultField}`;
       const query = this.queryFactory({ queryFragment, queryName: 'PageNode' });
-      if (typeof this.sideloadDataFn === 'function') {
-        this.sideloadDataFn.bind(this);
-        this.promise = Promise.all([
-          this.apolloClient.query({ query, variables }),
-          this.sideloadDataFn(),
-        ]).then(([r, sideloadedData]) => {
-          this.sideloadedData = sideloadedData;
-          return createNode(getAsObject(r, path));
-        });
-      } else {
-        this.promise = this.apolloClient.query({ query, variables })
-          .then(r => createNode(getAsObject(r, path)));
-      }
+      // Ensure there is a sideloadDataFn set, if not return empty object.
+      if (!isFn(this.sideloadDataFn)) this.sideloadDataFn = () => {};
+      const [r, sideloadedData] = await Promise.all([
+        this.apolloClient.query({ query, variables }),
+        this.sideloadDataFn(),
+      ]);
+      this.promise = createNode(getAsObject(r, path));
+      this.sideloadedData = sideloadedData;
     }
     return this.promise;
   }

--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -15,6 +15,7 @@ module.exports = ({
   redirectToFn,
   pathFn,
   formatResponse,
+  sideloadDataFn,
 } = {}) => asyncRoute(async (req, res) => {
   const id = isFn(idResolver) ? await idResolver(req, res) : req.params.id;
   const { apollo, query } = req;
@@ -36,6 +37,7 @@ module.exports = ({
     queryFragment,
     variables: { input: { id: Number(id), ...additionalInput } },
     resultField: 'content',
+    sideloadDataFn,
   });
   if (isFn(formatResponse)) await formatResponse({ res, content, pageNode });
   return res.marko(template, { ...content, pageNode });


### PR DESCRIPTION
Add new sideloadDataFn to be passed into pageNode middleware.  This allows for additional data to be loaded along side the standard calls.