### PR TITLE
Support for `withSponsored` on various `base-cms-marko-web-theme-monorail` components

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/marko.json
+++ b/packages/marko-web-theme-monorail/components/blocks/marko.json
@@ -140,6 +140,7 @@
     "@count-only": "boolean",
     "@display-image": "boolean",
     "@with-section": "boolean",
+    "@with-sponsored": "boolean",
     "@lazyload": "boolean",
     "@modifiers": "array",
     "@query-name": "string",

--- a/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
@@ -1,6 +1,7 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/section-feed-block";
+import setSectionNameFromLabel from "../../utils/set-section-name-from-label";
 
 $ const queryName = input.queryName ? input.queryName : "website-scheduled-content";
 $ const queryParams = {
@@ -34,13 +35,10 @@ $ const setWithSection = (node, nxNode, withNativeXSection = true, nodeInput = {
 </if>
 <else>
   <marko-web-query|{ nodes: returnedNodes }| name=queryName params=queryParams>
-    $ const nodes = withSponsored ? returnedNodes.map((node) => {
-      const { primarySection, ...rest } = node;
-      const generatedPrimarySection = getAsArray(node, "labels").includes("Sponsored") ? {
-        ...primarySection, name: "Sponsored"
-      } : primarySection;
-      const parsedNode = generatedPrimarySection.name === "Sponsored" ? { ...rest, primarySection: generatedPrimarySection, withSection: true } : node;
-      return parsedNode;
+    $ const nodes = withSponsored ? setSectionFromLabel({
+      nodes: returnedNodes,
+      labelToSearchFor: "Sponsored",
+      sectionNameToSet: "Sponsored"
     }) : returnedNodes;
     <if(input.before)>
       <${input.before.renderBody} />

--- a/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
@@ -1,5 +1,5 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
-import { getAsObject } from "@parameter1/base-cms-object-path";
+import { getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/section-feed-block";
 
 $ const queryName = input.queryName ? input.queryName : "website-scheduled-content";
@@ -16,6 +16,7 @@ $ const countOnly = defaultValue(input.countOnly, false);
 $ const modifiers = defaultValue(input.modifiers, []);
 $ const lazyload = defaultValue(input.lazyload, true);
 $ const withSection = defaultValue(input.withSection, true);
+$ const withSponsored = defaultValue(input.withSponsored, false);
 
 $ const { nativeX: nxConfig } = out.global;
 $ const nativeX = getAsObject(input, "nativeX");
@@ -32,7 +33,15 @@ $ const setWithSection = (node, nxNode, withNativeXSection = true, nodeInput = {
   </theme-query-total-count>
 </if>
 <else>
-  <marko-web-query|{ nodes }| name=queryName params=queryParams>
+  <marko-web-query|{ nodes: returnedNodes }| name=queryName params=queryParams>
+    $ const nodes = withSponsored ? returnedNodes.map((node) => {
+      const { primarySection, ...rest } = node;
+      const generatedPrimarySection = getAsArray(node, "labels").includes("Sponsored") ? {
+        ...primarySection, name: "Sponsored"
+      } : primarySection;
+      const parsedNode = generatedPrimarySection.name === "Sponsored" ? { ...rest, primarySection: generatedPrimarySection, withSection: true } : node;
+      return parsedNode;
+    }) : returnedNodes;
     <if(input.before)>
       <${input.before.renderBody} />
     </if>

--- a/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
@@ -1,5 +1,5 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
-import { getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
+import { getAsObject } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/section-feed-block";
 import setSectionNameFromLabel from "../../utils/set-section-name-from-label";
 

--- a/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-feed.marko
@@ -37,8 +37,8 @@ $ const setWithSection = (node, nxNode, withNativeXSection = true, nodeInput = {
   <marko-web-query|{ nodes: returnedNodes }| name=queryName params=queryParams>
     $ const nodes = withSponsored ? setSectionFromLabel({
       nodes: returnedNodes,
-      labelToSearchFor: "Sponsored",
-      sectionNameToSet: "Sponsored"
+      label: "Sponsored",
+      sectionName: "Sponsored"
     }) : returnedNodes;
     <if(input.before)>
       <${input.before.renderBody} />

--- a/packages/marko-web-theme-monorail/components/blocks/section-forbes.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-forbes.marko
@@ -2,6 +2,7 @@ import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
 import { getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/content-card-deck-block";
 import sectionFragment from "../../graphql/fragments/section-info";
+import setSectionNameFromLabel from "../../utils/set-section-name-from-label"
 
 $ const { i18n } = out.global;
 
@@ -31,14 +32,11 @@ $ const blockName = "section-forbes";
 $ const rowStyle = (input.reverse) ? "flex-direction: row-reverse" : "";
 
 <marko-web-query|{ nodes: returnedNodes, section: querySection }| name="website-scheduled-content" params=queryParams>
-  $ const nodes = withSponsored ? returnedNodes.map((node) => {
-      const { primarySection, ...rest } = node;
-      const generatedPrimarySection = getAsArray(node, "labels").includes("Sponsored") ? {
-        ...primarySection, name: "Sponsored"
-      } : primarySection;
-      const parsedNode = generatedPrimarySection.name === "Sponsored" ? { ...rest, primarySection: generatedPrimarySection, withSection: true } : node;
-      return parsedNode;
-    }) : returnedNodes;
+  $ const nodes = withSponsored ? setSectionNameFromLabel({
+    nodes: returnedNodes,
+    labelToSearchFor: "Sponsored",
+    sectionNameToSet: "Sponsored"
+  }) : returnedNodes;
   <marko-web-element tag="h1" block-name="top-stories" name="header">
     ${i18n(querySection.name)}
   </marko-web-element>

--- a/packages/marko-web-theme-monorail/components/blocks/section-forbes.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-forbes.marko
@@ -1,5 +1,4 @@
 import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
-import { getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/content-card-deck-block";
 import sectionFragment from "../../graphql/fragments/section-info";
 import setSectionNameFromLabel from "../../utils/set-section-name-from-label"

--- a/packages/marko-web-theme-monorail/components/blocks/section-forbes.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-forbes.marko
@@ -33,8 +33,8 @@ $ const rowStyle = (input.reverse) ? "flex-direction: row-reverse" : "";
 <marko-web-query|{ nodes: returnedNodes, section: querySection }| name="website-scheduled-content" params=queryParams>
   $ const nodes = withSponsored ? setSectionNameFromLabel({
     nodes: returnedNodes,
-    labelToSearchFor: "Sponsored",
-    sectionNameToSet: "Sponsored"
+    label: "Sponsored",
+    sectionName: "Sponsored"
   }) : returnedNodes;
   <marko-web-element tag="h1" block-name="top-stories" name="header">
     ${i18n(querySection.name)}

--- a/packages/marko-web-theme-monorail/components/blocks/section-forbes.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-forbes.marko
@@ -1,4 +1,5 @@
 import { defaultValue } from "@parameter1/base-cms-marko-web/utils";
+import { getAsArray } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/content-card-deck-block";
 import sectionFragment from "../../graphql/fragments/section-info";
 
@@ -12,6 +13,8 @@ $ const nativeX = {
   sectionName: `${i18n("Sponsor Content")}`,
   ...input.nativeX,
 };
+
+$ const withSponsored = defaultValue(input.withSponsored, false);
 
 $ const queryParams = {
   sectionAlias: input.alias,
@@ -27,7 +30,15 @@ $ const blockName = "section-forbes";
 
 $ const rowStyle = (input.reverse) ? "flex-direction: row-reverse" : "";
 
-<marko-web-query|{ nodes, section: querySection }| name="website-scheduled-content" params=queryParams>
+<marko-web-query|{ nodes: returnedNodes, section: querySection }| name="website-scheduled-content" params=queryParams>
+  $ const nodes = withSponsored ? returnedNodes.map((node) => {
+      const { primarySection, ...rest } = node;
+      const generatedPrimarySection = getAsArray(node, "labels").includes("Sponsored") ? {
+        ...primarySection, name: "Sponsored"
+      } : primarySection;
+      const parsedNode = generatedPrimarySection.name === "Sponsored" ? { ...rest, primarySection: generatedPrimarySection, withSection: true } : node;
+      return parsedNode;
+    }) : returnedNodes;
   <marko-web-element tag="h1" block-name="top-stories" name="header">
     ${i18n(querySection.name)}
   </marko-web-element>
@@ -79,7 +90,7 @@ $ const rowStyle = (input.reverse) ? "flex-direction: row-reverse" : "";
     <div class="col-lg-4">
       $ const cardNodes = nodes.slice(5, 7);
       <theme-content-card-deck-col-flow nodes=cardNodes modifiers=[blockName] cols=1>
-        <@node withSection=false />
+        <@node withSection=false withSponsored=withSponsored />
       </theme-content-card-deck-col-flow>
     </div>
   </div>

--- a/packages/marko-web-theme-monorail/components/flows/content/list.marko
+++ b/packages/marko-web-theme-monorail/components/flows/content/list.marko
@@ -7,6 +7,7 @@ $ const nativeX = getAsObject(input, "nativeX");
 $ const withNativeXSection = defaultValue(input.withNativeXSection, true);
 $ const setWithSection = (node, nxNode, withNativeXSection = true, nodeInput = {}) => {
   if (nodeInput.withSection) return true;
+  if (node.withSection) return true;
   if (!withNativeXSection) return false;
   return node.id !== nxNode.id;
 };

--- a/packages/marko-web-theme-monorail/components/nodes/content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/content.marko
@@ -34,6 +34,8 @@ $ if (withSection && alias && withPrimarySectionModifier) {
 
 $ const imageLink = primaryImage.src ? { href: content.siteContext.path, attrs: linkAttrs } : false;
 
+$ const withSponsored = primarySection && primarySection.name === 'Sponsored' && input.withSponsored;
+
 <marko-web-node
   type=`${content.type}-content`
   image-position=defaultValue(input.imagePosition, "left")
@@ -59,10 +61,10 @@ $ const imageLink = primaryImage.src ? { href: content.siteContext.path, attrs: 
   </if>
   <if(!imageOnly)>
     <@body>
-      <if(withSection || isEvent)>
+      <if(withSection || isEvent || withSponsored)>
         <@header attrs=headerAttributes>
           <@left|{ blockName }|>
-            <if(withSection)>
+            <if(withSection || withSponsored)>
               <section-sponsor block-name=blockName section=primarySection labels=content.labels />
             </if>
             <else-if(isEvent)>

--- a/packages/marko-web-theme-monorail/utils/set-section-name-from-label.js
+++ b/packages/marko-web-theme-monorail/utils/set-section-name-from-label.js
@@ -1,11 +1,11 @@
 const { getAsArray } = require('@parameter1/base-cms-object-path');
 
-module.exports = ({ nodes, labelToSearchFor, sectionNameToSet }) => nodes.map((node) => {
+module.exports = ({ nodes, label, sectionName }) => nodes.map((node) => {
   const { primarySection, ...rest } = node;
-  const generatedPrimarySection = getAsArray(node, 'labels').includes(labelToSearchFor) ? {
-    ...primarySection, name: sectionNameToSet,
+  const generatedPrimarySection = getAsArray(node, 'labels').includes(label) ? {
+    ...primarySection, name: sectionName,
   } : primarySection;
-  const parsedNode = generatedPrimarySection.name === sectionNameToSet ? {
+  const parsedNode = generatedPrimarySection.name === sectionName ? {
     ...rest,
     primarySection: generatedPrimarySection,
     withSection: true,

--- a/packages/marko-web-theme-monorail/utils/set-section-name-from-label.js
+++ b/packages/marko-web-theme-monorail/utils/set-section-name-from-label.js
@@ -1,0 +1,14 @@
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+
+module.exports = ({ nodes, labelToSearchFor, sectionNameToSet }) => nodes.map((node) => {
+  const { primarySection, ...rest } = node;
+  const generatedPrimarySection = getAsArray(node, 'labels').includes(labelToSearchFor) ? {
+    ...primarySection, name: sectionNameToSet,
+  } : primarySection;
+  const parsedNode = generatedPrimarySection.name === sectionNameToSet ? {
+    ...rest,
+    primarySection: generatedPrimarySection,
+    withSection: true,
+  } : node;
+  return parsedNode;
+});


### PR DESCRIPTION
Section Feed example:
![Screenshot from 2023-02-02 12-44-28](https://user-images.githubusercontent.com/46794001/216422679-d8f310d8-8c15-421c-a9c1-bf43f1a31b45.png)

Various Forbes blocks:
![Screenshot from 2023-02-02 12-44-44](https://user-images.githubusercontent.com/46794001/216422758-a53a6112-2b09-4771-be37-fcf9c8dd646e.png)
![Screenshot from 2023-02-02 12-44-48](https://user-images.githubusercontent.com/46794001/216422760-94ad2440-9b85-4201-9766-cc6d09fa4956.png)
![Screenshot from 2023-02-02 12-44-56](https://user-images.githubusercontent.com/46794001/216422761-57097fdb-31ca-4363-8149-a181f47bbe50.png)
![Screenshot from 2023-02-02 12-45-00](https://user-images.githubusercontent.com/46794001/216422763-ead3aecf-1934-47f6-a59f-37645ffb3418.png)
