### PR TITLE
Add new source cookie util & add set call to IdentityX login route

### DIFF
--- a/packages/marko-web-identity-x/package.json
+++ b/packages/marko-web-identity-x/package.json
@@ -24,7 +24,8 @@
     "express": "^4.17.1",
     "graphql-tag": "^2.12.5",
     "jsonwebtoken": "^8.5.1",
-    "node-fetch": "^2.6.5"
+    "node-fetch": "^2.6.5",
+    "tldjs": "^2.3.1"
   },
   "peerDependencies": {
     "@parameter1/base-cms-marko-core": "^2.0.0",

--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -43,6 +43,7 @@ module.exports = asyncRoute(async (req, res) => {
   });
   tokenCookie.setTo(res, authToken.value);
   contextCookie.setTo(res, { loginSource });
-  if (!sourceCookie.parseFrom(req) && loginSource) sourceCookie.setTo(res, loginSource);
+  const source = sourceCookie.parseFrom(req);
+  if (loginSource && loginSource !== source) sourceCookie.setTo(res, loginSource);
   res.json({ ok: true, user });
 });

--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -2,6 +2,7 @@ const gql = require('graphql-tag');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const tokenCookie = require('../utils/token-cookie');
 const contextCookie = require('../utils/context-cookie');
+const sourceCookie = require('../utils/source-cookie');
 const callHooksFor = require('../utils/call-hooks-for');
 const userFragment = require('../api/fragments/active-user');
 
@@ -42,5 +43,6 @@ module.exports = asyncRoute(async (req, res) => {
   });
   tokenCookie.setTo(res, authToken.value);
   contextCookie.setTo(res, { loginSource });
+  if (!sourceCookie.parseFrom(req) && loginSource) sourceCookie.setTo(res, loginSource);
   res.json({ ok: true, user });
 });

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -48,7 +48,7 @@ module.exports = asyncRoute(async (req, res) => {
     });
   }
 
-  sourceCookie.setTo(req, source);
+  sourceCookie.setTo(res, source);
 
   // Send login link.
   await identityX.sendLoginLink({

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -1,6 +1,7 @@
 const gql = require('graphql-tag');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const userFragment = require('../api/fragments/active-user');
+const sourceCookie = require('../utils/source-cookie');
 
 const buildQuery = () => gql`
   query LoginCheckAppUser($email: String!) {
@@ -46,6 +47,8 @@ module.exports = asyncRoute(async (req, res) => {
       variables: { input: { id } },
     });
   }
+
+  sourceCookie.setTo(req, source);
 
   // Send login link.
   await identityX.sendLoginLink({

--- a/packages/marko-web-identity-x/utils/source-cookie.js
+++ b/packages/marko-web-identity-x/utils/source-cookie.js
@@ -1,0 +1,43 @@
+const { getDomain } = require('tldjs');
+
+const COOKIE_NAME = 'identity-x-source';
+const DEFAULT_VALUE = 'source-unknown';
+
+const getDotDomainFrom = req => `.${getDomain(req.hostname)}`;
+
+const clean = (value) => {
+  if (!value || value === 'null') return DEFAULT_VALUE;
+  const cleaned = value.trim();
+  return /^[a-zA-Z0-9_-]/.test(cleaned) ? cleaned : null;
+};
+
+const parseFrom = (req) => {
+  const value = req.cookies[COOKIE_NAME] || DEFAULT_VALUE;
+  return clean(value);
+};
+
+const clearFrom = (req) => {
+  const dotDomain = getDotDomainFrom(req);
+  req.res.clearCookie(COOKIE_NAME);
+  req.res.clearCookie(COOKIE_NAME, { domain: dotDomain });
+};
+
+const setTo = (req, value) => {
+  const cleaned = clean(value);
+  if (!cleaned) return false;
+  const options = {
+    maxAge: 60 * 60 * 24 * 365,
+    httpOnly: false,
+  };
+  const dotDomain = getDotDomainFrom(req);
+  req.res.cookie(COOKIE_NAME, cleaned, options);
+  req.res.cookie(COOKIE_NAME, cleaned, { ...options, domain: dotDomain });
+  return true;
+};
+
+module.exports = {
+  clean,
+  clearFrom,
+  parseFrom,
+  setTo,
+};

--- a/packages/marko-web-identity-x/utils/source-cookie.js
+++ b/packages/marko-web-identity-x/utils/source-cookie.js
@@ -16,22 +16,22 @@ const parseFrom = (req) => {
   return clean(value);
 };
 
-const clearFrom = (req) => {
-  const dotDomain = getDotDomainFrom(req);
-  req.res.clearCookie(COOKIE_NAME);
-  req.res.clearCookie(COOKIE_NAME, { domain: dotDomain });
+const clearFrom = (res) => {
+  const dotDomain = getDotDomainFrom(res.req);
+  res.clearCookie(COOKIE_NAME);
+  res.clearCookie(COOKIE_NAME, { domain: dotDomain });
 };
 
-const setTo = (req, value) => {
+const setTo = (res, value) => {
   const cleaned = clean(value);
   if (!cleaned) return false;
   const options = {
     maxAge: 60 * 60 * 24 * 365,
     httpOnly: false,
   };
-  const dotDomain = getDotDomainFrom(req);
-  req.res.cookie(COOKIE_NAME, cleaned, options);
-  req.res.cookie(COOKIE_NAME, cleaned, { ...options, domain: dotDomain });
+  const dotDomain = getDotDomainFrom(res.req);
+  res.cookie(COOKIE_NAME, cleaned, options);
+  res.cookie(COOKIE_NAME, cleaned, { ...options, domain: dotDomain });
   return true;
 };
 


### PR DESCRIPTION
This will use the login source being sent to the login component to set the cookie value for login source.  This will be used at later steps in the identity x process to send along source information.   

In this example it will now set the identity-x-source: comments so that later on when the user authenticates or updates their profile it would know that the login source was commenting and can adjust the promoCode &or products accordingly.  
