### PR TITLE
Replace moment with dayjs, update `marko-core-date` to support `es` and `en` locales

### DIFF
--- a/packages/marko-core/components/elements/date.marko
+++ b/packages/marko-core/components/elements/date.marko
@@ -1,4 +1,4 @@
-import dayjs from "../../dayjs";
+import dayjs from "@parameter1/base-cms-dayjs";
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import defaultValue from "../../utils/default-value";
 
@@ -7,15 +7,6 @@ $ const config = getAsObject(out.global, "markoCoreDate");
 $ const format = defaultValue(input.format, config.format || "MMM Do, YYYY");
 $ const timezone = defaultValue(input.timezone, config.timezone || "America/Chicago");
 $ const locale = defaultValue(input.locale, config.locale);
-
-$ switch (locale) {
-  case 'es':
-    require("dayjs/locale/es");
-    dayjs.locale(locale);
-    break;
-  default:
-    dayjs.locale("en");
-}
 
 $ const date = defaultValue(input.value, null, v => dayjs(v).tz(timezone));
 $ const value = date && date.isValid() ? date.format(format) : null;

--- a/packages/marko-core/components/elements/date.marko
+++ b/packages/marko-core/components/elements/date.marko
@@ -6,7 +6,6 @@ $ const config = getAsObject(out.global, "markoCoreDate");
 
 $ const format = defaultValue(input.format, config.format || "MMM Do, YYYY");
 $ const timezone = defaultValue(input.timezone, config.timezone || "America/Chicago");
-$ const locale = defaultValue(input.locale, config.locale);
 
 $ const date = defaultValue(input.value, null, v => dayjs(v).tz(timezone));
 $ const value = date && date.isValid() ? date.format(format) : null;

--- a/packages/marko-core/components/elements/date.marko
+++ b/packages/marko-core/components/elements/date.marko
@@ -14,7 +14,7 @@ $ switch (locale) {
     dayjs.locale(locale);
     break;
   default:
-    dayjs.locale(locale);
+    dayjs.locale("en");
 }
 
 $ const date = defaultValue(input.value, null, v => dayjs(v).tz(timezone));

--- a/packages/marko-core/components/elements/date.marko
+++ b/packages/marko-core/components/elements/date.marko
@@ -1,4 +1,4 @@
-import moment from "moment-timezone";
+import dayjs from "../../dayjs";
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import defaultValue from "../../utils/default-value";
 
@@ -7,9 +7,17 @@ $ const config = getAsObject(out.global, "markoCoreDate");
 $ const format = defaultValue(input.format, config.format || "MMM Do, YYYY");
 $ const timezone = defaultValue(input.timezone, config.timezone || "America/Chicago");
 $ const locale = defaultValue(input.locale, config.locale);
-$ if (locale) moment.locale(locale);
 
-$ const date = defaultValue(input.value, null, v => moment(v).tz(timezone));
+$ switch (locale) {
+  case 'es':
+    require("dayjs/locale/es");
+    dayjs.locale(locale);
+    break;
+  default:
+    dayjs.locale(locale);
+}
+
+$ const date = defaultValue(input.value, null, v => dayjs(v).tz(timezone));
 $ const value = date && date.isValid() ? date.format(format) : null;
 
 $ const textInput = {

--- a/packages/marko-core/dayjs.js
+++ b/packages/marko-core/dayjs.js
@@ -1,6 +1,0 @@
-const dayjs = require('dayjs');
-const advancedFormat = require('dayjs/plugin/advancedFormat');
-const utc = require('dayjs/plugin/utc');
-const timezone = require('dayjs/plugin/timezone');
-
-module.exports = dayjs.extend(advancedFormat).extend(utc).extend(timezone);

--- a/packages/marko-core/dayjs.js
+++ b/packages/marko-core/dayjs.js
@@ -1,0 +1,6 @@
+const dayjs = require('dayjs');
+const advancedFormat = require('dayjs/plugin/advancedFormat');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+module.exports = dayjs.extend(advancedFormat).extend(utc).extend(timezone);

--- a/packages/marko-core/package.json
+++ b/packages/marko-core/package.json
@@ -12,10 +12,10 @@
     "test": "yarn compile && yarn lint"
   },
   "dependencies": {
+    "@parameter1/base-cms-dayjs": "^3.3.1",
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/base-cms-web-common": "^3.3.1",
-    "dayjs": "^1.11.6",
     "marko": "~4.20.0",
     "pretty": "^2.0.0"
   },

--- a/packages/marko-core/package.json
+++ b/packages/marko-core/package.json
@@ -15,9 +15,8 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
     "@parameter1/base-cms-web-common": "^3.3.1",
+    "dayjs": "^1.11.6",
     "marko": "~4.20.0",
-    "moment": "^2.29.1",
-    "moment-timezone": "^0.5.33",
     "pretty": "^2.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Screenshot taken from results of the changes made in https://github.com/parameter1/pmmi-media-group-websites/pull/481 (now technically incomplete as I forgot to provide translation support for Starts or whatever the verbiage ultimately ends up being there)

![Screenshot from 2022-11-30 09-46-43](https://user-images.githubusercontent.com/46794001/204845270-002b75d3-435f-4b56-becf-204e51cd47d5.png)
