### PR TITLE
Add SSR html body ad injection components.

### DIFF
--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -1,0 +1,47 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import MarkoWebContentBody from "@parameter1/base-cms-marko-web/components/element/content/body";
+import GAMDefineDisplayAd from "@parameter1/base-cms-marko-web-theme-monorail/components/gam/define-display-ad";
+
+$ const { global: $global } = out;
+$ const { content } = input;
+$ const preventHTMLInjection = getAsArray(content, "labels").some( l => ["Sponsored", "Product Spotlight"].indexOf(l) >= 0) || input.preventHTMLInjection;
+$ const blockName = defaultValue(input.blockName, 'page-contents');
+$ const aliases = getAsArray(input, 'aliases');
+$ const bodyId = `content-body-${content.id}`;
+
+<!-- Default Ad Injection of desktip and mobile inline-content-desktip & inline-content-mobile -->
+$ const adInjectionConfig = defaultValue(input.adInjectionConfig, [
+  {
+    name: 'inline-content-desktop',
+    modifiers: ["margin-auto-x",  "inline-content", "inline-content-desktop"],
+    counts: [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500],
+  },
+  {
+    name: 'inline-content-mobile',
+    modifiers: ["margin-auto-x",  "inline-content", "inline-content-mobile"],
+    counts: [250, 900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12050, 13350, 14650, 15950, 17250],
+  }
+]);
+
+<theme-ssr-html-inject
+  to-render=MarkoWebContentBody
+  selector=`#${bodyId}`
+>
+  <@component-input block-name=blockName obj=content attrs={ id: bodyId } />
+  <if(!preventHTMLInjection)>
+    <for|ad| of=adInjectionConfig>
+      $ const { counts, name, modifiers } = ad;
+      <for|count| of=ad.counts>
+        <@inject
+          at=count
+          html=GAMDefineDisplayAd.renderToString({
+            name,
+            modifiers,
+            $global
+          })
+        />
+      </for>
+    </for>
+  </if>
+</theme-ssr-html-inject>

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -10,8 +10,8 @@ $ const blockName = defaultValue(input.blockName, 'page-contents');
 $ const aliases = getAsArray(input, 'aliases');
 $ const bodyId = `content-body-${content.id}`;
 
