### PR TITLE
Use `spawn` instead of `fork` when creating dev server

### DIFF
--- a/packages/web-cli/serve/fork-server.js
+++ b/packages/web-cli/serve/fork-server.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const { fork } = require('child_process');
+const child = require('child_process');
+const log = require('fancy-log');
 
 const isFn = (v) => typeof v === 'function';
 
@@ -9,6 +10,7 @@ module.exports = ({
   onAfterRestart,
   onReady,
 } = {}) => {
+  /** @type {child.ChildProcess} */
   let proc;
 
   const file = path.resolve(cwd, entry);
@@ -18,20 +20,40 @@ module.exports = ({
       await new Promise((resolve, reject) => {
         proc.on('exit', resolve);
         proc.on('error', reject);
-        proc.kill();
+        let killed = proc.kill('SIGINT');
+        ['SIGINT', 'SIGKILL'].forEach((signal) => {
+          if (!killed) killed = proc.kill(signal);
+        });
+        if (!killed) {
+          // since there is an exit code, resolve so a new proc can be spawned.
+          if (proc.exitCode != null) {
+            resolve();
+          } else {
+            reject(new Error('The server process was unable to be killed but is not providing an exit code.'));
+          }
+        }
       });
     }
   };
 
+  const spawn = () => new Promise((resolve, reject) => {
+    proc = child.spawn('node', [file], { stdio: ['inherit', 'inherit', 'inherit', 'ipc'] });
+    proc.on('spawn', resolve);
+    proc.on('error', reject);
+  });
+
   const listen = async ({ rejectOnNonZeroExit = true } = {}) => {
+    log('killing current server...');
     await kill();
-    proc = fork(file, [], { stdio: ['inherit', 'inherit', 'inherit', 'ipc'] });
+    log('spawning new server process...');
+    await spawn();
+    log('waiting for marko web server to be ready...');
     const msg = await new Promise((resolve, reject) => {
       proc.on('message', (message) => {
         if (message.event === 'ready') resolve(message);
       });
       proc.on('exit', (code) => {
-        if (code && code !== 0 && rejectOnNonZeroExit) reject(new Error(`Forked process received a non-zero (${code}) exit code.`));
+        if (code && code !== 0 && rejectOnNonZeroExit) reject(new Error(`Spawned process received a non-zero (${code}) exit code.`));
       });
     });
     if (isFn(onReady)) await onReady();

--- a/packages/web-cli/serve/watch.js
+++ b/packages/web-cli/serve/watch.js
@@ -83,7 +83,7 @@ module.exports = async ({
       await handleEvent({ event, file });
     } catch (e) {
       // on error, ensure forked server is killed.
-      server.kill();
+      server.kill().catch();
       throw e;
     }
   });


### PR DESCRIPTION
Prefers `spawn` over `fork` when generating the dev server child process due to speed concerns. Handling was also added to the `kill` function to ensure the server re-spawns and doesn't hang after file changes, particularly in instances where the the website server was in a fatal error state.