### PR TITLE
Change `bobitconnect` to `formcms` for survey providers

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -86,7 +86,7 @@ enum GateableSurveyProvider {
   app_form_com
   idx
   alchemer
-  bobitconnect
+  formcms
 }
 
 enum ContentMutation {


### PR DESCRIPTION
Should be done with https://github.com/parameter1/base-platform/pull/194 & a cleanup script to set current bobitconnect survey types to formcms. The site will also have to account for the conversion as well.  
