### PR TITLE
Allow for buttonClass &  iconModifiers to be passed as props to idx form toggle button component

### DIFF
--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/toggle-button.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/toggle-button.vue
@@ -1,11 +1,11 @@
 <template>
   <button
-    class="site-navbar__idx-newsletter-toggler"
+    :class="buttonClass"
     type="button"
     aria-label="Newsletter Menu Toggle"
     @click="toggle"
   >
-    <component :is="icon" :modifiers="['lg']" />
+    <component :is="icon" :modifiers="iconModifiers" />
   </button>
 </template>
 
@@ -26,6 +26,14 @@ export default {
       type: String,
       default: 'mail',
       validator: validateIcon,
+    },
+    iconModifiers: {
+      type: Array,
+      default: () => ['lg'],
+    },
+    buttonClass: {
+      type: String,
+      default: 'site-navbar__idx-newsletter-toggler',
     },
   },
 


### PR DESCRIPTION
By default they will be set to the same thing.  This will allow for additions or modifications to these props