### PR TITLE
Adjust embedded image targeting for bottom border

### DIFF
--- a/packages/marko-web-theme-default/scss/components/_page-image.scss
+++ b/packages/marko-web-theme-default/scss/components/_page-image.scss
@@ -92,7 +92,9 @@
 }
 
 [data-embed-type="image"] {
-  > :last-child:not(img) {
-    border-bottom: 1px solid #ccc;
+  picture {
+    > :last-child:not(img) {
+      border-bottom: 1px solid #ccc;
+    }
   }
 }

--- a/packages/marko-web-theme-monorail/scss/theme-default/components/_page-image.scss
+++ b/packages/marko-web-theme-monorail/scss/theme-default/components/_page-image.scss
@@ -92,7 +92,9 @@
 }
 
 [data-embed-type="image"] {
-  > :last-child:not(img) {
-    border-bottom: 1px solid #ccc;
+  picture {
+    > :last-child:not(img) {
+      border-bottom: 1px solid #ccc;
+    }
   }
 }


### PR DESCRIPTION
Production:
![Screenshot from 2022-11-10 13-36-51](https://user-images.githubusercontent.com/46794001/201190827-d03e4969-e6ce-4bca-80bf-c50024b662b5.png)

Dev:
![Screenshot from 2022-11-10 13-31-56](https://user-images.githubusercontent.com/46794001/201190890-34a4eea5-b55a-4602-b3ec-2a182bc943f3.png)


NOTE: I opted not to change the behavior of https://github.com/parameter1/base-cms/blob/master/packages/marko-web-theme-monorail/scss/components/_content-page.scss#L263 as that behavior is functionally/logically different than these, if that should also be changed to be targeting in the same fashion, leave a review noting it.