### PR TITLE
Add linkSelector prop to trackContentBodyLinks

### DIFF
--- a/packages/marko-web-p1-events/browser/track-content-body-links.vue
+++ b/packages/marko-web-p1-events/browser/track-content-body-links.vue
@@ -13,6 +13,10 @@ export default {
       type: String,
       default: '.page-contents__content-body',
     },
+    linkSelector: {
+      type: String,
+      default: null,
+    },
     linkType: {
       type: String,
       default: 'external',
@@ -31,13 +35,14 @@ export default {
     if (!window.p1events) return;
     window.p1events('trackLinks', {
       ancestor: this.selector,
+      selector: this.linkSelector,
       linkType: this.linkType,
       handler: ({ element }) => {
         const url = element.getAttribute('href');
         if (!url) return null;
         return {
-          action: 'Click',
-          category: 'In-Body Content Link',
+          action: this.action,
+          category: this.category,
           entity: this.entity,
           props: { url },
         };

--- a/packages/marko-web-p1-events/components/marko.json
+++ b/packages/marko-web-p1-events/components/marko.json
@@ -26,6 +26,7 @@
       }
     },
     "@selector": "string",
+    "@link-selector": "string",
     "@link-type": "string",
     "@action": "string",
     "@category": "string"

--- a/packages/marko-web-p1-events/components/track-content-body-links.marko
+++ b/packages/marko-web-p1-events/components/track-content-body-links.marko
@@ -8,6 +8,7 @@ $ const content = getAsObject(input, "content");
   props={
     entity: eventEntity(content.id, content.type),
     selector: input.selector,
+    linkSelector: input.linkSelector,
     linkType: input.linkType,
     action: input.action,
     category: input.category,


### PR DESCRIPTION
Add ability to pass a link selector on top of a generic selector for targeting of links to track.

Also use the action and category prop to set p1Events value vs staticly being set.