### PR TITLE
Add additionalEventData flag for createdNewUser

### DIFF
--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -37,6 +37,7 @@ module.exports = asyncRoute(async (req, res) => {
   if (!appUser) {
     // Create the user.
     appUser = await identityX.createAppUser({ email });
+    additionalEventData.createdNewUser = true;
   }
 
   if (forceProfileReVerification) {
@@ -54,5 +55,5 @@ module.exports = asyncRoute(async (req, res) => {
     redirectTo,
     additionalEventData,
   });
-  return res.json({ ok: true, additionalEventData });
+  return res.json({ ok: true, additionalEventData, appUser });
 });


### PR DESCRIPTION
Add new additionEventData.createdNewUser  that is set when IdentityX creates a new user along with passing appUser to the loginLinkSent response.  This will allow for these to be passed through to the frontend to send event to gtm.