### PR TITLE
Pass aliases into content body ad injection component

### DIFF
--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -65,6 +65,7 @@ $ const gamAdInjection = (GAM) ? [
             at=count
             html=GAMDefineDisplayAd.renderToString({
               name,
+              aliases,
               modifiers,
               $global
             })


### PR DESCRIPTION
This will ensure that the content body is injecting the correct ad units bsed on section alieses.