### PR TITLE
Assert that `cropRectangle` returns `coords >= 0`

### DIFF
--- a/packages/image/src/crop-rectangle.js
+++ b/packages/image/src/crop-rectangle.js
@@ -63,7 +63,7 @@ module.exports = ({ width, height, cropDimensions }) => {
     y1,
     y2,
   } = coords.reduce((o, key) => {
-    const v = Math.round(cropDimensions[key] * scale);
+    const v = cropDimensions[key] > 0 ? Math.round(cropDimensions[key] * scale) : 0;
     return { ...o, [key]: v };
   }, {});
 


### PR DESCRIPTION
Ref: https://docs.imgix.com/apis/rendering/size/rect 

Imgix doesn't support crop dimensions less than 0 so we must assert that these are at least 0.