### PR TITLE
Use isNaN checks over truthy checks for dimensions, cropRectangle

### DIFF
--- a/packages/image/src/crop-rectangle.js
+++ b/packages/image/src/crop-rectangle.js
@@ -55,7 +55,7 @@ module.exports = ({ width, height, cropDimensions }) => {
     return { ...o, [key]: v };
   }, {});
 
-  if (!x1 || !x2 || !y1 || !y2) {
+  if (Number.isNaN(x1) || Number.isNaN(x2) || Number.isnNaN(y1) || Number.isNaN(y2)) {
     return new CropRectangle({
       x: 0,
       y: 0,


### PR DESCRIPTION
Slight oversight in https://github.com/parameter1/base-cms/pull/471 as 0 will cause these checks to fail and are perfectly valid numerical values.