### PR TITLE
Add `ContentBodyInput.useLinkInjectedBody` input

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -748,6 +748,7 @@ input ContentBodyInput {
     fit: "max",
     auto: "format,compress"
   }
+  useLinkInjectedBody: Boolean = false
 }
 
 input EmbeddedImageAttrsInput {

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -31,7 +31,7 @@ interface Content @requiresProject(fields: ["type"]) {
   # fields from platform.trait::Content\BodyFields
   # @todo Add truncate support!
   teaser(input: ContentTeaserInput = {}): String @projection(localField: "teaser", needs: ["teaserFallback", "mutations.Website.teaser", "mutations.Email.teaser", "mutations.Magazine.teaser"])
-  body(input: ContentBodyInput = {}): String @projection(localField: "body", needs: ["mutations.Website.body", "mutations.Email.body", "mutations.Magazine.body"])
+  body(input: ContentBodyInput = {}): String @projection(localField: "body", needs: ["mutations.Website.body", "mutations.Email.body", "mutations.Magazine.body", "linkInjectedBody"])
   notes: String @projection
 
   # fields from platform.trait::Taggable

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -533,6 +533,10 @@ module.exports = {
       const mutated = get(content, `mutations.${mutation}.body`);
 
       let value = mutation ? mutated || body : body;
+      if (input.useLinkInjectedBody) {
+        value = `${content.linkInjectedBody || ''}`.trim() || value;
+      }
+
       // Use site image host otherwise fallback to global default.
       const imageHost = site.get('imageHost', defaults.imageHost);
       // Convert image tags to include image attributes (src, alt, caption, credit).


### PR DESCRIPTION
When true, the `Content.body` resolver will attempt to use the `linkInjectedBody` value from the content. If not present, the body will fall back to the requested mutation and then the default body (as before). Using the link injected body is false by default.