### PR TITLE
Add allCompanyContent to query-total-count optionMap

### DIFF
--- a/packages/marko-web-theme-monorail/components/query-total-count.marko
+++ b/packages/marko-web-theme-monorail/components/query-total-count.marko
@@ -38,6 +38,16 @@ $ const optionsMap = {
     `,
     variables: { input: params },
   },
+  "all-company-content": {
+    query: gql`
+      query AllCompanyContentCount($input: AllCompanyContentQueryInput!) {
+        result: allCompanyContent(input: $input) {
+          totalCount
+        }
+      }
+    `,
+    variables: { input: params },
+  },
   "all-published-content": {
     query: gql`
       query AllPublishedContentCount($input: AllPublishedContentQueryInput!) {


### PR DESCRIPTION
Add support for allCompanyContent to the query-totoal-count component.  This will add the ability to add paginated related content result to the end of company landing pages.

Would look something like:
![leadersLandingPage](https://user-images.githubusercontent.com/3845869/211064143-569749bb-e6e3-4b17-9d2f-c622c5de43b8.jpg)
