### PR TITLE
Improve the magazine issue landing page layout

### DIFF
--- a/packages/marko-web-theme-monorail-magazine/components/marko.json
+++ b/packages/marko-web-theme-monorail-magazine/components/marko.json
@@ -6,5 +6,8 @@
   ],
   "<theme-magazine-publication-buttons>": {
     "template": "./publication-buttons.marko"
+  },
+  "<theme-magazine-publication-links>": {
+    "template": "./publication-links.marko"
   }
 }

--- a/packages/marko-web-theme-monorail-magazine/components/publication-links.marko
+++ b/packages/marko-web-theme-monorail-magazine/components/publication-links.marko
@@ -1,0 +1,61 @@
+import { getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { site } = out.global;
+$ const buttons = input.buttons || defaultValue(site.get("magazine.links"), ["subscribe", "digital-edition", "pdf", "archives", "change-address", "renewal", "cancel", "reprints", "e-inquiry"]);
+
+$ const link = { class: "magazine-link" };
+$ const targetBlankLink = {
+  ...link,
+  target: "_blank"
+};
+
+$ const issue = getAsObject(input, "issue");
+
+<for|button| of=buttons>
+  <if(button === "subscribe")>
+    <marko-web-magazine-publication-subscribe-url tag=null obj=issue.publication link=targetBlankLink>
+      Subscribe
+    </marko-web-magazine-publication-subscribe-url>
+  </if>
+  <if(button === "renew")>
+    <marko-web-magazine-publication-renewal-url tag=null obj=issue.publication link=targetBlankLink>
+      Renew
+    </marko-web-magazine-publication-renewal-url>
+  </if>
+  <if(button === "cancel")>
+    <marko-web-magazine-publication-cancel-url tag=null obj=issue.publication link=targetBlankLink>
+      Cancel
+    </marko-web-magazine-publication-cancel-url>
+  </if>
+  <if(button === "change-address")>
+    <marko-web-magazine-publication-change-address-url tag=null obj=issue.publication link=targetBlankLink>
+      Change Address
+    </marko-web-magazine-publication-change-address-url>
+  </if>
+  <if(button === "digital-edition")>
+    <marko-web-magazine-issue-digital-edition-url tag=null obj=issue link=targetBlankLink>
+      Digital Edition
+    </marko-web-magazine-issue-digital-edition-url>
+  </if>
+  <if(button === "pdf")>
+    <marko-web-magazine-issue-pdf-url tag=null obj=issue link=targetBlankLink>
+      Download PDF
+    </marko-web-magazine-issue-pdf-url>
+  </if>
+  <if(button === "archives")>
+    <marko-web-magazine-publication-name tag=null obj=issue.publication link=link>
+      Archives
+    </marko-web-magazine-publication-name>
+  </if>
+  <if(button === "reprints")>
+    <marko-web-magazine-publication-reprints-url tag=null obj=issue.publication link=targetBlankLink>
+      Reprints
+    </marko-web-magazine-publication-reprints-url>
+  </if>
+  <if(button === "e-inquiry")>
+    <marko-web-magazine-publication-einquiry-url tag=null obj=issue.publication link=targetBlankLink>
+      E-Inquiry
+    </marko-web-magazine-publication-einquiry-url>
+  </if>
+</for>

--- a/packages/marko-web-theme-monorail-magazine/graphql/fragments/latest-issue.js
+++ b/packages/marko-web-theme-monorail-magazine/graphql/fragments/latest-issue.js
@@ -15,6 +15,8 @@ fragment MagazinePublicationCardLatestIssueFragment on MagazineIssue {
     id
     name
     subscribeUrl
+    cancelUrl
+    changeAddressUrl
     renewalUrl
     reprintsUrl
     einquiryUrl

--- a/packages/marko-web-theme-monorail-magazine/graphql/fragments/magazine-content-feed-block.js
+++ b/packages/marko-web-theme-monorail-magazine/graphql/fragments/magazine-content-feed-block.js
@@ -1,0 +1,33 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment MagazineFeedContentFragment on Content {
+  id
+  type
+  shortName
+  labels
+  teaser(input: { useFallback: false, maxLength: null })
+  siteContext {
+    path
+  }
+  published
+  primarySection {
+    id
+    name
+    fullName
+    canonicalPath
+  }
+  primaryImage {
+    id
+    src(input: { options: { auto: "format,compress" } })
+    alt
+    isLogo
+  }
+  ... on ContentWebinar {
+    linkUrl
+    startDate
+  }
+}
+
+`;

--- a/packages/marko-web-theme-monorail-magazine/graphql/fragments/magazine-issue-page.js
+++ b/packages/marko-web-theme-monorail-magazine/graphql/fragments/magazine-issue-page.js
@@ -15,8 +15,13 @@ fragment MagazineIssuePageFragment on MagazineIssue {
   publication {
     id
     name
+    description
     subscribeUrl
+    cancelUrl
+    changeAddressUrl
     renewalUrl
+    reprintsUrl
+    einquiryUrl
     canonicalPath
   }
 }

--- a/packages/marko-web-theme-monorail-magazine/graphql/fragments/magazine-latest-issue.js
+++ b/packages/marko-web-theme-monorail-magazine/graphql/fragments/magazine-latest-issue.js
@@ -5,6 +5,7 @@ module.exports = gql`
 fragment MagazineCurrentIssueFragment on MagazineIssue {
   id
   name
+  description
   digitalEditionUrl
   canonicalPath
   coverImage {
@@ -14,7 +15,13 @@ fragment MagazineCurrentIssueFragment on MagazineIssue {
   publication {
     id
     name
+    description
     subscribeUrl
+    cancelUrl
+    changeAddressUrl
+    renewalUrl
+    reprintsUrl
+    einquiryUrl
     canonicalPath
   }
 }

--- a/packages/marko-web-theme-monorail-magazine/scss/index.scss
+++ b/packages/marko-web-theme-monorail-magazine/scss/index.scss
@@ -1,5 +1,3 @@
-
-
 .magazine-issues {
   $self: &;
   margin-right: $marko-web-page-wrapper-padding * -1;
@@ -87,6 +85,11 @@
   }
 }
 
+.node__text--magazine-publication-links {
+  display: flex;
+  flex-direction: column;
+}
+
 
 .magazine-publication-buttons {
   $self: &;
@@ -152,32 +155,30 @@
       }
     }
   }
-  // &--magazine-issue {
-    .magazine-publication-card-block {
-      &__body {
-        padding-right: 10px;
-        padding-left: 10px;
+  .magazine-publication-card-block {
+    &__body {
+      padding-right: 10px;
+      padding-left: 10px;
+    }
+    .node {
+      &__title {
+        @include skin-typography($style: "section-header");
+        text-transform: none;
       }
-      .node {
-        &__title {
-          @include skin-typography($style: "section-header");
-          text-transform: none;
-        }
-        &__footer-left {
-          display: flex;
-          justify-content: space-between;
-          @include marko-web-node-list-border(border-top);
-          width: 100%;
-          padding-top: 1rem;
-          font-weight: $font-weight-bold;
-          .btn {
-            padding: 12px;
-            font-size: 12px;
-          }
+      &__footer-left {
+        display: flex;
+        justify-content: space-between;
+        @include marko-web-node-list-border(border-top);
+        width: 100%;
+        padding-top: 1rem;
+        font-weight: $font-weight-bold;
+        .btn {
+          padding: 12px;
+          font-size: 12px;
         }
       }
     }
-  // }
+  }
 }
 .node-list {
   $self: &;
@@ -211,5 +212,12 @@
         border-bottom: none;
       }
     }
+  }
+}
+
+// add margin to top of ad below paginated content results
+.page--magazine-issue {
+  .pagination-controls + .ad-container--inter-block {
+    margin-top: map-get($spacers, block);
   }
 }

--- a/packages/marko-web-theme-monorail-magazine/templates/issue.marko
+++ b/packages/marko-web-theme-monorail-magazine/templates/issue.marko
@@ -1,7 +1,8 @@
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import issueFragment from "../graphql/fragments/magazine-issue-archive";
+import contentListFragment from "../graphql/fragments/magazine-content-feed-block";
 
-$ const { site } = out.global;
+$ const { site, pagination: p, } = out.global;
 $ const { id, pageNode } = data;
 
 <marko-web-magazine-issue-page-layout id=id>
@@ -11,20 +12,20 @@ $ const { id, pageNode } = data;
     </marko-web-gtm-magazine-issue-context>
   </@head>
   <@page>
-    <marko-web-page-wrapper class="mb-block">
-      <@section|{ aliases }|>
-        <theme-gam-define-display-ad
-          name="rotation"
-          position="magazine_page"
-          aliases=aliases
-          modifiers=["inter-block"]
-        />
-      </@section>
+    <marko-web-resolve-page|{ data: issue }| node=pageNode>
+      <marko-web-page-wrapper class="mb-block">
+        <@section|{ aliases }|>
+          <theme-gam-define-display-ad
+            name="rotation"
+            position="magazine_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+        </@section>
 
-      <@section>
-        <div class="row">
-          <div class="col">
-            <marko-web-resolve-page|{ data: issue }| node=pageNode>
+        <@section>
+          <div class="row">
+            <div class="col">
               <theme-breadcrumbs modifiers=["website-section"]>
                 <@item><marko-web-link href="/magazine">Magazine</marko-web-link></@item>
                 <@item><marko-web-magazine-publication-name tag=null obj=issue.publication link=true /></@item>
@@ -32,7 +33,7 @@ $ const { id, pageNode } = data;
               <div class="magazine-publication-card-block">
                 <div class="magazine-publication-card-block__body">
                   <div class="row">
-                    <div class="col-lg-8 pl-0">
+                    <div class="col-lg-4 pl-0">
                       <marko-web-node image-position="left" modifiers=["flush"] flush=false>
                         <@image
                           src=issue.coverImage.src
@@ -42,6 +43,10 @@ $ const { id, pageNode } = data;
                           width=300
                           options={ fit: "max" }
                         />
+                      </marko-web-node>
+                    </div>
+                    <div class="col-lg-8 pl-0">
+                      <marko-web-node image-position="left" modifiers=["flush"] flush=false>
                         <@body>
                           <@title tag="h1">
                             <marko-web-magazine-issue-name tag=null obj=issue />
@@ -49,55 +54,118 @@ $ const { id, pageNode } = data;
                           <@text modifiers=["teaser"]>
                             <marko-web-magazine-issue-description tag=null obj=issue />
                           </@text>
-                          <@footer>
-                            <@left>
-                              <theme-magazine-publication-buttons issue=issue />
-                            </@left>
-                          </@footer>
+                          <@text modifiers=["magazine-publication-links"]>
+                            <theme-magazine-publication-links issue=issue />
+                          </@text>
                         </@body>
                       </marko-web-node>
                     </div>
-                    <marko-web-query|{ nodes: issues }| name="magazine-active-issues"
-                      params={
-                        publicationId: issue.publication.id,
-                        excludeIssueIds: [issue.id],
-                        queryFragment: issueFragment,
-                        limit: 9,
-                        requiresCoverImage: true
-                      }
-                    >
-                      <div class="col-lg-4">
-                        <div class="row">
-                          <for|issue| of=issues>
-                            <div class="col-4 issue-archive-cover">
-                              <marko-web-node
-                                image-position="top"
-                                card=true
-                                flush=true
-                                full-height=true
-                              >
-                                <@image
-                                  src=issue.coverImage.src
-                                  alt=(issue.coverImage.alt || issue.name)
-                                  fluid=true
-                                  ar="3:4"
-                                  width=190
-                                  link={ href: issue.canonicalPath, title: issue.name }
-                                  options={ fit: "max" }
-                                />
-                              </marko-web-node>
-                            </div>
-                          </for>
-                        </div>
-                      </div>
-                    </marko-web-query>
+                    <!-- <div class="col-lg-4 pl-0">
+                      <marko-web-node image-position="left" modifiers=["flush"] flush=false>
+                        <@body>
+                          <@title tag="h1">
+                            <marko-web-magazine-issue-name tag=null obj=issue />
+                          </@title>
+                          <@text modifiers=["teaser"]>
+                            <marko-web-magazine-issue-description tag=null obj=issue />
+                          </@text>
+                        </@body>
+                      </marko-web-node>
+                    </div>
+                    <div class="col-lg-4 pl-0">
+                      <marko-web-node image-position="left" modifiers=["flush"] flush=false>
+                        <@body>
+                          <@title tag="h2">
+                            Magazine Resources
+                          </@title>
+                          <@text modifiers=["magazine-publication-links"]>
+                            <theme-magazine-publication-links issue=issue />
+                          </@text>
+                        </@body>
+                      </marko-web-node>
+                    </div> -->
                   </div>
                 </div>
               </div>
-            </marko-web-resolve-page>
+            </div>
           </div>
-        </div>
-      </@section>
-    </marko-web-page-wrapper>
+        </@section>
+
+        <@section|{ aliases }|>
+          <theme-gam-define-display-ad
+            name="rotation"
+            position="magazine_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+        </@section>
+
+        <@section|{ aliases }|>
+          $ const contentQueryName = "magazine-scheduled-content";
+          $ const contentQueryParams = { issueId: id, queryFragment: contentListFragment };
+          <theme-section-feed-block query-name=contentQueryName query-params=contentQueryParams>
+            <@header>
+              In This Issue <if(p.page !== 1)>(Page ${p.page})</if>
+            </@header>
+            <@after>
+              <theme-section-feed-block|{ totalCount }| alias=`/magazine/${issue.id}` count-only=true query-name=contentQueryName query-params=contentQueryParams>
+                <theme-pagination-controls
+                  per-page=12
+                  total-count=totalCount
+                  path=`/magazine/${issue.id}`
+                />
+              </theme-section-feed-block>
+              <theme-gam-define-display-ad
+                name="rotation"
+                position="magazine_page"
+                aliases=aliases
+                modifiers=["inter-block"]
+              />
+            </@after>
+          </theme-section-feed-block>
+        </@section>
+
+        <@section>
+          <marko-web-query|{ nodes }| name="magazine-active-issues"
+            params={
+              publicationId: issue.publication.id,
+              excludeIssueIds: [issue.id],
+              queryFragment: issueFragment,
+              limit: 12,
+              requiresCoverImage: true
+            }
+          >
+          <marko-web-node-list
+            inner-justified=true
+            flush-x=true
+            flush-y=false
+            modifiers=["issue-archives"]
+            collapsible=false
+          >
+            <@header>
+              Past Issues
+            </@header>
+            <@body>
+              <theme-magazine-issue-archive-flow nodes=nodes flush=true />
+            </@body>
+            <@footer>
+              <marko-web-magazine-publication-name tag=null obj=issue.publication link={ class: "btn btn-primary" }>
+                View All Past Issues
+              </marko-web-magazine-publication-name>
+            </@footer>
+          </marko-web-node-list>
+          </marko-web-query>
+        </@section>
+
+        <@section|{ aliases }|>
+          <theme-gam-define-display-ad
+            name="rotation"
+            position="magazine_page"
+            aliases=aliases
+            modifiers=["inter-block"]
+          />
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
   </@page>
 </marko-web-magazine-issue-page-layout>

--- a/packages/marko-web-theme-monorail-magazine/templates/issue.marko
+++ b/packages/marko-web-theme-monorail-magazine/templates/issue.marko
@@ -92,15 +92,6 @@ $ const { id, pageNode } = data;
         </@section>
 
         <@section|{ aliases }|>
-          <theme-gam-define-display-ad
-            name="rotation"
-            position="magazine_page"
-            aliases=aliases
-            modifiers=["inter-block"]
-          />
-        </@section>
-
-        <@section|{ aliases }|>
           $ const contentQueryName = "magazine-scheduled-content";
           $ const contentQueryParams = { issueId: id, queryFragment: contentListFragment };
           <theme-section-feed-block query-name=contentQueryName query-params=contentQueryParams>


### PR DESCRIPTION
Update the magazine issue landing page with the ability to display all of its links
 - Display current issue at top with left 1/3 being coverImage & right 2/3 being title, descriptions & links
 - Display the paginated list of content scheduled to the issue
 - Display grid of past issue and link to all past issue below that
 
###  With Content:

![mag-with-content](https://user-images.githubusercontent.com/3845869/205152977-e5174e4a-17be-45a2-a372-bddfdc1304b8.jpg)


###  Without Content:
![mag-without-content](https://user-images.githubusercontent.com/3845869/205152692-aaad9e3a-3081-4b62-9ca8-7e54f0e6474e.jpg)
