### PR TITLE
Query for redirect `from` values containing the input `params`

### DIFF
--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -16,18 +16,7 @@
       {{ buttonLabels.logout || "Log out" }}
     </a>
   </div>
-  <div v-else-if="complete">
-    <h4>Almost Done!</h4>
-    <p>
-      We just sent an email to <em>{{ email }}</em> with your one-time login link.
-      To finish {{ actionText || "logging in" }}, open the email message and click the link within.
-    </p>
-    <p>
-      Note: please check your spam/junk folders.
-      If you do not receive this email, your firewall or ISP has likely blocked it.
-      Please add {{ senderEmailAddress }} to your whitelist and try registering again.
-    </p>
-  </div>
+  <div v-else-if="complete" v-html="almostDoneVerbiage" />
   <div v-else>
     <form @submit.prevent="handleSubmit">
       <email
@@ -159,6 +148,11 @@ export default {
       type: Array,
       default: () => [],
     },
+
+    lang: {
+      type: String,
+      default: 'en',
+    },
   },
 
   /**
@@ -187,6 +181,31 @@ export default {
      */
     hasActiveUser() {
       return this.activeUser && this.activeUser.email;
+    },
+
+    almostDoneVerbiage() {
+      if (this.lang === 'es') {
+        return `<h4>Falta muy poco!</h4>
+        <p>
+          Enviamos un correo a <em>${this.email}</em> con su enlace de inicio de sesión único.
+          Para terminar de  ${this.actionText || 'logging in'}, abra el mensaje de correo electrónico y haga clic en el enlace que contiene.
+        </p>
+        <p>
+          Nota: por favor revise sus carpetas de spam/basura.
+          Si no recibe este correo electrónico, es probable que su firewall o ISP lo haya bloqueado.
+          Agregue${this.senderEmailAddress} a su lista blanca e intente registrarse nuevamente.
+        </p>`;
+      }
+      return `<h4>Almost Done!</h4>
+      <p>
+        We just sent an email to <em>${this.email}</em> with your one-time login link.
+        To finish ${this.actionText || 'logging in'}, open the email message and click the link within.
+      </p>
+      <p>
+        Note: please check your spam/junk folders.
+        If you do not receive this email, your firewall or ISP has likely blocked it.
+        Please add ${this.senderEmailAddress} to your whitelist and try registering again.
+      </p>`;
     },
 
     /**

--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -193,7 +193,7 @@ export default {
         <p>
           Nota: por favor revise sus carpetas de spam/basura.
           Si no recibe este correo electrónico, es probable que su firewall o ISP lo haya bloqueado.
-          Agregue${this.senderEmailAddress} a su lista blanca e intente registrarse nuevamente.
+          Agregue ${this.senderEmailAddress} a su lista blanca e intente registrarse nuevamente.
         </p>`;
       }
       return `<h4>Almost Done!</h4>

--- a/packages/marko-web-identity-x/components/form-login.marko
+++ b/packages/marko-web-identity-x/components/form-login.marko
@@ -15,11 +15,13 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       endpoints: identityX.config.getEndpoints(),
       buttonLabels: input.buttonLabels,
       redirect: input.redirect,
+      loginEmailLabel: input.loginEmailLabel,
       loginEmailPlaceholder: input.loginEmailPlaceholder,
       consentPolicy: get(application, "organization.consentPolicy"),
       emailConsentRequest: get(application, "organization.emailConsentRequest"),
       regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
       appContextId: identityX.config.get("appContextId"),
+      lang: defaultValue(input.lang, "en"),
     };
     <if(isEnabled)>
       <marko-web-browser-component name="IdentityXLogin" props=props />

--- a/packages/marko-web-identity-x/components/marko.json
+++ b/packages/marko-web-identity-x/components/marko.json
@@ -33,7 +33,9 @@
     "@action-text": "string",
     "@button-labels": "object",
     "@login-email-placeholder": "string",
-    "@redirect": "string"
+    "@redirect": "string",
+    "@login-email-label": "string",
+    "@lang": "string"
   },
   "<marko-web-identity-x-form-logout>": {
     "template": "./form-logout.marko",

--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
@@ -27,6 +27,8 @@
             :regional-consent-policies="regionalConsentPolicies"
             :app-context-id="appContextId"
             :login-email-label="translateEmail"
+            :lang="lang"
+            :action-text="actionText"
             success-message-type="newsletter-signup"
             @login-link-sent="handleLoginLinkSent"
             @login-errored="handleError"
@@ -154,6 +156,10 @@ export default {
     regionalConsentPolicies: {
       type: Array,
       default: () => [],
+    },
+    actionText: {
+      type: String,
+      default: 'signing up to receive your email notifications',
     },
   },
 

--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
@@ -33,6 +33,7 @@
             :app-context-id="appContextId"
             :action-text="actionText"
             :login-email-label="translateEmail"
+            :lang="lang"
             @login-link-sent="handleLoginLinkSent"
             @login-errored="handleError"
             @focus="$emit('focus')"

--- a/packages/marko-web-theme-monorail/components/identity-x/content-page-gate.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/content-page-gate.marko
@@ -12,6 +12,9 @@ $ const {
   requiresUserInput,
   profileCallToAction,
   profileButtonLabel,
+  buttonLabels,
+  loginEmailLabel,
+  actionText
 } = input;
 $ const messages = getAsObject(input, "messages");
 $ const title = defaultValue(input.title, "Log in to view the full article");
@@ -51,6 +54,10 @@ $ const additionalEventData = {
         <marko-web-identity-x-form-login
           additional-event-data=additionalEventData
           source="contentGate"
+          login-email-label=loginEmailLabel
+          button-labels=buttonLabels
+          action-text=actionText
+          lang=defaultValue(site.config.lang, "en")
         />
       </marko-web-element>
     </else>

--- a/packages/marko-web-theme-monorail/components/identity-x/marko.json
+++ b/packages/marko-web-theme-monorail/components/identity-x/marko.json
@@ -18,7 +18,10 @@
     "@additional-event-data": "object",
     "@content-gate-type": "string",
     "@login-event-name": "string",
-    "@profile-event-name": "string"
+    "@profile-event-name": "string",
+    "@button-labels": "object",
+    "@login-email-label": "string",
+    "@action-text": "string"
   },
   "<identity-x-newsletter-form-pushdown>": {
     "template": "./newsletter-pushdown.marko"

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-footer.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-footer.marko
@@ -42,6 +42,7 @@ $ const lang = site.config.lang || "en";
           redirect: input.redirect,
           loginEmailPlaceholder,
           loginEmailLabel: input.loginEmailLabel,
+          actionText: input.actionText,
           consentPolicy: input.consentPolicy || get(application, "organization.consentPolicy"),
           emailConsentRequest: get(application, "organization.emailConsentRequest"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
@@ -51,6 +51,7 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
           redirect: input.redirect,
           loginEmailPlaceholder,
           loginEmailLabel: input.loginEmailLabel,
+          actionText: input.actionText,
           consentPolicy: input.consentPolicy || get(application, "organization.consentPolicy"),
           emailConsentRequest: get(application, "organization.emailConsentRequest"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
@@ -49,6 +49,7 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
           redirect: input.redirect,
           loginEmailPlaceholder,
           loginEmailLabel: input.loginEmailLabel,
+          actionText: input.actionText,
           consentPolicy: input.consentPolicy || get(application, "organization.consentPolicy"),
           emailConsentRequest: get(application, "organization.emailConsentRequest"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),

--- a/services/graphql-server/src/graphql/resolvers/website/redirect.js
+++ b/services/graphql-server/src/graphql/resolvers/website/redirect.js
@@ -51,6 +51,8 @@ module.exports = {
         $or: [
           { siteId: { [siteOp]: siteId }, from },
           { siteId: { [siteOp]: siteId }, from: from.toLowerCase() },
+          { siteId: { [siteOp]: siteId }, from: `${from}?${queryParams}` },
+          { siteId: { [siteOp]: siteId }, from: `${from.toLowerCase()}?${queryParams}` },
         ],
       };
       const redirect = await basedb.findOne('website.Redirects', query);


### PR DESCRIPTION
Previously this wasn't trying to look for `from` values with the passed in query string parameters from the query input, this does that and redirects the item with the existing behavior.

Example: http://www-policemag.dev.parameter1.com:9801/tags?tag=wisconsin would now go to
http://www-policemag.dev.parameter1.com:9801/t/6817018?tag=wisconsin

![Screenshot from 2023-02-16 09-56-37](https://user-images.githubusercontent.com/46794001/219419364-2a0c2422-a22d-4c67-bf13-ee337537339f.png)


This will not require any changes to dependencies or site routing.