### PR TITLE
Update htmlBodyInjector selector to exclude p with last element being a `<span data-embed-type />`

### DIFF
--- a/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
+++ b/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
@@ -26,7 +26,7 @@ $ const canInject = ({
     && childIndex + 1 !== childrenLength;
 };
 
-$ const childSelector = 'p';
+$ const childSelector = 'p:not(:has(span[data-embed-type]:last-child))';
 $ let totalLength = 0;
 $ const $ = cheerio.load(html);
 $ const $children = $(`${input.selector} > ${childSelector}`);


### PR DESCRIPTION
Update logic to skip any p tag that has an span for embed as its last element.  This doesn mean that it will no longer count the copy in those p tags towards the word count.

**Here are a couple of DEV(left) vs PROD(right)  screen shots:**
<img width="1623" alt="Screen Shot 2022-12-07 at 10 19 32 AM" src="https://user-images.githubusercontent.com/3845869/206233479-852a8d14-89ec-4278-819a-75d02ebc5941.png">

<img width="1577" alt="Screen Shot 2022-12-07 at 10 18 52 AM" src="https://user-images.githubusercontent.com/3845869/206233449-69f63520-87ab-486a-bf0a-fc073c789ee6.png">
