### PR TITLE
Ensure upgrades respect current semver range

### DIFF
--- a/packages/dependency-tool/package.json
+++ b/packages/dependency-tool/package.json
@@ -18,6 +18,7 @@
     "@parameter1/base-cms-object-path": "^3.0.0",
     "chalk": "^2.4.2",
     "fancy-log": "^1.3.3",
+    "semver": "^7.3.8",
     "yargs": "^14.2.3"
   },
   "publishConfig": {

--- a/packages/dependency-tool/src/commands/upgrade/extract-deps.js
+++ b/packages/dependency-tool/src/commands/upgrade/extract-deps.js
@@ -3,9 +3,13 @@ const depTypes = require('./dep-types');
 
 const { keys } = Object;
 
-module.exports = pkg => depTypes.reduce((set, depType) => {
+module.exports = pkg => depTypes.reduce((map, depType) => {
   keys(getAsObject(pkg, depType))
     .filter(name => /^@parameter1\/base-cms-/.test(name))
-    .forEach(name => set.add(name));
-  return set;
-}, new Set());
+    .forEach((name) => {
+      const v = pkg[depType][name];
+      const key = `${name}@${v}`;
+      map.set(key, { name, v });
+    });
+  return map;
+}, new Map());

--- a/packages/dependency-tool/src/commands/upgrade/index.js
+++ b/packages/dependency-tool/src/commands/upgrade/index.js
@@ -1,41 +1,70 @@
 const chalk = require('chalk');
 const log = require('fancy-log');
+const semver = require('semver');
 const cwd = require('@parameter1/base-cms-cli-utils/get-cwd');
 const logCmd = require('@parameter1/base-cms-cli-utils/log-command');
 const exit = require('@parameter1/base-cms-cli-utils/print-and-exit');
 const loadPackage = require('./load-package');
 const exractDeps = require('./extract-deps');
-const loadLatestVersions = require('./load-latest-versions');
+const loadVersionInfo = require('./load-version-info');
 const updatePackage = require('./update-package');
 const savePackage = require('./save-package');
 const loadWorkspaceDirs = require('./load-workspace-dirs');
 
 const { isArray } = Array;
 
-const execute = async ({ dir }) => {
+const execute = async ({ dir, forceLatest }) => {
   const pkg = loadPackage({ dir });
   log(chalk`Loaded package {magenta ${pkg.name}}`);
-  const baseDeps = exractDeps(pkg);
-  log(`Found ${baseDeps.size} dependencies`);
+  const baseDepMap = exractDeps(pkg);
+  log(`Found ${baseDepMap.size} dependencies`);
+  const names = new Set([...baseDepMap.values()].map(({ name }) => name));
 
-  const info = await loadLatestVersions([...baseDeps]);
-  updatePackage(info, pkg);
-  savePackage(dir, pkg);
+  const packageVersionMap = new Map();
+  await Promise.all([...names].map(async (name) => {
+    const { versions } = await loadVersionInfo(name);
+    const latest = versions.filter(v => !semver.prerelease(v)).pop();
+    packageVersionMap.set(name, { versions, latest });
+  }));
 
-  log(chalk`Upgrade of package {magenta ${pkg.name}} complete`);
+
+  const toChange = new Map();
+  baseDepMap.forEach(({ name, v: range }, key) => {
+    const { versions: available, latest } = packageVersionMap.get(name);
+    const { version: current } = semver.coerce(range);
+
+    const maxSatisfying = semver.maxSatisfying(available, range);
+    const newVersion = forceLatest ? latest : maxSatisfying;
+
+    if (newVersion === current) return;
+
+    if (semver.gt(latest, newVersion)) {
+      log(chalk`{yellow WARNING:} The latest version of {grey ${name}} is {red ${latest}} but will use {green ${newVersion}} until the {blue --latest} flag is used`);
+    }
+
+    toChange.set(key, `^${newVersion}`);
+  });
+
+  if (toChange.size) {
+    updatePackage(toChange, pkg);
+    savePackage(dir, pkg);
+    log(chalk`Upgrade of package {magenta ${pkg.name}} complete`);
+  } else {
+    log('No dependencies need upgrading... exiting');
+  }
 
   if (isArray(pkg.workspaces)) {
     log(chalk`Workspaces detected. Will upgrade recursively: {gray ${JSON.stringify(pkg.workspaces)}}`);
     const workspaceDirs = loadWorkspaceDirs(dir, pkg.workspaces);
-    await Promise.all(workspaceDirs.map(async wsDir => execute({ dir: wsDir })));
+    await Promise.all(workspaceDirs.map(async wsDir => execute({ dir: wsDir, forceLatest })));
   }
 };
 
-module.exports = ({ path }) => {
+module.exports = ({ path, latest: forceLatest = false }) => {
   const dir = cwd(path);
   logCmd('upgrade', dir);
 
-  execute({ dir }).then(() => {
+  execute({ dir, forceLatest }).then(() => {
     exit(chalk`{green Upgrade complete!}`, 0);
   }).catch((e) => {
     exit(e.message);

--- a/packages/dependency-tool/src/commands/upgrade/update-package.js
+++ b/packages/dependency-tool/src/commands/upgrade/update-package.js
@@ -1,12 +1,20 @@
-const { get, set } = require('@parameter1/base-cms-object-path');
+const { set, getAsObject } = require('@parameter1/base-cms-object-path');
 const depTypes = require('./dep-types');
 
-module.exports = (info, pkg) => {
-  depTypes.forEach((type) => {
-    info.forEach(({ name, latest }) => {
-      const depPath = `${type}.${name}`;
-      if (get(pkg, depPath)) set(pkg, depPath, `^${latest}`);
-    });
+const { keys } = Object;
+
+module.exports = (toChange, pkg) => {
+  depTypes.forEach((depType) => {
+    keys(getAsObject(pkg, depType))
+      .filter(name => /^@parameter1\/base-cms-/.test(name))
+      .forEach((name) => {
+        const v = pkg[depType][name];
+        const key = `${name}@${v}`;
+        if (toChange.has(key)) {
+          const depPath = `${depType}.${name}`;
+          set(pkg, depPath, toChange.get(key));
+        }
+      });
   });
   return pkg;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16903,6 +16903,13 @@ semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.3.8:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
Only the maximum satisfying version of the current version range will be upgraded, unless the `--latest` flag is used. If provided, the most recent version of the package will be used.