### PR TITLE
Upgrade services from Node `10.24` to `14.21`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 node_modules
+docker-compose.yml
+.git
+.env
 Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "10.24"
+node_js: "14.21"
 cache: yarn
 
 _production-job: &production-job

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,9 +1,13 @@
 # Migrating from 3.x to 4.x
 - Ensure you have the latest 3.x version of the dependency upgrade tool installed globally
   - `yarn global add @parameter1/base-cms-dependency-tool@v3.27.0`
-- Run the dependency tool and force the `--latest` version
-  - `p1-basecms-dependencies upgrade --latest`
-- Run yarn install _in the docker image_ via `./scripts/yarn.sh` or by `docker-compose run --rm --entrypoint yarn commands` from the project root
-- Once the new packages are installed, some Babel versions may be mismatched -- delete all entries in `yarn.lock` that match regex `/^@babel\//` then re-run yarn install above
+- Update _all_ website `docker-compose.yml` and `Dockerfile` files to use `node:14.21` image
+  - For GitHub actions, update the `node-version` in `.github/workflows/node-ci.yml` to `14.21`
+- Run the dependency tool using the latest flag: `p1-basecms-dependencies upgrade --latest`
+  - If trying to upgrade to a pre-release, also include the `--prereleases` flag
+- Optional: you may want to clear your `node_modules` before running yarn: run `rm -rf node_modules` from the website root
+- Run yarn install _in the new node:14 docker image_ via `./scripts/yarn.sh` or by `docker-compose run --rm --entrypoint yarn commands` from the project root
+  - `node-sass` may hang or error when compiling binaries in the final stage of the install. if this happens, delete any `yarn.lock` entries where `node-sass@` is less than 4.14.1 and re-install
+- Once the new packages are installed, some Babel versions may be mismatched -- delete all entries in `yarn.lock` that match regex `/^"@babel\//` then re-run yarn install above
 - Update browserslist entries via `npx browserslist@latest --update-db`
 - Remove any references to components `<marko-web-deferred-script-loader-init />` and `<marko-web-deferred-script-loader-load />`. These are now included in core and do not need to be in the websites.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ x-env-elastic: &env-elastic
 x-node-defaults: &node
   tty: true
   init: true
-  image: node:10.24
+  image: node:14.21
   entrypoint: ["node"]
   working_dir: /base-cms
   volumes:

--- a/services/google-data-api/Dockerfile
+++ b/services/google-data-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.24
+FROM node:14.21
 ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms

--- a/services/graphql-server/Dockerfile
+++ b/services/graphql-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.24
+FROM node:14.21
 ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms

--- a/services/hooks/Dockerfile
+++ b/services/hooks/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.24
+FROM node:14.21
 ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms

--- a/services/oembed/Dockerfile
+++ b/services/oembed/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.24
+FROM node:14.21
 ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms

--- a/services/omail-link-processor/Dockerfile
+++ b/services/omail-link-processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.24
+FROM node:14.21
 ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms

--- a/services/rss/Dockerfile
+++ b/services/rss/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.24
+FROM node:14.21
 ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms

--- a/services/sitemaps/Dockerfile
+++ b/services/sitemaps/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.24
+FROM node:14.21
 ENV NODE_ENV production
 ADD ./ /base-cms
 WORKDIR /base-cms

--- a/yarn.lock
+++ b/yarn.lock
@@ -11806,7 +11806,7 @@ lodash.clone@^4.3.2:
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
 
-lodash.clonedeep@^4.3.2, lodash.clonedeep@^4.5.0:
+lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
@@ -11895,11 +11895,6 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.mergewith@^4.6.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
-  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.once@^4.0.0:
   version "4.1.1"
@@ -12834,11 +12829,6 @@ mz@^2.4.0, mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.10.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.0.tgz#9d443fdb5e13a20770cc5e602eee59760a685885"
-  integrity sha512-zT5nC0JhbljmyEf+Z456nvm7iO7XgRV2hYxoBtPpnyp+0Q4aCoP6uWNn76v/I6k2kCYNLWqWbwBWQcjsNI/bjw==
-
 nan@^2.13.2:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -13078,7 +13068,7 @@ node-releases@^2.0.8:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
   integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
 
-node-sass@^4.14.1:
+node-sass@^4.14.1, node-sass@^4.8.3:
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.14.1.tgz#99c87ec2efb7047ed638fb4c9db7f3a42e2217b5"
   integrity sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==
@@ -13098,31 +13088,6 @@ node-sass@^4.14.1:
     npmlog "^4.0.0"
     request "^2.88.0"
     sass-graph "2.2.5"
-    stdout-stream "^1.4.0"
-    "true-case-path" "^1.0.2"
-
-node-sass@^4.8.3:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.11.0.tgz#183faec398e9cbe93ba43362e2768ca988a6369a"
-  integrity sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==
-  dependencies:
-    async-foreach "^0.1.3"
-    chalk "^1.1.1"
-    cross-spawn "^3.0.0"
-    gaze "^1.0.0"
-    get-stdin "^4.0.1"
-    glob "^7.0.3"
-    in-publish "^2.0.0"
-    lodash.assign "^4.2.0"
-    lodash.clonedeep "^4.3.2"
-    lodash.mergewith "^4.6.0"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    nan "^2.10.0"
-    node-gyp "^3.8.0"
-    npmlog "^4.0.0"
-    request "^2.88.0"
-    sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
@@ -16229,16 +16194,6 @@ sass-graph@2.2.5:
     lodash "^4.0.0"
     scss-tokenizer "^0.2.3"
     yargs "^13.3.2"
-
-sass-graph@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
-  integrity sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=
-  dependencies:
-    glob "^7.0.0"
-    lodash "^4.0.0"
-    scss-tokenizer "^0.2.3"
-    yargs "^7.0.0"
 
 sass-loader@^8.0.2:
   version "8.0.2"
@@ -19504,7 +19459,7 @@ yargs@^16.0.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^7.0.0, yargs@^7.1.0:
+yargs@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
   integrity sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=


### PR DESCRIPTION
Once installed into a website repo, this change will require updates to the `docker-compose.yml`, `Dockerfile` and `.github/workflows/node-ci.yml` files.

Dependencies will also need to be installed inside the new Node 14 container, and some `yarn.lock` modifications may be required.

For more information on both, see the included `MIGRATING.md` file.
