### PR TITLE
Add new P1 IdentityX Action Tracker component

### DIFF
--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -609,7 +609,7 @@ export default {
         // force scroll to top of page when form and success message toggle
         window.scrollTo(0, 0);
 
-        this.emit('profile-updated');
+        this.emit('profile-updated', ({ data, email: this.user.email }));
 
         if (this.reloadPageOnSubmit) {
           this.isReloadingPage = true;

--- a/packages/marko-web-p1-events/browser/index.js
+++ b/packages/marko-web-p1-events/browser/index.js
@@ -1,9 +1,13 @@
 const TrackContentBodyLinks = () => import(/* webpackChunkName: "p1-events-track-content-body-links" */ './track-content-body-links.vue');
+const TrackIdentityXActions = () => import(/* webpackChunkName: "p1-events-track-identity-x-actions" */ './track-identity-x-actions.vue');
 const TrackInquirySubmission = () => import(/* webpackChunkName: "p1-events-track-inquiry-submission" */ './track-inquiry-submission.vue');
 
 export default (Browser) => {
   const { EventBus } = Browser;
   Browser.register('P1EventsTrackContentBodyLinks', TrackContentBodyLinks);
+  Browser.register('P1EventsTrackIdentityXActions', TrackIdentityXActions, {
+    provide: { EventBus },
+  });
   Browser.register('P1EventsTrackInquirySubmission', TrackInquirySubmission, {
     provide: { EventBus },
   });

--- a/packages/marko-web-p1-events/browser/track-identity-x-actions.vue
+++ b/packages/marko-web-p1-events/browser/track-identity-x-actions.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="marko-web-p1-events-identity-x-listener" style="display: none;" />
+</template>
+
+<script>
+export default {
+  inject: ['EventBus'],
+
+  props: {
+    eventNames: {
+      type: Array,
+      default: () => [
+        'identity-x-login-link-sent',
+        'identity-x-authentication-success',
+        'identity-x-profile-updated',
+      ]
+    }
+  },
+
+  created() {
+    if (!window.p1events) return;
+    this.eventNames.forEach((eventName) => {
+      this.EventBus.$on(eventName, ({ data, email, source } = {}) => {
+        const props = { data, email, source };
+        window.p1events('track', {
+          category: 'IdentityXAction',
+          action: eventName,
+          props,
+        });
+      });
+    })
+
+  },
+};
+</script>

--- a/packages/marko-web-p1-events/components/marko.json
+++ b/packages/marko-web-p1-events/components/marko.json
@@ -31,6 +31,9 @@
     "@action": "string",
     "@category": "string"
   },
+  "<marko-web-p1-events-track-identity-x-actions>": {
+    "template": "./track-identity-x-actions.marko"
+  },
   "<marko-web-p1-events-track-inquiry-submission>": {
     "template": "./track-inquiry-submission.marko",
     "<content>": {

--- a/packages/marko-web-p1-events/components/track-identity-x-actions.marko
+++ b/packages/marko-web-p1-events/components/track-identity-x-actions.marko
@@ -1,0 +1,3 @@
+<marko-web-browser-component
+  name="P1TrackIdentityXActions"
+/>


### PR DESCRIPTION
This will send new p1 events with a payload of
```js
{
  category: ‘IdentityXAction',
  action: ‘identity-x-login-link-sent’, // identity-x-athentication-success || identity-x-profile-updated
  prop: {
    data,
    email,
    source,
  },
},
```