### PR TITLE
Allow additioinalEventData prop to be passed along

### DIFF
--- a/packages/marko-web-theme-monorail/components/identity-x/comment-stream.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/comment-stream.marko
@@ -11,6 +11,7 @@ $ const lang = site.config.lang || "en";
   <div class="idx-comment-stream-wrapper">
     <marko-web-identity-x-comment-stream
       identifier=`${content.id}`
+      additional-event-data=input.additionalEventData
       title=content.name
       description=content.teaser
       url=content.siteContext.canonicalUrl


### PR DESCRIPTION
Allow for monorail comment streem component to pass along additional event data to allow for site to pass in stuff like promoCode.