### PR TITLE
Verify GAM exists before calling methods on it

### DIFF
--- a/packages/marko-web-theme-monorail/components/gam/define-display-ad.marko
+++ b/packages/marko-web-theme-monorail/components/gam/define-display-ad.marko
@@ -6,7 +6,7 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { GAM, req } = out.global;
 
-$ const adUnit = GAM.getAdUnit({ name: input.name, aliases: input.aliases });
+$ const adUnit = GAM ? GAM.getAdUnit({ name: input.name, aliases: input.aliases }) : {};
 $ const { templateName } = adUnit;
 $ const showLabel = defaultValue(input.showLabel, true);
 $ const targeting = defaultValue(input.targeting, {});


### PR DESCRIPTION
This is contained within a feed block of the Monorail theme. In the case provided this is https://github.com/parameter1/base-cms/blob/master/packages/marko-web-theme-monorail/components/blocks/latest-products-feed.marko which is a part of products layout for AB, provided that AB is no longer using GAM calling GAM "willy nilly" like this causing erroring as GAM is no longer defined in that context. 

Provided that the block calling this is a member of the theme (see previous link), this should likely be accounted for anywhere that is utilizing this component to allow for it's "GAM logic" to be replaced by passed in components from the site level if need be.

One could argue that these components shouldn't be a part of `theme-monorail` (or at the very least not part of it's core implementation) and should be ported into either in place of the existing versions in `marko-web-gam` (or in addition to the ones already in `marko-web-gam` or into it's own package of `marko-web-theme-monorail-gam` etc. as while it may be typical that a site will use GAM in the even it doesn't it shouldn't inhibit the use of the items contained within the theme itself.

Production:
![Screenshot from 2022-11-21 11-33-00](https://user-images.githubusercontent.com/46794001/203123737-58462887-c5f0-4fa4-949c-ab8ff8295a4d.png)

Development:
![Screenshot from 2022-11-21 11-30-13](https://user-images.githubusercontent.com/46794001/203123785-ed1b5d2f-6ebc-43ad-9380-103516ba99a8.png)