### PR TITLE
Add userRegistration to content-meter fragment

### DIFF
--- a/packages/marko-web-theme-monorail/graphql/fragments/content-meter.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/content-meter.js
@@ -13,5 +13,8 @@ fragment ContentMeterFragment on Content {
     id
     alias
   }
+  userRegistration {
+    isCurrentlyRequired
+  }
 }
 `;


### PR DESCRIPTION
This will be used in the content meter middleware to bypass contentMetering if userRegisteration.isCurrentlyRequired.

```markojs
const requiresRegistration = get(content, 'userRegistration.isCurrentlyRequired');
if (requiresRegistration) return false;
```