### PR TITLE
Create `newrelic` package and add `stopSampler` util

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ x-env-defaults: &env
 x-env-newrelic: &env-newrelic
   NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED-0}
   NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY-(unset)}
+  NEW_RELIC_TURN_OFF_SAMPLER: ${NEW_RELIC_TURN_OFF_SAMPLER-}
 
 x-env-mongo: &env-mongo
   MONGO_DSN: ${MONGO_DSN-mongodb://mongodb:27017}

--- a/packages/newrelic/README.md
+++ b/packages/newrelic/README.md
@@ -1,0 +1,2 @@
+# BaseCMS Async
+Promisified wrappers for the `async` library.

--- a/packages/newrelic/README.md
+++ b/packages/newrelic/README.md
@@ -1,2 +1,1 @@
-# BaseCMS Async
-Promisified wrappers for the `async` library.
+# BaseCMS New Relic

--- a/packages/newrelic/package.json
+++ b/packages/newrelic/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@parameter1/base-cms-newrelic",
+  "version": "3.0.0",
+  "description": "Utilities for the newrelic library.",
+  "main": "src/index.js",
+  "author": "Jacob Bare <jacob@parameter1.com>",
+  "repository": "https://github.com/parameter1/base-cms/tree/master/packages/newrelic",
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint --ext .js --max-warnings 5 ./",
+    "test": "yarn lint"
+  },
+  "peerDependencies": {
+    "newrelic": "^6"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/newrelic/src/index.js
+++ b/packages/newrelic/src/index.js
@@ -1,0 +1,3 @@
+const stopSampler = require('./stop-sampler');
+
+module.exports = { stopSampler };

--- a/packages/newrelic/src/stop-sampler.js
+++ b/packages/newrelic/src/stop-sampler.js
@@ -1,0 +1,21 @@
+const sampler = require('newrelic/lib/sampler');
+
+const envEnabled = [true, 'true', 1, '1'].includes(process.env.NEW_RELIC_TURN_OFF_SAMPLER);
+
+module.exports = ({
+  enabled = envEnabled,
+  maxWaitMS = 5000,
+  intervalMs = 250,
+} = {}) => {
+  if (!enabled) return;
+  let totalMS = 0;
+  const interval = setInterval(() => {
+    totalMS += intervalMs;
+    if (sampler.state === 'running') {
+      sampler.stop();
+      clearInterval(interval);
+    } else if (totalMS > maxWaitMS) {
+      clearInterval(interval);
+    }
+  }, intervalMs);
+};

--- a/services/graphql-server/package.json
+++ b/services/graphql-server/package.json
@@ -22,6 +22,7 @@
     "@parameter1/base-cms-image": "^3.13.5",
     "@parameter1/base-cms-inflector": "^3.0.0",
     "@parameter1/base-cms-micro": "^3.0.0",
+    "@parameter1/base-cms-newrelic": "^3.0.0",
     "@parameter1/base-cms-object-path": "^3.0.0",
     "@parameter1/base-cms-tenant-context": "^3.0.0",
     "@parameter1/base-cms-tooling": "^3.0.0",

--- a/services/graphql-server/src/newrelic.js
+++ b/services/graphql-server/src/newrelic.js
@@ -1,5 +1,8 @@
+const { stopSampler } = require('@parameter1/base-cms-newrelic');
 const { NEW_RELIC_ENABLED } = require('./env');
 
 process.env.NEW_RELIC_ENABLED = NEW_RELIC_ENABLED;
+
+stopSampler();
 
 module.exports = require('newrelic');


### PR DESCRIPTION
When installed, if the `NEW_RELIC_TURN_OFF_SAMPLER` is set to `true` or `1`, the newrelic metric sampler for CPU, memory, and native metrics will be disabled once its running state is detected.