### PR TITLE
Create reusable website integration test

### DIFF
--- a/packages/marko-core/components/resolve.marko
+++ b/packages/marko-core/components/resolve.marko
@@ -13,7 +13,7 @@ $ const { isArray } = Array;
       <${input.onError} err=err />
     </if>
     <else>
-      <pre>An unexpected error occurred: ${err.message}</pre>
+      <pre data-marko-error="true">An unexpected error occurred: ${err.message}</pre>
       <if(isDev)>
         <pre>${err.stack}</pre>
         $ console.error(err);

--- a/packages/marko-web/components/document/components/error.marko
+++ b/packages/marko-web/components/document/components/error.marko
@@ -14,7 +14,7 @@ $ const error = input.error || {};
     <@page for="error">
       <marko-web-page-wrapper>
         <@section>
-          <h3>${input.statusCode} ${input.statusMessage}</h3>
+          <h3 data-marko-error="true">${input.statusCode} ${input.statusMessage}</h3>
           <h4>${error.message}</h4>
           <if(isDev)>
             <pre>${error.stack}</pre>

--- a/packages/marko-web/integration/test-website-boot.js
+++ b/packages/marko-web/integration/test-website-boot.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch');
+
 const { error, log } = console;
 
 setInterval(async () => {

--- a/packages/marko-web/integration/test-website-boot.js
+++ b/packages/marko-web/integration/test-website-boot.js
@@ -1,0 +1,23 @@
+const fetch = require('node-fetch');
+const { error, log } = console;
+
+setInterval(async () => {
+  try {
+    const res = await fetch('http://localhost:80', { method: 'get' });
+    if (!res.ok) {
+      error('Response not ok!', res.status, res.statusText);
+      process.exit(1);
+    } else {
+      const html = await res.text();
+      const found = /.*<\/head>.*<\/body>.*<\/html>.*/is.test(html);
+      if (!found) {
+        error('Unable to find closing HTML tags!');
+        process.exit(1);
+      }
+      log('Integration tests passed!');
+      process.exit(0);
+    }
+  } catch (e) {
+    // noop
+  }
+}, 100);

--- a/packages/marko-web/integration/test-website-boot.js
+++ b/packages/marko-web/integration/test-website-boot.js
@@ -13,6 +13,13 @@ setInterval(async () => {
       if (!found) {
         error('Unable to find closing HTML tags!');
         process.exit(1);
+        return;
+      }
+      // now check for any server errors
+      if (/data-marko-error="true"/g.test(html)) {
+        error('An in-page server-side Marko error was encountered!');
+        process.exit(1);
+        return;
       }
       log('Integration tests passed!');
       process.exit(0);

--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -47,6 +47,7 @@
     "http-errors": "^1.8.1",
     "jquery": "^3.6.3",
     "marko": "~4.20.0",
+    "node-fetch": "^2.6.9",
     "vue": "^2.7.14",
     "vue-server-renderer": "^2.7.14"
   },


### PR DESCRIPTION
Should be imported into the `./test/integration.js` file at the root of every website repo.

```js
// ./test/integration.js
require('@parameter1/base-cms-marko-web/integration/test-website-boot');
```

This will test that the website container boots, responses with a 200, fully renders (has closing head, body, and html tags), and doesn't contain any server side, async errors (via `data-marko-error="true"`)