### PR TITLE
Ensure dimensions are actually numbers, crop dimensions within crop rectangle.

### DIFF
--- a/packages/image/src/crop-rectangle.js
+++ b/packages/image/src/crop-rectangle.js
@@ -55,12 +55,8 @@ module.exports = ({ width, height, cropDimensions }) => {
     return { ...o, [key]: v };
   }, {});
 
-  if (
-    typeof x1 !== 'number'
-    || typeof x2 !== 'number'
-    || typeof y1 !== 'number'
-    || typeof y2 !== 'number'
-  ) {
+  const dimExists = dimension => (typeof dimension !== 'undefined' && dimension !== null && !Number.isNaN(Number(dimension)));
+  if (!dimExists(x1) || !dimExists(x2) || !dimExists(y1) || !dimExists(y2)) {
     return new CropRectangle({
       x: 0,
       y: 0,

--- a/packages/image/src/crop-rectangle.js
+++ b/packages/image/src/crop-rectangle.js
@@ -43,20 +43,9 @@ module.exports = ({ width, height, cropDimensions }) => {
       cropped: false,
     });
   }
-  // @see Cygnus\ApplicationBundle\Apps\Management\Controller::cropImageAction
-  const scale = width / 640;
-  const {
-    x1,
-    x2,
-    y1,
-    y2,
-  } = ['x1', 'x2', 'y1', 'y2'].reduce((o, key) => {
-    const v = Math.round(cropDimensions[key] * scale);
-    return { ...o, [key]: v };
-  }, {});
 
-  const dimExists = dimension => (typeof dimension !== 'undefined' && dimension !== null && !Number.isNaN(Number(dimension)));
-  if (!dimExists(x1) || !dimExists(x2) || !dimExists(y1) || !dimExists(y2)) {
+  const coords = ['x1', 'x2', 'y1', 'y2'];
+  if (coords.some(key => cropDimensions[key] == null || Number.isNaN(cropDimensions[key]))) {
     return new CropRectangle({
       x: 0,
       y: 0,
@@ -65,6 +54,19 @@ module.exports = ({ width, height, cropDimensions }) => {
       cropped: false,
     });
   }
+
+  // @see Cygnus\ApplicationBundle\Apps\Management\Controller::cropImageAction
+  const scale = width / 640;
+  const {
+    x1,
+    x2,
+    y1,
+    y2,
+  } = coords.reduce((o, key) => {
+    const v = Math.round(cropDimensions[key] * scale);
+    return { ...o, [key]: v };
+  }, {});
+
 
   return new CropRectangle({
     x: x1,


### PR DESCRIPTION
Due to these being casts as numbers via `Math.round()` these pass a type validation, doubly ensure that they are valid numbers before proceeding.

Consult: https://github.com/parameter1/base-cms/pull/471 for the instances by which this would occur 

Here is a new example: https://www.truckpartsandservice.com/products/supplier-updates/article/15064218/midwest-truck-auto-parts-updates-ordering-portal

Production:
<img width="1920" alt="Screen Shot 2022-11-07 at 2 11 59 PM" src="https://user-images.githubusercontent.com/46794001/200405661-a0544930-f122-40a3-85f6-7bffd7ed06d6.png">

Development:
<img width="1920" alt="Screen Shot 2022-11-07 at 2 11 43 PM" src="https://user-images.githubusercontent.com/46794001/200405691-822028a5-9c9f-476c-ad10-c955c06b173a.png">
