### PR TITLE
Add emptyHTML check to only return transcripts that are not empty 

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -63,7 +63,7 @@ const retrieveYoutubePlaylistId = async ({ youtube }) => {
   }
 };
 
-const convertEmptyHtmlToNull = async (html) => {
+const convertEmptyHtmlToNull = (html) => {
   if (!html) return null;
   const $ = cheerio.load(html);
   if (!$.text().trim()) return null;
@@ -816,30 +816,21 @@ module.exports = {
 
       return null;
     },
-    transcript: async (content) => {
-      const transcript = await convertEmptyHtmlToNull(content.transcript);
-      return transcript;
-    },
+    transcript: ({ transcript }) => convertEmptyHtmlToNull(transcript),
   },
 
   /**
    *
    */
   ContentPodcast: {
-    transcript: async (content) => {
-      const transcript = await convertEmptyHtmlToNull(content.transcript);
-      return transcript;
-    },
+    transcript: ({ transcript }) => convertEmptyHtmlToNull(transcript),
   },
 
   /**
    *
    */
   ContentWebinar: {
-    transcript: async (content) => {
-      const transcript = await convertEmptyHtmlToNull(content.transcript);
-      return transcript;
-    },
+    transcript: ({ transcript }) => convertEmptyHtmlToNull(transcript),
   },
 
   ContentCompanyYoutube: {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -63,6 +63,13 @@ const retrieveYoutubePlaylistId = async ({ youtube }) => {
   }
 };
 
+const convertEmptyHtmlToNull = async (html) => {
+  if (!html) return null;
+  const $ = cheerio.load(html);
+  if (!$.text().trim()) return null;
+  return html;
+};
+
 const { isArray } = Array;
 
 const resolveType = async ({ type }) => `Content${type}`;
@@ -808,6 +815,30 @@ module.exports = {
       if (brightcoveSrc) return brightcoveSrc;
 
       return null;
+    },
+    transcript: async (content) => {
+      const transcript = await convertEmptyHtmlToNull(content.transcript);
+      return transcript;
+    },
+  },
+
+  /**
+   *
+   */
+  ContentPodcast: {
+    transcript: async (content) => {
+      const transcript = await convertEmptyHtmlToNull(content.transcript);
+      return transcript;
+    },
+  },
+
+  /**
+   *
+   */
+  ContentWebinar: {
+    transcript: async (content) => {
+      const transcript = await convertEmptyHtmlToNull(content.transcript);
+      return transcript;
     },
   },
 


### PR DESCRIPTION
This will insure that the transcript field is actually set to something with text in it vs empty html.  Before if you cleared out or the user has just save a couple of empty html element it would return and display what looked to be nothing, but was really emply p  & h tags.  This check looks to see if there is actually text to render within the given html elements.

For example if you clear out the transcript field or hit return once in the field and save the model you now have an empty <p></p> saved in the value for transcript.  This new check would see that value as empty when it convert the html to text and trim the whitespace.  It will return a null value instead of an empty html string.

This should allow for this [PR](https://github.com/parameter1/industrial-media-websites/pull/287) to be closed, but the site repos will have to have a dep upgrade done to prevent empty transcript fields from displaying.  