### PR TITLE
Adjust userProfileSuccess template

### DIFF
--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -183,10 +183,15 @@
           <a :href="returnTo">Click here</a> to continue.
         </div>
         <div v-else class="success-message__message">
-          <button class="btn btn-link p-0" type="button" @click="handleReload()">
-            Click here
-          </button> to continue modiying your profile or
-          <a href="/">click here</a> to return to the home page.
+          <p>
+            To continue modifying your profile,
+            <button class="" type="button" @click="handleReload()">
+              click here
+            </button>.
+          </p>
+          <p>
+            <a href="/">Click here</a> to return to the home page.
+          </p>
         </div>
       </div>
     </div>

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -179,8 +179,13 @@
           Your profile has been saved.
         </div>
         <div v-if="returnTo" class="success-message__message">
-          You will be automatically redirected in {{ returnToDelay / 1000 }} seconds.
-          <a :href="returnTo">Click here</a> to continue.
+          <p>
+            You will be automatically redirected in {{ returnToDelay / 1000 }} seconds.
+          </p>
+          <p>
+            To continue now,
+            <a :href="returnTo">click here</a>.
+          </p>
         </div>
         <div v-else class="success-message__message">
           <p>
@@ -190,7 +195,7 @@
             </button>.
           </p>
           <p>
-            <a href="/">Click here</a> to return to the home page.
+            To return to the home page, <a href="/">click here</a>.
           </p>
         </div>
       </div>

--- a/packages/marko-web-theme-monorail/scss/components/_identity-x.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_identity-x.scss
@@ -36,11 +36,20 @@
   }
   &--profile {
     .success-message {
+      min-height: calc(60vh);
       @include skin-typography($style: "article-text", $link-style: "content-body");
       &__title {
         @include skin-typography($style: "header-2", $link-style: "primary");
-        margin-top: map-get($spacers, 2);
-        margin-bottom: map-get($spacers, 2);
+        margin: 2rem 0;
+      }
+      button {
+        @include skin-typography($style: "article-text", $link-style: "primary");
+        color: $primary;
+        padding: 0;
+        margin: 0;
+        background: none;
+        border: none;
+        text-decoration: underline;
       }
     }
   }


### PR DESCRIPTION
 - Add min-height of 60vh, allowing for screen size to help fill the availavle space.
 - Update/remove btn classing and handle click here button style to match other link styles.
 - Fix spelling of modiying => modifying.
 
### Without a redirect
<img width="1318" alt="Screen Shot 2022-11-14 at 8 55 32 AM" src="https://user-images.githubusercontent.com/3845869/201692861-9811f1ef-de96-4473-8392-79aa4dc933b1.png">
<img width="394" alt="Screen Shot 2022-11-14 at 8 55 44 AM" src="https://user-images.githubusercontent.com/3845869/201692866-4df2959f-d76e-438d-8007-3b9473b0ad5a.png">

### With auto redirection
<img width="1331" alt="Screen Shot 2022-11-14 at 8 57 42 AM" src="https://user-images.githubusercontent.com/3845869/201692867-ae771479-b6c4-4275-aff8-9e771ec4f270.png">
<img width="408" alt="Screen Shot 2022-11-14 at 8 59 03 AM" src="https://user-images.githubusercontent.com/3845869/201692868-f1e0ab0c-bc8c-46ab-a8ef-9226a9f6915e.png">
