### PR TITLE
Do not assume compile or watch directories

### DIFF
--- a/packages/export-framework/package.json
+++ b/packages/export-framework/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-compiler/bin/compile.js
+++ b/packages/marko-compiler/bin/compile.js
@@ -2,15 +2,18 @@
 
 /* eslint-disable global-require */
 const minimist = require('minimist');
-const log = require('fancy-log');
 const { blue, gray, green } = require('chalk');
+const createLogger = require('../utils/create-logger');
 
 const { isArray } = Array;
-log('cli starting...');
 
 const commands = new Set(['compile']);
 (async () => {
   const argv = minimist(process.argv.slice(2));
+  const debug = !argv.silent;
+  const log = createLogger({ debug });
+
+  log('cli starting...');
   const [command] = argv._;
 
   const getArrayValuesFor = (key, def) => {
@@ -39,6 +42,7 @@ const commands = new Set(['compile']);
       cwd,
       dirs: getArrayValuesFor('dir'),
       clean: argv.clean == null ? true : argv.clean,
+      debug,
     };
     log(`beginning '${blue('compile')}' with options`, opts);
     await compile(opts);

--- a/packages/marko-compiler/bin/compile.js
+++ b/packages/marko-compiler/bin/compile.js
@@ -37,7 +37,7 @@ const commands = new Set(['compile']);
     const compile = require('../index');
     const opts = {
       cwd,
-      dirs: getArrayValuesFor('dir', ['../../packages']),
+      dirs: getArrayValuesFor('dir'),
       clean: argv.clean == null ? true : argv.clean,
     };
     log(`beginning '${blue('compile')}' with options`, opts);

--- a/packages/marko-compiler/compile/one-sync.js
+++ b/packages/marko-compiler/compile/one-sync.js
@@ -1,9 +1,9 @@
 const path = require('path');
 const { readFileSync, writeFileSync, renameSync } = require('fs');
 const { getProfileMS } = require('@parameter1/base-cms-utils');
-const log = require('fancy-log');
 const { grey } = require('chalk');
 const runCompile = require('./run');
+const createLogger = require('../utils/create-logger');
 const stat = require('../utils/stat');
 
 const encoding = 'utf8';
@@ -28,6 +28,7 @@ module.exports = (templateFile, {
   compilerOptions,
 } = {}) => {
   let start;
+  const log = createLogger({ debug });
   if (debug) start = process.hrtime();
   if (!path.isAbsolute(templateFile)) throw new Error('Marko template files must be absolute.');
   const compiledFile = `${templateFile}.js`;

--- a/packages/marko-compiler/compile/one.js
+++ b/packages/marko-compiler/compile/one.js
@@ -1,9 +1,9 @@
 const path = require('path');
 const { readFile, writeFile, rename } = require('fs').promises;
 const { grey } = require('chalk');
-const log = require('fancy-log');
 const { getProfileMS } = require('@parameter1/base-cms-utils');
 const runCompile = require('./run');
+const createLogger = require('../utils/create-logger');
 const stat = require('../utils/stat');
 
 const encoding = 'utf8';
@@ -28,6 +28,7 @@ module.exports = async (templateFile, {
   compilerOptions,
 } = {}) => {
   let start;
+  const log = createLogger({ debug });
   if (debug) start = process.hrtime();
   if (!path.isAbsolute(templateFile)) throw new Error('Marko template files must be absolute.');
   const compiledFile = `${templateFile}.js`;

--- a/packages/marko-compiler/index.js
+++ b/packages/marko-compiler/index.js
@@ -1,7 +1,11 @@
 const { getProfileMS } = require('@parameter1/base-cms-utils');
-const log = require('fancy-log');
+const fancy = require('fancy-log');
 const compile = require('./compile');
 const { deleteCompiledFiles } = require('./utils');
+
+const logger = ({ debug }) => (...args) => {
+  if (debug) fancy(...args);
+};
 
 /**
  *
@@ -13,14 +17,20 @@ const { deleteCompiledFiles } = require('./utils');
  *                                 a global package existed in `packages/global` you would add an
  *                                 `../packages/global` entry
  */
-module.exports = async ({ cwd, dirs, clean } = {}) => {
+module.exports = async ({
+  cwd,
+  dirs,
+  clean,
+  debug,
+} = {}) => {
+  const log = logger({ debug });
   if (clean) {
     log('deleting all compiled Marko templates...');
-    await deleteCompiledFiles(cwd, { dirs });
+    await deleteCompiledFiles(cwd, { dirs, debug });
     log('compiled templates deleted');
   }
   log('compiling marko templates...');
   const start = process.hrtime();
-  await compile.all(cwd, { dirs, debug: true });
+  await compile.all(cwd, { dirs, debug });
   log(`marko templates compiled in ${getProfileMS(start)}ms`);
 };

--- a/packages/marko-compiler/utils/create-logger.js
+++ b/packages/marko-compiler/utils/create-logger.js
@@ -1,0 +1,5 @@
+const log = require('fancy-log');
+
+module.exports = ({ debug }) => (...args) => {
+  if (debug) log(...args);
+};

--- a/packages/marko-compiler/utils/delete-compiled-files.js
+++ b/packages/marko-compiler/utils/delete-compiled-files.js
@@ -7,7 +7,7 @@ const findFiles = require('./find-files');
  * @param {object} options
  * @param {string[]} [options.dirs=[]] Additional directories to remove files from
  */
-module.exports = async (cwd, { dirs = [] }) => {
-  const entries = await findFiles(cwd, { dirs, compiled: true });
+module.exports = async (cwd, { dirs = [], debug }) => {
+  const entries = await findFiles(cwd, { dirs, compiled: true, debug });
   await Promise.all(entries.map(({ path }) => unlink(path)));
 };

--- a/packages/marko-compiler/utils/find-files.js
+++ b/packages/marko-compiler/utils/find-files.js
@@ -1,6 +1,6 @@
 const fg = require('fast-glob');
-const log = require('fancy-log');
 const path = require('path');
+const createLogger = require('./create-logger');
 
 const extensionPattern = '**/*.marko';
 
@@ -23,6 +23,7 @@ module.exports = async (cwd, {
   debug,
   ...rest
 } = {}) => {
+  const log = createLogger({ debug });
   const suffix = compiled ? `${extensionPattern}.js` : extensionPattern;
   const patterns = [
     `./${suffix}`,

--- a/packages/marko-core/package.json
+++ b/packages/marko-core/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-newsletters-email-x/package.json
+++ b/packages/marko-newsletters-email-x/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-newsletters-gam/package.json
+++ b/packages/marko-newsletters-gam/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-newsletters-mc/package.json
+++ b/packages/marko-newsletters-mc/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "lint:fix": "yarn lint --fix",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "peerDependencies": {

--- a/packages/marko-newsletters-omail/package.json
+++ b/packages/marko-newsletters-omail/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "lint:fix": "yarn lint --fix",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "peerDependencies": {

--- a/packages/marko-newsletters/package.json
+++ b/packages/marko-newsletters/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-contact-us/package.json
+++ b/packages/marko-web-contact-us/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-deferred-script-loader/package.json
+++ b/packages/marko-web-deferred-script-loader/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-gam/package.json
+++ b/packages/marko-web-gam/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint && mocha --reporter spec"
   },
   "dependencies": {

--- a/packages/marko-web-gcse/package.json
+++ b/packages/marko-web-gcse/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-gtm/package.json
+++ b/packages/marko-web-gtm/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-html-sitemap/package.json
+++ b/packages/marko-web-html-sitemap/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 --ignore-path ../../.eslintignore ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-icons/package.json
+++ b/packages/marko-web-icons/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "publishConfig": {

--- a/packages/marko-web-identity-x/package.json
+++ b/packages/marko-web-identity-x/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-inquiry/package.json
+++ b/packages/marko-web-inquiry/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 --ignore-path ../../.eslintignore ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-leaders/package.json
+++ b/packages/marko-web-leaders/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-native-x/package.json
+++ b/packages/marko-web-native-x/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-omeda-identity-x/package.json
+++ b/packages/marko-web-omeda-identity-x/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-omeda/package.json
+++ b/packages/marko-web-omeda/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-p1-events/package.json
+++ b/packages/marko-web-p1-events/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-p1-fii/package.json
+++ b/packages/marko-web-p1-fii/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-photoswipe/package.json
+++ b/packages/marko-web-photoswipe/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-radix/package.json
+++ b/packages/marko-web-radix/package.json
@@ -9,7 +9,7 @@
     "lint": "yarn lint:js",
     "lint:js": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "peerDependencies": {

--- a/packages/marko-web-reveal-ad/package.json
+++ b/packages/marko-web-reveal-ad/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-search/package.json
+++ b/packages/marko-web-search/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-social-sharing/package.json
+++ b/packages/marko-web-social-sharing/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-theme-default/package.json
+++ b/packages/marko-web-theme-default/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-theme-monorail-magazine/package.json
+++ b/packages/marko-web-theme-monorail-magazine/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 --ignore-path ../../.eslintignore ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web-theme-monorail/package.json
+++ b/packages/marko-web-theme-monorail/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 --ignore-path ../../.eslintignore ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .js --ext .vue --max-warnings 5 ./",
     "compile": "basecms-marko-compile compile",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn compile --silent",
     "test": "yarn compile --no-clean && yarn lint"
   },
   "dependencies": {

--- a/packages/web-cli/bin/index.js
+++ b/packages/web-cli/bin/index.js
@@ -12,8 +12,6 @@ const exit = (message, code = 0) => {
   process.exit(code);
 };
 
-const defaultCompileDirs = ['../../packages'];
-
 const commands = new Set(['build', 'build:css', 'build:js', 'build:ssr', 'dev']);
 (async () => {
   const argv = minimist(process.argv.slice(2));
@@ -51,7 +49,7 @@ const commands = new Set(['build', 'build:css', 'build:js', 'build:ssr', 'dev'])
         styles: argv.styles || './server/styles/index.scss',
       },
       // defaults to what the site repos normally use.
-      compileDirs: getArrayValuesFor('compile-dir', defaultCompileDirs),
+      compileDirs: getArrayValuesFor('compile-dir'),
       cleanCompiledFiles: clean == null ? true : clean,
     };
     log(`beginning '${blue('build')}' server with options`, opts);
@@ -93,11 +91,9 @@ const commands = new Set(['build', 'build:css', 'build:js', 'build:ssr', 'dev'])
         ssr: argv.ssr || './browser/ssr.js',
         styles: argv.styles || './server/styles/index.scss',
       },
-      // defaults to what the site repos normally use.
-      compileDirs: getArrayValuesFor('compile-dir', defaultCompileDirs),
+      compileDirs: getArrayValuesFor('compile-dir'),
       cleanCompiledFiles: Boolean(argv['clean-compiled-files']),
-      // defaults to what the site repos normally use.
-      additionalWatchDirs: getArrayValuesFor('watch-dir', ['../../packages']),
+      additionalWatchDirs: getArrayValuesFor('watch-dir'),
       watchIgnore: getArrayValuesFor('watch-ignore'),
       abortOnInstanceError: Boolean(argv['abort-on-error']),
       showWatchedFiles: Boolean(argv['show-watched-files']),


### PR DESCRIPTION
This was particular bad when compile assumed the `../../packages` folder, as every package was also compiling every other package -- causing some funky behavior (not mention quite inefficient). Implementing repositories need to be specific with their `package.json` scripts, as the CLI will no longer make assumptions. This is detailed in the updated `MIGRATING.md` doc.