### PR TITLE
"Whitelist" video embed providers and assert them as `data-embed-type="video"`

### DIFF
--- a/packages/marko-web-theme-default/scss/components/_embedded-media.scss
+++ b/packages/marko-web-theme-default/scss/components/_embedded-media.scss
@@ -57,7 +57,7 @@ p [data-embed-type] {
   display: none;
 }
 
-[data-oembed-type="video"] {
+[data-oembed-type="video"], [data-oembed-type="link"] {
   @extend .embed-responsive;
   @extend .embed-responsive-16by9;
 }

--- a/packages/marko-web-theme-monorail/scss/theme-default/components/_embedded-media.scss
+++ b/packages/marko-web-theme-monorail/scss/theme-default/components/_embedded-media.scss
@@ -57,7 +57,7 @@ p [data-embed-type] {
   display: none;
 }
 
-[data-oembed-type="video"] {
+[data-oembed-type="video"], [data-oembed-type="link"] {
   @extend .embed-responsive;
   @extend .embed-responsive-16by9;
 }

--- a/packages/marko-web/browser/components/oembed.vue
+++ b/packages/marko-web/browser/components/oembed.vue
@@ -10,7 +10,8 @@
     :data-expand="expand"
     v-html="html"
   />
-  <span v-else
+  <span
+    v-else
     :id="id"
     class="lazyload"
     :data-embed-type="attrs.type"
@@ -18,7 +19,7 @@
     :data-oembed-provider="provider"
     :data-expand="expand"
   >
-      <iframe
+    <iframe
       :src="oembedUrl"
       width="100%"
       height="100%"

--- a/packages/marko-web/browser/components/oembed.vue
+++ b/packages/marko-web/browser/components/oembed.vue
@@ -12,7 +12,7 @@
     <iframe
       :src="oembedUrl"
       width="100%"
-      style="aspect-ratio: 16/9"
+      height="100%"
       frameborder="0"
     />
   </span>

--- a/packages/marko-web/browser/components/oembed.vue
+++ b/packages/marko-web/browser/components/oembed.vue
@@ -1,23 +1,7 @@
 <!-- eslint-disable vue/no-v-html-->
 <template>
   <span
-    v-if="oembedType === 'link'"
-    :id="id"
-    class="lazyload"
-    :data-embed-type="attrs.type"
-    :data-oembed-type="oembedType"
-    :data-oembed-provider="provider"
-    :data-expand="expand"
-  >
-    <iframe
-      :src="oembedUrl"
-      width="100%"
-      height="100%"
-      frameborder="0"
-    />
-  </span>
-  <span
-    v-else
+    v-if="html"
     :id="id"
     class="lazyload"
     :data-embed-type="attrs.type"
@@ -26,6 +10,21 @@
     :data-expand="expand"
     v-html="html"
   />
+  <span v-else
+    :id="id"
+    class="lazyload"
+    :data-embed-type="attrs.type"
+    :data-oembed-type="oembedType"
+    :data-oembed-provider="provider"
+    :data-expand="expand"
+  >
+      <iframe
+      :src="oembedUrl"
+      width="100%"
+      height="100%"
+      frameborder="0"
+    />
+  </span>
 </template>
 
 <script>

--- a/packages/marko-web/browser/components/oembed.vue
+++ b/packages/marko-web/browser/components/oembed.vue
@@ -12,7 +12,7 @@
     <iframe
       :src="oembedUrl"
       width="100%"
-      height="100%"
+      style="aspect-ratio: 16/9"
       frameborder="0"
     />
   </span>

--- a/packages/marko-web/browser/components/oembed.vue
+++ b/packages/marko-web/browser/components/oembed.vue
@@ -1,17 +1,7 @@
 <!-- eslint-disable vue/no-v-html-->
 <template>
   <span
-    v-if="html"
-    :id="id"
-    class="lazyload"
-    :data-embed-type="attrs.type"
-    :data-oembed-type="oembedType"
-    :data-oembed-provider="provider"
-    :data-expand="expand"
-    v-html="html"
-  />
-  <span
-    v-else
+    v-if="oembedType === 'link'"
     :id="id"
     class="lazyload"
     :data-embed-type="attrs.type"
@@ -26,6 +16,16 @@
       frameborder="0"
     />
   </span>
+  <span
+    v-else
+    :id="id"
+    class="lazyload"
+    :data-embed-type="attrs.type"
+    :data-oembed-type="oembedType"
+    :data-oembed-provider="provider"
+    :data-expand="expand"
+    v-html="html"
+  />
 </template>
 
 <script>

--- a/services/oembed/src/app.js
+++ b/services/oembed/src/app.js
@@ -93,12 +93,12 @@ const videoProvider = new Set([
   'wwltv.com',
 ]);
 
-const retrieveOembed = async ({url, params}) => {
+const retrieveOembed = async ({ url, params }) => {
   const data = await embedly.oembed(url, params);
   // Match on "valid video urls" and enforce providers.
   if (url.match(/player|video/) && videoProvider.has(data.provider_name)) return { ...data, type: 'video' };
   return data;
-}
+};
 
 app.post('/', asyncRoute(async (req, res) => {
   const { url, ...params } = req.body;

--- a/services/oembed/src/app.js
+++ b/services/oembed/src/app.js
@@ -21,82 +21,12 @@ app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
 app.use(CORS);
 app.options('*', CORS);
 
-const videoProvider = new Set([
-  '11Alive.com',
-  '12news.com',
-  'wMAZ',
-  'KUSA.com',
-  '6abc',
-  'Abc11',
-  'Abc13',
-  'Abc30',
-  'Abc3340',
-  'Abc7',
-  'Abc7chicago',
-  'Abc7news',
-  'Abc7ny',
-  'ABC News',
-  'Scrippsdigital',
-  'cbs8.com',
-  'Jwplayer',
-  'Kaltura',
-  'Jwplatform',
-  'fox43.com',
-  'Foxillinois',
-  'Katu',
-  'kens5.com',
-  'khou.com',
-  'ksdk.com',
-  'ktvb.com',
-  'abc10.com',
-  'kgw.com',
-  'king5.com',
-  'thv11.com',
-  'wfaa.com',
-  'wtol.com',
-  'Washingtonpost',
-  'Nbcwashington',
-  'Newschannel9',
-  'Cnbc',
-  'Brightcove',
-  'TMZ',
-  'Sinclairstoryline',
-  'azcentral',
-  'cantonrep',
-  'Cincinnati',
-  'courierpress',
-  'desmoinesregister',
-  'freep',
-  'jsonline',
-  'lansingstatejournal',
-  'lohud',
-  'news-press',
-  'northjersey',
-  'oklahoman',
-  'tennessean',
-  'usatoday',
-  'Lura',
-  '9c9media',
-  'wgrz.com',
-  'whas11.com',
-  'wua9.com',
-  '5newsonline.com',
-  'Cbsnews',
-  'Mail Online',
-  'firstcostnews.com',
-  'kare11.com',
-  'kiiitv.com',
-  'newscentermain.com',
-  'Viddler',
-  'wcnc.com',
-  'wthr.com',
-  'wwltv.com',
-]);
-
 const retrieveOembed = async ({ url, params }) => {
   const data = await embedly.oembed(url, params);
-  // Match on "valid video urls" and enforce providers.
-  if (url.match(/player|video/) && videoProvider.has(data.provider_name)) return { ...data, type: 'video' };
+  // If it returns as link return it as a video instead
+  if (data.type === 'link') {
+    return { ...data, url, type: 'video' };
+  }
   return data;
 };
 

--- a/services/oembed/src/app.js
+++ b/services/oembed/src/app.js
@@ -21,9 +21,88 @@ app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal']);
 app.use(CORS);
 app.options('*', CORS);
 
+const videoProvider = new Set([
+  '11Alive.com',
+  '12news.com',
+  'wMAZ',
+  'KUSA.com',
+  '6abc',
+  'Abc11',
+  'Abc13',
+  'Abc30',
+  'Abc3340',
+  'Abc7',
+  'Abc7chicago',
+  'Abc7news',
+  'Abc7ny',
+  'ABC News',
+  'Scrippsdigital',
+  'cbs8.com',
+  'Jwplayer',
+  'Kaltura',
+  'Jwplatform',
+  'fox43.com',
+  'Foxillinois',
+  'Katu',
+  'kens5.com',
+  'khou.com',
+  'ksdk.com',
+  'ktvb.com',
+  'abc10.com',
+  'kgw.com',
+  'king5.com',
+  'thv11.com',
+  'wfaa.com',
+  'wtol.com',
+  'Washingtonpost',
+  'Nbcwashington',
+  'Newschannel9',
+  'Cnbc',
+  'Brightcove',
+  'TMZ',
+  'Sinclairstoryline',
+  'azcentral',
+  'cantonrep',
+  'Cincinnati',
+  'courierpress',
+  'desmoinesregister',
+  'freep',
+  'jsonline',
+  'lansingstatejournal',
+  'lohud',
+  'news-press',
+  'northjersey',
+  'oklahoman',
+  'tennessean',
+  'usatoday',
+  'Lura',
+  '9c9media',
+  'wgrz.com',
+  'whas11.com',
+  'wua9.com',
+  '5newsonline.com',
+  'Cbsnews',
+  'Mail Online',
+  'firstcostnews.com',
+  'kare11.com',
+  'kiiitv.com',
+  'newscentermain.com',
+  'Viddler',
+  'wcnc.com',
+  'wthr.com',
+  'wwltv.com',
+]);
+
+const retrieveOembed = async ({url, params}) => {
+  const data = await embedly.oembed(url, params);
+  // Match on "valid video urls" and enforce providers.
+  if (url.match(/player|video/) && videoProvider.has(data.provider_name)) return { ...data, type: 'video' };
+  return data;
+}
+
 app.post('/', asyncRoute(async (req, res) => {
   const { url, ...params } = req.body;
-  const data = await embedly.oembed(url, params);
+  const data = await retrieveOembed({ url, params });
   // post will set to cache, but not read from it
   await cache.setFor({ url, params, data });
   res.json(data);
@@ -41,7 +120,7 @@ app.get('/', asyncRoute(async (req, res) => {
     res.set('Age', cached.age);
     return res.json(cached.data);
   }
-  const data = await embedly.oembed(url, params);
+  const data = await retrieveOembed({ url, params });
   await cache.setFor({ url, params, data });
   return res.json(data);
 }));

--- a/services/oembed/src/app.js
+++ b/services/oembed/src/app.js
@@ -25,7 +25,7 @@ const retrieveOembed = async ({ url, params }) => {
   const data = await embedly.oembed(url, params);
   // If it returns as link return it as a video instead
   if (data.type === 'link') {
-    return { ...data, url, type: 'video' };
+    return { ...data, url, };
   }
   return data;
 };

--- a/services/oembed/src/app.js
+++ b/services/oembed/src/app.js
@@ -25,7 +25,7 @@ const retrieveOembed = async ({ url, params }) => {
   const data = await embedly.oembed(url, params);
   // If it returns as link return it as a video instead
   if (data.type === 'link') {
-    return { ...data, url, };
+    return { ...data, url };
   }
   return data;
 };


### PR DESCRIPTION
Previously many video embeds were coming back as links, this attempts to resolve a decent number of the ones "missed" and asserts them based on the provider name AND specific keywords (player or video) in the URL of the embed. This was done so as to not change all embeds from certain providers to videos etc.

Live:
![Screenshot from 2023-03-02 21-54-00](https://user-images.githubusercontent.com/46794001/222628305-dd1fa603-69d6-45b2-a5e1-a81249c8628e.png)

Dev:
![Screenshot from 2023-03-02 21-54-03](https://user-images.githubusercontent.com/46794001/222628308-76daf930-8e02-4179-90d1-0ca7fdcf5f5c.png)
![Screenshot from 2023-03-02 21-54-18](https://user-images.githubusercontent.com/46794001/222628310-baca0c88-8f9e-4840-a7fc-1a05e491bfd9.png)