-<!-- Default Ad Injection of desktip and mobile inline-content-desktip & inline-content-mobile -->
-$ const injections = defaultValue(input.injections, [
+<!-- only set default injection for GAM if GAM is configured -->
+$ const defaultInjection = ($global.GAM) ? [
   {
     counts: [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500],
     html: GAMDefineDisplayAd.renderToString({
@@ -28,7 +28,10 @@ $ const injections = defaultValue(input.injections, [
       $global
     })
   }
-]);
+] : [];
+
+<!-- Default Ad Injection of desktip and mobile inline-content-desktip & inline-content-mobile -->
+$ const injections = defaultValue(input.injections, defaultInjection);
 
 <theme-ssr-html-inject
   to-render=MarkoWebContentBody

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -14,7 +14,6 @@ $ const injections = getAsArray(input, 'injections');
   to-render=MarkoWebContentBody
   selector=`#${bodyId}`
 >
-
   <@component-input block-name=blockName obj=content attrs={ id: bodyId } />
   <if(!preventHTMLInjection)>
     <for|injection| of=injections>

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -11,16 +11,22 @@ $ const aliases = getAsArray(input, 'aliases');
 $ const bodyId = `content-body-${content.id}`;
 
 <!-- Default Ad Injection of desktip and mobile inline-content-desktip & inline-content-mobile -->
-$ const adInjectionConfig = defaultValue(input.adInjectionConfig, [
+$ const injections = defaultValue(input.adInjectionConfig, [
   {
-    name: 'inline-content-desktop',
-    modifiers: ["margin-auto-x",  "inline-content", "inline-content-desktop"],
     counts: [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500],
+    html: GAMDefineDisplayAd.renderToString({
+      name: 'inline-content-desktop',
+      modifiers: ["margin-auto-x",  "inline-content", "inline-content-desktop"],
+      $global
+    })
   },
   {
-    name: 'inline-content-mobile',
-    modifiers: ["margin-auto-x",  "inline-content", "inline-content-mobile"],
     counts: [250, 900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12050, 13350, 14650, 15950, 17250],
+    html: GAMDefineDisplayAd.renderToString({
+      name: 'inline-content-mobile',
+      modifiers: ["margin-auto-x",  "inline-content", "inline-content-mobile"],
+      $global
+    })
   }
 ]);
 
@@ -30,16 +36,12 @@ $ const adInjectionConfig = defaultValue(input.adInjectionConfig, [
 >
   <@component-input block-name=blockName obj=content attrs={ id: bodyId } />
   <if(!preventHTMLInjection)>
-    <for|ad| of=adInjectionConfig>
-      $ const { counts, name, modifiers } = ad;
-      <for|count| of=ad.counts>
+    <for|injection| of=injections>
+      $ const { counts, html } = injection;
+      <for|count| of=injection.counts>
         <@inject
           at=count
-          html=GAMDefineDisplayAd.renderToString({
-            name,
-            modifiers,
-            $global
-          })
+          html=html
         />
       </for>
     </for>

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -1,7 +1,6 @@
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import MarkoWebContentBody from "@parameter1/base-cms-marko-web/components/element/content/body";
-import GAMDefineDisplayAd from "@parameter1/base-cms-marko-web-theme-monorail/components/gam/define-display-ad";
 
 $ const { global: $global } = out;
 $ const { content } = input;
@@ -9,29 +8,7 @@ $ const preventHTMLInjection = getAsArray(content, "labels").some( l => ["Sponso
 $ const blockName = defaultValue(input.blockName, 'page-contents');
 $ const aliases = getAsArray(input, 'aliases');
 $ const bodyId = `content-body-${content.id}`;
-
-<!-- only set default injection for GAM if GAM is configured -->
-$ const defaultInjection = ($global.GAM) ? [
-  {
-    counts: [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500],
-    html: GAMDefineDisplayAd.renderToString({
-      name: 'inline-content-desktop',
-      modifiers: ["margin-auto-x",  "inline-content", "inline-content-desktop"],
-      $global
-    })
-  },
-  {
-    counts: [250, 900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12050, 13350, 14650, 15950, 17250],
-    html: GAMDefineDisplayAd.renderToString({
-      name: 'inline-content-mobile',
-      modifiers: ["margin-auto-x",  "inline-content", "inline-content-mobile"],
-      $global
-    })
-  }
-] : [];
-
-<!-- Default Ad Injection of desktip and mobile inline-content-desktip & inline-content-mobile -->
-$ const injections = defaultValue(input.injections, defaultInjection);
+$ const injections = getAsArray(input, 'injections');
 
 <theme-ssr-html-inject
   to-render=MarkoWebContentBody
@@ -45,6 +22,7 @@ $ const injections = defaultValue(input.injections, defaultInjection);
         <@inject
           at=count
           html=html
+          dataPropToPrevetDups=injection.dataPropToPrevetDups
         />
       </for>
     </for>

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -1,14 +1,55 @@
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import MarkoWebContentBody from "@parameter1/base-cms-marko-web/components/element/content/body";
+import GAMDefineDisplayAd from "@parameter1/base-cms-marko-web-theme-monorail/components/gam/define-display-ad";
 
 $ const { global: $global } = out;
+$ const { GAM } = $global;
 $ const { content } = input;
 $ const preventHTMLInjection = getAsArray(content, "labels").some( l => ["Sponsored", "Product Spotlight"].indexOf(l) >= 0) || input.preventHTMLInjection;
 $ const blockName = defaultValue(input.blockName, 'page-contents');
 $ const aliases = getAsArray(input, 'aliases');
 $ const bodyId = `content-body-${content.id}`;
-$ const injections = getAsArray(input, 'injections');
+
+<!-- Desktop Inline Ad props -->
+$ const desktopAdCounts = defaultValue(input.desktopAdCounts, [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500]);
+$ const desktopAdName = defaultValue(input.desktopAdName, "inline-content-desktop");
+$ const desktopAdModifiers = defaultValue(input.desktopAdModifiers, ["margin-auto-x",  "inline-content", "inline-content-desktop"]);
+$ const desktopAdDataPropToPrevetDups = defaultValue(input.desktopAdDataPropToPrevetDups, "gamTemplateName");
+
+<!-- Mobile Inline Ad props -->
+$ const mobileAdCounts = defaultValue(input.mobileAdCounts, [900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12050, 13350, 14650, 15950, 17250]);
+$ const mobileAdName = defaultValue(input.mobileAdName, "inline-content-mobile");
+$ const mobileAdModifiers = defaultValue(input.mobileAdModifiers, ["margin-auto-x",  "inline-content", "inline-content-mobile"]);
+$ const mobileAdDataPropToPrevetDups = defaultValue(input.mobileAdDataPropToPrevetDups, "gamTemplateName");
+
+<!-- Mobile Leaderboard Ad props || fallback set to 250 & mobileAdProps -->
+$ const mobileLeaderboardAdCounts = defaultValue(input.mobileLeaderboardAdCounts, [250]);
+$ const mobileLeaderboardAdName = defaultValue(input.mobileLeaderboardAdName, mobileAdName);
+$ const mobileLeaderboardAdModifiers = defaultValue(input.mobileLeaderboardAdModifiers, mobileAdModifiers);
+$ const mobileLeaderboardAdDataPropToPrevetDups = defaultValue(input.mobileLeaderboarAdDataPropToPrevetDups, mobileAdDataPropToPrevetDups);
+
+<!-- Only set GAM defaults if GAM is present on out.global -->
+$ const gamAdInjection = (GAM) ? [
+  {
+    counts: desktopAdCounts,
+    name: desktopAdName,
+    modifiers: desktopAdModifiers,
+    dataPropToPrevetDups: desktopAdDataPropToPrevetDups
+  },
+  {
+    counts: mobileLeaderboardAdCounts,
+    name: mobileLeaderboardAdName,
+    modifiers: mobileLeaderboardAdModifiers,
+    dataPropToPrevetDups: mobileLeaderboardAdDataPropToPrevetDups
+  },
+  {
+    counts: mobileAdCounts,
+    name: mobileAdName,
+    modifiers: mobileAdModifiers,
+    dataPropToPrevetDups: mobileAdDataPropToPrevetDups
+  }
+] : [];
 
 <theme-ssr-html-inject
   to-render=MarkoWebContentBody
@@ -16,15 +57,21 @@ $ const injections = getAsArray(input, 'injections');
 >
   <@component-input block-name=blockName obj=content attrs={ id: bodyId } />
   <if(!preventHTMLInjection)>
-    <for|injection| of=injections>
-      $ const { counts, html } = injection;
-      <for|count| of=injection.counts>
-        <@inject
-          at=count
-          html=html
-          dataPropToPrevetDups=injection.dataPropToPrevetDups
-        />
-      </for>
+    <for|adInjection| of=gamAdInjection>
+      $ const { counts, name, modifiers } = adInjection;
+      <if(adInjection.counts.length)>
+        <for|count| of=adInjection.counts>
+          <@inject
+            at=count
+            html=GAMDefineDisplayAd.renderToString({
+              name,
+              modifiers,
+              $global
+            })
+            dataPropToPrevetDups=adInjection.dataPropToPrevetDups
+          />
+        </for>
+      </if>
     </for>
   </if>
 </theme-ssr-html-inject>

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -14,6 +14,7 @@ $ const injections = getAsArray(input, 'injections');
   to-render=MarkoWebContentBody
   selector=`#${bodyId}`
 >
+
   <@component-input block-name=blockName obj=content attrs={ id: bodyId } />
   <if(!preventHTMLInjection)>
     <for|injection| of=injections>

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -11,7 +11,7 @@ $ const aliases = getAsArray(input, 'aliases');
 $ const bodyId = `content-body-${content.id}`;
 
 <!-- Default Ad Injection of desktip and mobile inline-content-desktip & inline-content-mobile -->
-$ const injections = defaultValue(input.adInjectionConfig, [
+$ const injections = defaultValue(input.injections, [
   {
     counts: [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500],
     html: GAMDefineDisplayAd.renderToString({

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -15,19 +15,19 @@ $ const bodyId = `content-body-${content.id}`;
 $ const desktopAdCounts = defaultValue(input.desktopAdCounts, [1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500]);
 $ const desktopAdName = defaultValue(input.desktopAdName, "inline-content-desktop");
 $ const desktopAdModifiers = defaultValue(input.desktopAdModifiers, ["margin-auto-x",  "inline-content", "inline-content-desktop"]);
-$ const desktopAdDataPropToPrevetDups = defaultValue(input.desktopAdDataPropToPrevetDups, "gamTemplateName");
+$ const desktopAdDataPropToPreventDupes = defaultValue(input.desktopAdDataPropToPreventDupes, "gamTemplateName");
 
 <!-- Mobile Inline Ad props -->
 $ const mobileAdCounts = defaultValue(input.mobileAdCounts, [900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12050, 13350, 14650, 15950, 17250]);
 $ const mobileAdName = defaultValue(input.mobileAdName, "inline-content-mobile");
 $ const mobileAdModifiers = defaultValue(input.mobileAdModifiers, ["margin-auto-x",  "inline-content", "inline-content-mobile"]);
-$ const mobileAdDataPropToPrevetDups = defaultValue(input.mobileAdDataPropToPrevetDups, "gamTemplateName");
+$ const mobileAdDataPropToPreventDupes = defaultValue(input.mobileAdDataPropToPreventDupes, "gamTemplateName");
 
 <!-- Mobile Leaderboard Ad props || fallback set to 250 & mobileAdProps -->
 $ const mobileLeaderboardAdCounts = defaultValue(input.mobileLeaderboardAdCounts, [250]);
 $ const mobileLeaderboardAdName = defaultValue(input.mobileLeaderboardAdName, mobileAdName);
 $ const mobileLeaderboardAdModifiers = defaultValue(input.mobileLeaderboardAdModifiers, mobileAdModifiers);
-$ const mobileLeaderboardAdDataPropToPrevetDups = defaultValue(input.mobileLeaderboarAdDataPropToPrevetDups, mobileAdDataPropToPrevetDups);
+$ const mobileLeaderboardAdDataPropToPreventDupes = defaultValue(input.mobileLeaderboarAdDataPropToPreventDupes, mobileAdDataPropToPreventDupes);
 
 <!-- Only set GAM defaults if GAM is present on out.global -->
 $ const gamAdInjection = (GAM) ? [
@@ -35,19 +35,19 @@ $ const gamAdInjection = (GAM) ? [
     counts: desktopAdCounts,
     name: desktopAdName,
     modifiers: desktopAdModifiers,
-    dataPropToPrevetDups: desktopAdDataPropToPrevetDups
+    dataPropToPreventDupes: desktopAdDataPropToPreventDupes
   },
   {
     counts: mobileLeaderboardAdCounts,
     name: mobileLeaderboardAdName,
     modifiers: mobileLeaderboardAdModifiers,
-    dataPropToPrevetDups: mobileLeaderboardAdDataPropToPrevetDups
+    dataPropToPreventDupes: mobileLeaderboardAdDataPropToPreventDupes
   },
   {
     counts: mobileAdCounts,
     name: mobileAdName,
     modifiers: mobileAdModifiers,
-    dataPropToPrevetDups: mobileAdDataPropToPrevetDups
+    dataPropToPreventDupes: mobileAdDataPropToPreventDupes
   }
 ] : [];
 
@@ -68,7 +68,7 @@ $ const gamAdInjection = (GAM) ? [
               modifiers,
               $global
             })
-            dataPropToPrevetDups=adInjection.dataPropToPrevetDups
+            dataPropToPreventDupes=adInjection.dataPropToPreventDupes
           />
         </for>
       </if>

--- a/packages/marko-web-theme-monorail/components/content/marko.json
+++ b/packages/marko-web-theme-monorail/components/content/marko.json
@@ -3,5 +3,8 @@
     "./contact-details/marko.json",
     "./download/marko.json",
     "./link-url/marko.json"
-  ]
+  ],
+  "<theme-body-with-injection>": {
+    "template": "./body-with-injection.marko"
+  }
 }

--- a/packages/marko-web-theme-monorail/components/marko.json
+++ b/packages/marko-web-theme-monorail/components/marko.json
@@ -39,7 +39,7 @@
   "<theme-query-total-count>": {
     "template": "./query-total-count.marko"
   },
-  "<global-ssr-html-inject>": {
+  "<theme-ssr-html-inject>": {
     "template": "./ssr-html-inject.marko",
     "<component-input>": {},
     "@inject <inject>[]": {},

--- a/packages/marko-web-theme-monorail/components/marko.json
+++ b/packages/marko-web-theme-monorail/components/marko.json
@@ -38,5 +38,13 @@
   },
   "<theme-query-total-count>": {
     "template": "./query-total-count.marko"
+  },
+  "<global-ssr-html-inject>": {
+    "template": "./ssr-html-inject.marko",
+    "<component-input>": {},
+    "@inject <inject>[]": {},
+    "@selector": "string",
+    "@to-render": "expression",
+    "@ad-inject-config": "array"
   }
 }

--- a/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
+++ b/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
@@ -1,0 +1,96 @@
+import cheerio from "cheerio";
+import { getAsArray } from "@parameter1/base-cms-object-path";
+
+$ const { toRender, componentInput } = input;
+$ const html = toRender.renderToString({ ...componentInput, $global: out.global });
+
+$ const inject = getAsArray(input, "inject").filter(o => o && o.at);
+$ const toInject = inject.reduce((o, i) => {
+  return { ...o, [i.at]: i.html };
+}, {});
+
+$ const targetLengths = Object.keys(toInject).map(n => parseInt(n, 10)).filter(n => n && n >= 1);
+
+$ const hasInjectedContent = {};
+$ const canInject = ({
+  targetLength,
+  totalLength,
+  childLength,
+  childIndex,
+  childrenLength,
+} = {}) => {
+  const hasInjected = hasInjectedContent[targetLength];
+  if (hasInjected || !targetLength) return false;
+  return totalLength <= targetLength
+    && totalLength + childLength >= targetLength
+    && childIndex + 1 !== childrenLength;
+};
+
+$ const childSelector = 'p';
+$ let totalLength = 0;
+$ const $ = cheerio.load(html);
+$ const $children = $(`${input.selector} > ${childSelector}`);
+$ $children.each(function injectAds(index) {
+  const $child = $(this);
+  const { length } = $child.text().trim();
+  if (length === 0) return;
+  const $nextChild = $(this).next(childSelector);
+
+  targetLengths.forEach((targetLength) => {
+    if (canInject({
+      targetLength,
+      totalLength,
+      childLength: length,
+      childIndex: index,
+      childrenLength: $children.length,
+    })) {
+      const contents = toInject[targetLength];
+      if (contents) {
+        const headlineTags = 'h1,h2,h3,h4,h5,h6';
+        if ($nextChild.text().length <= 1) {
+          $child.nextAll(childSelector).each(function handleBefore() {
+            if ($(this).text().length > 1) {
+              const $previous = $(this).prev();
+              if ($previous.text().trim().length === 0) {
+                $(this).after(contents);
+              } else if ($previous.is(headlineTags)) {
+                $previous.before(contents);
+              } else if ($previous.attr('data-embed-type')) {
+                $(this).after(contents);
+              } else {
+                $(this).before(contents);
+              }
+              return false;
+            }
+          });
+        } else {
+          const $next = $(this).next();
+          if ($next.attr('data-embed-type')) {
+            if ($child.prev().is(headlineTags)) {
+              $child.prev().before(contents);
+            } else {
+              $child.before(contents);
+            }
+          } else if ($child.is(headlineTags)) {
+            $child.before(contents);
+          } else if (!$next.hasClass('ad-container')) {
+            $child.after(contents);
+          } else {
+            const r = $.parseHTML(contents);
+            const [toInsert] = $.parseHTML(contents);
+            if (!toInsert) return;
+            if ($(toInsert).data() && $(toInsert).data().bamZoneAlias && $(toInsert).data().bamZoneAlias === $next.data().bamZoneAlias) return;
+            $child.after(contents);
+          }
+        }
+      }
+      hasInjectedContent[targetLength] = true;
+    }
+  });
+  totalLength += length;
+});
+
+$ const injectedHtml = $('body').html();
+<if(true)>
+  $!{injectedHtml}
+</if>

--- a/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
+++ b/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
@@ -6,7 +6,7 @@ $ const html = toRender.renderToString({ ...componentInput, $global: out.global 
 
 $ const inject = getAsArray(input, "inject").filter(o => o && o.at);
 $ const toInject = inject.reduce((o, i) => {
-  return { ...o, [i.at]: { html: i.html, dataPropToPrevetDups: i.dataPropToPrevetDups } };
+  return { ...o, [i.at]: { html: i.html, dataPropToPreventDupes: i.dataPropToPreventDupes } };
 }, {});
 
 $ const targetLengths = Object.keys(toInject).map(n => parseInt(n, 10)).filter(n => n && n >= 1);
@@ -44,7 +44,7 @@ $ $children.each(function injectAds(index) {
       childIndex: index,
       childrenLength: $children.length,
     })) {
-      const { html: contents, dataPropToPrevetDups} = toInject[targetLength];
+      const { html: contents, dataPropToPreventDupes} = toInject[targetLength];
       if (contents) {
         const headlineTags = 'h1,h2,h3,h4,h5,h6';
         if ($nextChild.text().length <= 1) {
@@ -75,12 +75,12 @@ $ $children.each(function injectAds(index) {
             $child.before(contents);
           } else if (!$next.hasClass('ad-container')) {
             $child.after(contents);
-          } else if (dataPropToPrevetDups) {
+          } else if (dataPropToPreventDupes) {
             const r = $.parseHTML(contents);
             const [toInsert] = $.parseHTML(contents);
             if (!toInsert) return;
 
-            if ($(toInsert).data() && $(toInsert).data(`${dataPropToPrevetDups}`) && $(toInsert).data(`${dataPropToPrevetDups}`) === $next.data(`${dataPropToPrevetDups}`)) return;
+            if ($(toInsert).data() && $(toInsert).data(`${dataPropToPreventDupes}`) && $(toInsert).data(`${dataPropToPreventDupes}`) === $next.data(`${dataPropToPreventDupes}`)) return;
             $child.after(contents);
           } else {
             const r = $.parseHTML(contents);

--- a/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
+++ b/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
@@ -6,7 +6,7 @@ $ const html = toRender.renderToString({ ...componentInput, $global: out.global 
 
 $ const inject = getAsArray(input, "inject").filter(o => o && o.at);
 $ const toInject = inject.reduce((o, i) => {
-  return { ...o, [i.at]: i.html };
+  return { ...o, [i.at]: { html: i.html, dataPropToPrevetDups: i.dataPropToPrevetDups } };
 }, {});
 
 $ const targetLengths = Object.keys(toInject).map(n => parseInt(n, 10)).filter(n => n && n >= 1);
@@ -44,7 +44,7 @@ $ $children.each(function injectAds(index) {
       childIndex: index,
       childrenLength: $children.length,
     })) {
-      const contents = toInject[targetLength];
+      const { html: contents, dataPropToPrevetDups} = toInject[targetLength];
       if (contents) {
         const headlineTags = 'h1,h2,h3,h4,h5,h6';
         if ($nextChild.text().length <= 1) {
@@ -75,11 +75,17 @@ $ $children.each(function injectAds(index) {
             $child.before(contents);
           } else if (!$next.hasClass('ad-container')) {
             $child.after(contents);
+          } else if (dataPropToPrevetDups) {
+            const r = $.parseHTML(contents);
+            const [toInsert] = $.parseHTML(contents);
+            if (!toInsert) return;
+
+            if ($(toInsert).data() && $(toInsert).data(`${dataPropToPrevetDups}`) && $(toInsert).data(`${dataPropToPrevetDups}`) === $next.data(`${dataPropToPrevetDups}`)) return;
+            $child.after(contents);
           } else {
             const r = $.parseHTML(contents);
             const [toInsert] = $.parseHTML(contents);
             if (!toInsert) return;
-            if ($(toInsert).data() && $(toInsert).data().bamZoneAlias && $(toInsert).data().bamZoneAlias === $next.data().bamZoneAlias) return;
             $child.after(contents);
           }
         }

--- a/services/example-website/server/templates/content.marko
+++ b/services/example-website/server/templates/content.marko
@@ -16,13 +16,13 @@ $ const { recaptcha } = out.global;
         <div class="col-md-8">
           <div class="content-page-body">
             <theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
-              <content-body content=content block-name=blockName>
-                <@after-body|{ context }|>
-                  <if(context.canAccess)>
-                    <comment-stream content=content />
-                  </if>
-                </@after-body>
-              </content-body>
+              <theme-body-with-injection
+                content=content
+                aliases=[]
+                block-name=blockName
+                preventHTMLInjection=false
+              />
+              <theme-identity-x-comment-stream content=content />
             </theme-page-contents>
           </div>
         </div>


### PR DESCRIPTION
This ads the components needed to be able to pass in overrides for the html ad injections into the body and transcript fields.

**Example PR using this new component:** https://github.com/parameter1/randall-reilly-websites/pull/498

**Example PR using a spin off of this new component:** https://github.com/parameter1/ab-media-websites/pull/248

Thing to note is the dataPropToPreventDups prop.  This is what the ads currently use to see if the sibling html element is the same or in the case of ads if the zone or GAMTemplate match.  Prevent them from putting two identical ad calls side by side. 
```js
$ const gamAdInjection = (GAM) ? [
  {
    counts: desktopAdCounts,
    name: desktopAdName,
    modifiers: desktopAdModifiers,
    dataPropToPrevetDups: desktopAdDataPropToPrevetDups
  },
  {
    counts: mobileLeaderboardAdCounts,
    name: mobileLeaderboardAdName,
    modifiers: mobileLeaderboardAdModifiers,
    dataPropToPrevetDups: mobileLeaderboardAdDataPropToPrevetDups
  },
  {
    counts: mobileAdCounts,
    name: mobileAdName,
    modifiers: mobileAdModifiers,
    dataPropToPrevetDups: mobileAdDataPropToPrevetDups
  }
] : [];

```

Produces the following config:
```json
[
  {
    "counts": [
      1000, 2750, 4500, 6250, 8000, 9750, 11500, 13250, 15000, 16750, 18500],
    "name": 'inline-content-desktop',
    "modifiers": ['margin-auto-x', 'inline-content', 'inline-content-desktop'],
    "dataPropToPrevetDups": 'gamTemplateName'
  },
  {
    "counts": [250],
    "name": 'inline-leaderboard-mobile',
    "modifiers": ['margin-auto-x', 'inline-content', 'inline-leaderboard-mobile'],
    "dataPropToPrevetDups": 'gamTemplateName'
  },
  {
    "counts": [900, 1650, 2950, 4250, 5550, 6850, 8150, 9450, 10750, 12050, 13350, 14650, 15950, 17250],
    "name": 'inline-content-mobile',
    "modifiers": ['margin-auto-x', 'inline-content', 'inline-content-mobile'],
    "dataPropToPrevetDups": 'gamTemplateName'
  }
]
```