### PR TITLE
Replace moment with dayjs, support `es` and `en` locales and translate 

### DIFF
--- a/packages/marko-web-html-sitemap/components/breadcrumb.marko
+++ b/packages/marko-web-html-sitemap/components/breadcrumb.marko
@@ -1,4 +1,6 @@
-import moment from "moment";
+import dayjs from "../dayjs";
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const {
   pageNode,
@@ -7,6 +9,18 @@ $ const {
   month,
   day,
 } = input;
+
+$ const dateConfig = getAsObject(out.global, "markoCoreDate");
+$ const locale = defaultValue(dateConfig.locale, "en");
+
+$ switch (locale) {
+  case 'es':
+    require("dayjs/locale/es");
+    dayjs.locale(locale);
+    break;
+  default:
+    dayjs.locale("en");
+}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
@@ -18,11 +32,11 @@ $ const {
               ${year}
             </marko-web-link>
           </li>
+          $ const d = new Date(`${year}/${month}`);
           <if(day)>
             <li class="breadcrumb-item">
-              $ const d = new Date(`${year}/${month}`)
-              <marko-web-link href=`${mountPoint}/${year}/${moment(d).format("MM")}`>
-                ${month}
+              <marko-web-link href=`${mountPoint}/${year}/${dayjs(d).format("MM")}`>
+                ${dayjs(d).format("MMMM")}
               </marko-web-link>
             </li>
             <li class="breadcrumb-item">
@@ -31,7 +45,7 @@ $ const {
           </if>
           <else>
             <li class="breadcrumb-item">
-              ${month}
+              ${dayjs(d).format("MMMM")}
             </li>
           </else>
         </if>

--- a/packages/marko-web-html-sitemap/components/breadcrumb.marko
+++ b/packages/marko-web-html-sitemap/components/breadcrumb.marko
@@ -1,6 +1,4 @@
 import dayjs from "@parameter1/base-cms-dayjs";
-import { getAsObject } from "@parameter1/base-cms-object-path";
-import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const {
   pageNode,

--- a/packages/marko-web-html-sitemap/components/breadcrumb.marko
+++ b/packages/marko-web-html-sitemap/components/breadcrumb.marko
@@ -1,4 +1,4 @@
-import dayjs from "../dayjs";
+import dayjs from "@parameter1/base-cms-dayjs";
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
@@ -9,18 +9,6 @@ $ const {
   month,
   day,
 } = input;
-
-$ const dateConfig = getAsObject(out.global, "markoCoreDate");
-$ const locale = defaultValue(dateConfig.locale, "en");
-
-$ switch (locale) {
-  case 'es':
-    require("dayjs/locale/es");
-    dayjs.locale(locale);
-    break;
-  default:
-    dayjs.locale("en");
-}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">

--- a/packages/marko-web-html-sitemap/dayjs.js
+++ b/packages/marko-web-html-sitemap/dayjs.js
@@ -1,6 +1,0 @@
-const dayjs = require('dayjs');
-const advancedFormat = require('dayjs/plugin/advancedFormat');
-const utc = require('dayjs/plugin/utc');
-const timezone = require('dayjs/plugin/timezone');
-
-module.exports = dayjs.extend(advancedFormat).extend(utc).extend(timezone);

--- a/packages/marko-web-html-sitemap/dayjs.js
+++ b/packages/marko-web-html-sitemap/dayjs.js
@@ -1,0 +1,6 @@
+const dayjs = require('dayjs');
+const advancedFormat = require('dayjs/plugin/advancedFormat');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+module.exports = dayjs.extend(advancedFormat).extend(utc).extend(timezone);

--- a/packages/marko-web-html-sitemap/package.json
+++ b/packages/marko-web-html-sitemap/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
+    "dayjs": "^1.11.6",
     "graphql": "^14.5.4",
-    "graphql-tag": "^2.12.5",
-    "moment": "^2.29.1"
+    "graphql-tag": "^2.12.5"
   },
   "peerDependencies": {
     "@parameter1/base-cms-marko-core": "^2.0.0",

--- a/packages/marko-web-html-sitemap/package.json
+++ b/packages/marko-web-html-sitemap/package.json
@@ -9,9 +9,9 @@
     "test": "yarn lint"
   },
   "dependencies": {
+    "@parameter1/base-cms-dayjs": "^3.3.1",
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-utils": "^3.0.0",
-    "dayjs": "^1.11.6",
     "graphql": "^14.5.4",
     "graphql-tag": "^2.12.5"
   },

--- a/packages/marko-web-html-sitemap/routes/index.js
+++ b/packages/marko-web-html-sitemap/routes/index.js
@@ -1,8 +1,8 @@
 
 const { getAsArray } = require('@parameter1/base-cms-object-path');
-const moment = require('moment');
 const gql = require('graphql-tag');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
+const dayjs = require('../dayjs');
 const dateListTemplate = require('../templates/date-list');
 const dayTemplate = require('../templates/day');
 
@@ -38,15 +38,15 @@ module.exports = (app, { mountPoint } = { mountPoint: '/site-map' }) => {
 
     // Validate date
     const dateString = `${year}-${month}-${day}`;
-    const date = moment(dateString, FORMAT);
+    const date = dayjs(dateString, FORMAT);
     if (!date.isValid()) throw invalidDate();
-    const now = moment().endOf('day');
+    const now = dayjs().endOf('day');
     if (date > now) throw dateNotFound();
 
     // Set page data
-    const ending = moment(dateString).endOf('day');
-    const after = moment(dateString).startOf('day');
-    const displayMonth = moment(dateString).format('MMMM');
+    const ending = dayjs(dateString).endOf('day');
+    const after = dayjs(dateString).startOf('day');
+    const displayMonth = dayjs(dateString).format('MMMM');
     return res.marko(
       dayTemplate,
       {
@@ -62,10 +62,10 @@ module.exports = (app, { mountPoint } = { mountPoint: '/site-map' }) => {
 
   app.get(`${mountPoint}/:year(\\d{4})/:month(\\d{2})`, asyncRoute(async (req, res) => {
     const { year, month } = req.params;
-    const startOfMonth = moment(`${year}-${month}-01`, FORMAT);
+    const startOfMonth = dayjs(`${year}-${month}-01`, FORMAT);
     if (!startOfMonth.isValid()) throw invalidDate();
     const endOfMonth = startOfMonth.clone().endOf('month');
-    const now = moment().endOf('day');
+    const now = dayjs().endOf('day');
     const after = startOfMonth.format(FORMAT);
     if (startOfMonth > now) throw dateNotFound();
     const before = (endOfMonth > now ? now : endOfMonth).format(FORMAT);
@@ -95,7 +95,7 @@ module.exports = (app, { mountPoint } = { mountPoint: '/site-map' }) => {
 
   app.get(`${mountPoint}/:year(\\d{4})`, asyncRoute(async (req, res) => {
     const { year } = req.params;
-    const now = moment().endOf('day');
+    const now = dayjs().endOf('day');
     if (year > now.format('year')) throw dateNotFound();
     const nowFormatted = now.format(FORMAT);
     const end = `${year}-12-31`;
@@ -125,8 +125,8 @@ module.exports = (app, { mountPoint } = { mountPoint: '/site-map' }) => {
   }));
 
   app.get(`${mountPoint}`, asyncRoute(async (req, res) => {
-    const now = moment().endOf('day');
-    const year = moment().format('YYYY');
+    const now = dayjs().endOf('day');
+    const year = dayjs().format('YYYY');
     const nowFormatted = now.format(FORMAT);
     const end = `${year}-12-31`;
     const before = nowFormatted < end ? nowFormatted : end;

--- a/packages/marko-web-html-sitemap/routes/index.js
+++ b/packages/marko-web-html-sitemap/routes/index.js
@@ -2,7 +2,7 @@
 const { getAsArray } = require('@parameter1/base-cms-object-path');
 const gql = require('graphql-tag');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
-const dayjs = require('../dayjs');
+const dayjs = require('@parameter1/base-cms-dayjs');
 const dateListTemplate = require('../templates/date-list');
 const dayTemplate = require('../templates/day');
 

--- a/packages/marko-web-html-sitemap/templates/date-list.marko
+++ b/packages/marko-web-html-sitemap/templates/date-list.marko
@@ -1,5 +1,21 @@
-import moment from "moment";
-$ const { config } = out.global;
+import dayjs from "../dayjs";
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { isFunction } from '@parameter1/base-cms-utils';
+
+$ const { config, i18n } = out.global;
+$ const dateConfig = getAsObject(out.global, "markoCoreDate");
+$ const locale = defaultValue(dateConfig.locale, "en");
+
+$ switch (locale) {
+  case 'es':
+    require("dayjs/locale/es");
+    dayjs.locale(locale);
+    break;
+  default:
+    dayjs.locale("en");
+}
+
 $ const {
   nodes,
   displayType,
@@ -11,7 +27,7 @@ $ const {
 
 $ const type = "sitemap";
 $ const pageNode = {
-  title: "Site Map",
+  title: `${ isFunction(i18n) ? i18n("Site Map") : "Site Map"}`,
 };
 $ switch (displayType) {
   case "day":
@@ -47,7 +63,7 @@ $ switch (displayType) {
                 <marko-web-link href=`${node.alias}` >
                   <if(displayType === 'month')>
                     $ const d = new Date(`${node.year}/${node.month}`)
-                    ${moment(d).format("MMMM")}
+                    ${dayjs(d).format("MMMM")}
                   </if>
                   <else>
                     ${node[displayType]}

--- a/packages/marko-web-html-sitemap/templates/date-list.marko
+++ b/packages/marko-web-html-sitemap/templates/date-list.marko
@@ -1,20 +1,7 @@
-import dayjs from "../dayjs";
-import { getAsObject } from "@parameter1/base-cms-object-path";
-import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import dayjs from "@parameter1/base-cms-dayjs";
 import { isFunction } from '@parameter1/base-cms-utils';
 
 $ const { config, i18n } = out.global;
-$ const dateConfig = getAsObject(out.global, "markoCoreDate");
-$ const locale = defaultValue(dateConfig.locale, "en");
-
-$ switch (locale) {
-  case 'es':
-    require("dayjs/locale/es");
-    dayjs.locale(locale);
-    break;
-  default:
-    dayjs.locale("en");
-}
 
 $ const {
   nodes,

--- a/packages/marko-web-html-sitemap/templates/day.marko
+++ b/packages/marko-web-html-sitemap/templates/day.marko
@@ -1,6 +1,7 @@
 import queryFragment from "../graphql/fragments/sitemap-published-content";
+import { isFunction } from '@parameter1/base-cms-utils';
 
-$ const { config, htmlSitemapPagination: p, req } = out.global;
+$ const { config, htmlSitemapPagination: p, req, i18n } = out.global;
 $ const {
   ending,
   after,
@@ -14,7 +15,7 @@ $ const perPage = 1000;
 $ const type = "sitemap";
 $ const date = `${month} ${day}, ${year}`;
 $ const pageNode = {
-  title: "Site Map",
+  title: `${ isFunction(i18n) ? i18n("Site Map") : "Site Map"}`,
   description: `All ${config.siteName()} stories published on ${date}`,
 };
 <marko-web-default-page-layout type=type title=pageNode.title description=pageNode.description>


### PR DESCRIPTION
Utilized the same check for if i18n is configured as https://github.com/parameter1/base-cms/pull/459 which should also work here as the Allured search pages still work (which were the test cases in that PR for such a condition).

![Screenshot from 2022-11-30 10-54-27](https://user-images.githubusercontent.com/46794001/204862712-5ea3fab5-1e94-4598-8f68-52f0625b4cce.png)
![Screenshot from 2022-11-30 10-56-00](https://user-images.githubusercontent.com/46794001/204862716-5b041153-39eb-4bb9-994c-2b5e841cfddd.png)
![Screenshot from 2022-11-30 10-56-04](https://user-images.githubusercontent.com/46794001/204862718-ea57d254-c814-4a3c-9242-0447bc90f60a.png)
