### PR TITLE
Replace moment with new base-cms-dayjs package in marko-web & theme-monorail

### DIFF
--- a/packages/marko-web-theme-monorail/components/nodes/content-published.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/content-published.marko
@@ -11,8 +11,8 @@ $ const { obj, blockName } = input;
 $ const format = defaultValue(input.format, "MMM D, YYYY");
 $ const timezone = defaultValue(input.timezone, config.timezone || "America/Chicago");
 $ const locale = defaultValue(input.locale, config.locale);
-$ const publishedDate = defaultValue(obj.published, null, v => dayjs(v, 'MMM Do, YYYY').tz(timezone));
-$ const updatedDate = defaultValue(obj.updated, null, v => dayjs(v, 'MMM Do, YYYY').tz(timezone));
+$ const publishedDate = defaultValue(obj.published, null, v => dayjs(v).tz(timezone));
+$ const updatedDate = defaultValue(obj.updated, null, v => dayjs(v).tz(timezone));
 $ const displayUpdatedDate = defaultValue(input.displayUpdatedDate, true);
 
 <marko-web-obj-date|{ value }|

--- a/packages/marko-web-theme-monorail/components/nodes/content-published.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/content-published.marko
@@ -1,4 +1,4 @@
-import moment from "moment-timezone";
+import dayjs from "@parameter1/base-cms-dayjs";
 import { getAsObject } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
@@ -11,10 +11,8 @@ $ const { obj, blockName } = input;
 $ const format = defaultValue(input.format, "MMM D, YYYY");
 $ const timezone = defaultValue(input.timezone, config.timezone || "America/Chicago");
 $ const locale = defaultValue(input.locale, config.locale);
-$ if (locale) moment.locale(locale);
-
-$ const publishedDate = defaultValue(obj.published, null, v => moment(v).tz(timezone));
-$ const updatedDate = defaultValue(obj.updated, null, v => moment(v).tz(timezone));
+$ const publishedDate = defaultValue(obj.published, null, v => dayjs(v, 'MMM Do, YYYY').tz(timezone));
+$ const updatedDate = defaultValue(obj.updated, null, v => dayjs(v, 'MMM Do, YYYY').tz(timezone));
 $ const displayUpdatedDate = defaultValue(input.displayUpdatedDate, true);
 
 <marko-web-obj-date|{ value }|

--- a/packages/marko-web-theme-monorail/package.json
+++ b/packages/marko-web-theme-monorail/package.json
@@ -9,6 +9,7 @@
     "test": "yarn lint"
   },
   "dependencies": {
+    "@parameter1/base-cms-dayjs": "3.17.0",
     "@parameter1/base-cms-image": "^3.13.5",
     "@parameter1/base-cms-inflector": "^3.0.0",
     "@parameter1/base-cms-marko-core": "^3.17.0",

--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -37,7 +37,6 @@
     "http-errors": "^1.8.0",
     "jquery": "^3.6.0",
     "marko": "~4.20.0",
-    "moment": "^2.29.1",
     "vue": "^2.6.14",
     "vue-server-renderer": "^2.6.14",
     "whatwg-fetch": "^3.6.1"


### PR DESCRIPTION
 - Remove from marko-web's list dependencies as it is not referenced within the package itself. 
 - Convert the content-published.marko component within marko-web-theme-monorail to use the new base-cms-dayjs package instead of using the moment-timezone package

This is currently causing issues with the monorail package as the content-publish component is using moment-timezone, but it is not in the list of deps.  