### PR TITLE
Improve website integration tests

### DIFF
--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -12,7 +12,7 @@
     "test": "yarn lint"
   },
   "dependencies": {
-    "async": "^2.6.3"
+    "async": "^3.2.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/marko-web/integration/test-website-boot.js
+++ b/packages/marko-web/integration/test-website-boot.js
@@ -29,7 +29,7 @@ const checkReadiness = async ({
   path = '/_health',
   startAfter = 5000,
   checkInterval = 1000,
-  unhealthAfter = 5,
+  unhealthyAfter = 5,
 } = {}) => {
   log('checking readiness...');
   log(`initially waiting for ${startAfter}ms before checking...`);
@@ -39,7 +39,7 @@ const checkReadiness = async ({
   let booted = false;
   await whilst(async () => !booted, async () => {
     timesChecked += 1;
-    if (timesChecked > unhealthAfter) {
+    if (timesChecked > unhealthyAfter) {
       throw new Error('The readiness probe has reached its maximum check limit.');
     }
     log(`pinging health check, attempt number ${timesChecked}...`);

--- a/packages/marko-web/integration/test-website-boot.js
+++ b/packages/marko-web/integration/test-website-boot.js
@@ -1,40 +1,107 @@
-const fetch = require('node-fetch');
 const { htmlEntities } = require('@parameter1/base-cms-html');
+const { sleep: wait, cleanPath } = require('@parameter1/base-cms-utils');
+const whilst = require('async/whilst');
+const fetch = require('node-fetch');
 
-const { error, log } = console;
+const { log } = console;
 
-const url = process.env.MARKO_WEB_INTEGRATION_TEST_URL || 'http://localhost:80';
+const origin = process.env.MARKO_WEB_INTEGRATION_TEST_URL || 'http://localhost:80';
 
-setInterval(async () => {
+const fetchResponse = async ({
+  path = '/',
+  catchErrors = false,
+  returnNullWhenNotOk = false,
+} = {}) => {
+  const url = `${cleanPath(origin)}/${cleanPath(path)}`;
+  log(`fetching ${url}`);
+  const opts = { method: 'get' };
+  if (!catchErrors) return fetch(url, opts);
   try {
-    const res = await fetch(url, { method: 'get' });
-    if (!res.ok) {
-      error('Response not ok!', res.status, res.statusText);
-      process.exit(1);
-    } else {
-      const html = await res.text();
-      // check for in-body body errors
-      const matches = [...html.matchAll(/data-marko-error="(.*?)"/g)];
-      const errors = [];
-      matches.forEach((values) => {
-        const value = values[1];
-        errors.push(htmlEntities.decode(value));
-      });
-      if (errors.length) {
-        error('In-page, server-side Marko error(s) were encountered!', errors);
-        process.exit(1);
-      }
-
-      // if not in-body errors, ensure page rendered.
-      const found = /.*<\/head>.*<\/body>.*<\/html>.*/is.test(html);
-      if (!found) {
-        error('Unable to find closing HTML tags!');
-        process.exit(1);
-      }
-      log('Integration tests passed!');
-      process.exit(0);
-    }
+    const res = await fetch(url, opts);
+    if (returnNullWhenNotOk && !res.ok) return null;
+    return res;
   } catch (e) {
-    // noop
+    return null;
   }
-}, 100);
+};
+
+const checkReadiness = async ({
+  path = '/_health',
+  startAfter = 5000,
+  checkInterval = 1000,
+  unhealthAfter = 5,
+} = {}) => {
+  log('checking readiness...');
+  log(`initially waiting for ${startAfter}ms before checking...`);
+  await wait(startAfter);
+
+  let timesChecked = 0;
+  let booted = false;
+  await whilst(async () => !booted, async () => {
+    timesChecked += 1;
+    if (timesChecked > unhealthAfter) {
+      throw new Error('The readiness probe has reached its maximum check limit.');
+    }
+    log(`pinging health check, attempt number ${timesChecked}...`);
+    const res = await fetchResponse({ path, catchErrors: true });
+    // if response is null, a connection error occrred
+    if (res == null || (res && !res.ok)) {
+      if (res == null) log('did not receive a response - assuming not ready.');
+      if (res && !res.ok) log(`received a non-ok response from health check - ${res.status} ${res.statusText}`);
+      log(`waiting another ${checkInterval}ms before retrying.`);
+      await wait(checkInterval);
+      return;
+    }
+    booted = true;
+  });
+  log('container is ready.');
+};
+
+const testPage = async ({ path, retryAttempts = 3 } = {}) => {
+  log(`testing page path ${path}`);
+
+  let timesChecked = 0;
+  let passed = false;
+  await whilst(async () => !passed, async () => {
+    timesChecked += 1;
+    if (timesChecked > retryAttempts) {
+      throw new Error(`The test runner for page path ${path} has reached its maximum check limit.`);
+    }
+    const res = await fetchResponse({ path });
+    if (!res.ok) throw new Error(`Received a non-ok response from path page ${path}`, res.status, res.statusText);
+    const html = await res.text();
+
+    // first ensure the entire page rendered. if it didn't a fatal backened error occurred
+    // that prevented rendering.
+    const found = /.*<\/head>.*<\/body>.*<\/html>.*/is.test(html);
+    if (!found) throw new Error(`The page at path ${path} did not completely render.`);
+
+    // then check for in-body errors. this means an async internal block failed
+    // but the page could fully render.
+    const matches = [...html.matchAll(/data-marko-error="(.*?)"/g)];
+    const errors = [];
+    matches.forEach((values) => {
+      const value = values[1];
+      errors.push(htmlEntities.decode(value));
+    });
+    if (errors.length) {
+      // if all the errors were timeout errors, let's try again.
+      if (errors.every((msg) => msg === 'Timed out after 10000ms')) {
+        log(`all errors for page path ${path} were timeout errors. retrying...`);
+        return;
+      }
+      // otherwise error.
+      log({ errors });
+      throw new Error(`Encountered server-side Marko error(s) at page path ${path}`);
+    }
+    passed = true;
+  });
+  log(`page path ${path} passed tests.`);
+};
+
+const run = async () => {
+  await checkReadiness();
+  await testPage({ path: '/' });
+};
+
+run().catch((e) => setImmediate(() => { throw e; }));

--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -38,6 +38,7 @@
     "@parameter1/base-cms-tenant-context": "^4.0.2",
     "@parameter1/base-cms-utils": "^4.0.2",
     "@parameter1/base-cms-web-common": "^4.0.2",
+    "async": "^3.2.4",
     "cheerio": "^1.0.0-rc.12",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.2",

--- a/services/keyword-analysis/package.json
+++ b/services/keyword-analysis/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@parameter1/base-cms-tooling": "^4.0.2",
-    "async": "^2.6.3",
+    "async": "^3.2.4",
     "chalk": "^4.1.2",
     "clear": "^0.1.0",
     "dataloader": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,14 +2200,14 @@ async-settle@^1.0.0:
   dependencies:
     async-done "^1.2.2"
 
-async@^2.0.1, async@^2.6.1, async@^2.6.3:
+async@^2.0.1, async@^2.6.1:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
   integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
   dependencies:
     lodash "^4.17.14"
 
-async@^3.2.3:
+async@^3.2.3, async@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==


### PR DESCRIPTION
Adds an improvied readiness check that includes initial wait times, waits between checks, and failures after maximum retries.

Also supports retrying a web page when all errors are internal timeouts