### PR TITLE
Bail if crop dimensions aren’t available for "cropped" image

### DIFF
--- a/packages/image/src/crop-rectangle.js
+++ b/packages/image/src/crop-rectangle.js
@@ -55,6 +55,16 @@ module.exports = ({ width, height, cropDimensions }) => {
     return { ...o, [key]: v };
   }, {});
 
+  if (!x1 || !x2 || !y1 || !y2) {
+    return new CropRectangle({
+      x: 0,
+      y: 0,
+      width,
+      height,
+      cropped: false,
+    });
+  }
+
   return new CropRectangle({
     x: x1,
     y: y1,


### PR DESCRIPTION
Previously an assumption was being made (rightly or wrongly) that x1, x2, y1 and y2 would always be available on an Image that was marked as "cropped", however (as noted below) there are possibilities in the Base interface to crop an image without these values being set at all. Instead of returning null, causing the GraphQL query/fragment to fail for returning null on a non-nullable field, we will bail with the same logic we use when there is not a width, height or cropDimensions passed into this function.

URL: https://www.ccjdigital.com/alternative-power/article/15293351/truckings-ev-revolution-will-not-be-driven-by-price

Image from Production in current state:
<img width="1920" alt="Screen Shot 2022-11-02 at 2 14 27 PM" src="https://user-images.githubusercontent.com/46794001/199586318-8e03ba49-53d5-4e11-b2b1-98353807e915.png">

In Mongo:
<img width="1475" alt="Screen Shot 2022-11-02 at 2 32 48 PM" src="https://user-images.githubusercontent.com/46794001/199586376-c51bc931-c7cb-48de-a280-836d90d91a2d.png">

Asset causing issue in Mongo:
<img width="1473" alt="Screen Shot 2022-11-02 at 2 14 47 PM" src="https://user-images.githubusercontent.com/46794001/199586413-916d33c2-4048-4613-b758-b28847247618.png">

Asset cause issue in Base:
<img width="1920" alt="Screen Shot 2022-11-02 at 2 23 46 PM" src="https://user-images.githubusercontent.com/46794001/199586442-8ebd5e86-5cb6-4688-8237-45c5a458848f.png">

Resulting page following this correction:
<img width="1920" alt="Screen Shot 2022-11-02 at 2 34 26 PM" src="https://user-images.githubusercontent.com/46794001/199586491-02af4e83-a068-4eef-9b04-cad1174473c4.png">

