### PR TITLE
Generically render Marko components from the browser

### DIFF
--- a/packages/marko-web/browser/components/index.js
+++ b/packages/marko-web/browser/components/index.js
@@ -4,6 +4,7 @@ const TriggerScreenChangeEvent = () => import(/* webpackChunkName: "trigger-scre
 const OEmbed = () => import(/* webpackChunkName: "oembed" */ './oembed.vue');
 const WufooGatedDownload = () => import(/* webpackChunkName: "wufoo-gated-download" */ './gated-download/wufoo.vue');
 const ImageSlider = () => import(/* webpackChunkName: "image-slider" */ './image-slider.vue');
+const RenderMarkoComponent = () => import(/* webpackChunkName: "render-marko-component" */ './render-marko-component.vue');
 
 export default (Browser) => {
   Browser.register('LoadMoreTrigger', LoadMoreTrigger);
@@ -12,4 +13,5 @@ export default (Browser) => {
   Browser.register('OEmbed', OEmbed);
   Browser.register('WufooGatedDownload', WufooGatedDownload);
   Browser.register('ImageSlider', ImageSlider);
+  Browser.register('RenderMarkoComponent', RenderMarkoComponent);
 };

--- a/packages/marko-web/browser/components/render-marko-component.vue
+++ b/packages/marko-web/browser/components/render-marko-component.vue
@@ -1,0 +1,60 @@
+<template>
+  <div :class="classes">
+    <div v-if="isLoading">
+      Loading...
+    </div>
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div v-else-if="html" v-html="html" />
+    <div v-if="error">
+      <h5>Unable to load to lock.</h5>
+      <p>{{ error.message }}</p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    input: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+
+  data: () => ({
+    error: null,
+    hasLoaded: false,
+    html: null,
+    isLoading: false,
+    classes: ['lazyload'],
+  }),
+
+  created() {
+    document.addEventListener('lazybeforeunveil', this.load.bind(this));
+  },
+
+  methods: {
+    async load() {
+      if (!this.isLoading && !this.hasLoaded) {
+        try {
+          this.error = null;
+          this.isLoading = true;
+          const input = JSON.stringify(this.input);
+          const href = `/__render-marko-component?id=${encodeURIComponent(this.id)}&input=${encodeURIComponent(input)}`;
+          const res = await fetch(href, { credentials: 'same-origin' });
+          this.html = await res.text();
+          this.hasLoaded = true;
+        } catch (e) {
+          this.error = e;
+        } finally {
+          this.isLoading = false;
+        }
+      }
+    },
+  },
+};
+</script>

--- a/packages/marko-web/components/marko.json
+++ b/packages/marko-web/components/marko.json
@@ -23,5 +23,13 @@
     "@class": "string",
     "@attrs": "object",
     "@props": "object"
+  },
+  "<marko-web-render-marko-component>": {
+    "template": "./render-marko-component.marko",
+    "<input>": {},
+    "@id": {
+      "type": "string",
+      "required": true
+    }
   }
 }

--- a/packages/marko-web/components/render-marko-component.marko
+++ b/packages/marko-web/components/render-marko-component.marko
@@ -1,0 +1,1 @@
+<marko-web-browser-component name="RenderMarkoComponent" props={ id: input.id, input: input.input } />

--- a/packages/marko-web/express/index.js
+++ b/packages/marko-web/express/index.js
@@ -18,6 +18,7 @@ const { version } = require('../package.json');
 const websiteContext = require('./website-context');
 const CoreConfig = require('../config/core');
 const SiteConfig = require('../config/site');
+const renderMarkoComponent = require('./render-marko-component');
 
 module.exports = (config = {}) => {
   const {
@@ -114,6 +115,7 @@ module.exports = (config = {}) => {
   app.use(markoMiddleware());
   app.use(purgedCSS());
   app.use(cleanMarkoResponse());
+  renderMarkoComponent(app);
 
   // Serve static assets
   app.use('/dist/css', express.static(`${distDir}/css`, { maxAge: '2y', immutable: true }));

--- a/packages/marko-web/express/render-marko-component.js
+++ b/packages/marko-web/express/render-marko-component.js
@@ -1,0 +1,31 @@
+const createError = require('http-errors');
+
+const load = (id) => {
+  try {
+    return require(id); // eslint-disable-line
+  } catch (e) {
+    throw createError(404, e.message.split('\n').shift());
+  }
+};
+
+const parseJSON = (value) => {
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    return {};
+  }
+};
+
+module.exports = (app) => {
+  app.get('/__render-marko-component', (req, res) => {
+    const { id, input } = req.query;
+    if (!id) throw createError(400, 'The component module id is required.');
+    const component = load(id);
+    if (!component || (!component.path && !component.meta)) throw createError(400, 'The requested module does not appear to be a Marko component.');
+    return res.marko(component, parseJSON(input));
+  }, (err, req, res, next) => { // eslint-disable-line
+    res.set({ 'content-type': 'text/html; charset=utf-8' });
+    res.status(err.status || err.statusCode || 500);
+    res.send(`Unable to render marko component. ${err.message}`);
+  });
+};

--- a/services/example-website/server/templates/index.marko
+++ b/services/example-website/server/templates/index.marko
@@ -29,6 +29,12 @@
       </@section>
 
       <@section>
+        <marko-web-render-marko-component id="@parameter1/base-cms-marko-web-theme-monorail/components/blocks/most-popular-list">
+          <@input foo="bar" />
+        </marko-web-render-marko-component>
+      </@section>
+
+      <@section>
         <div class="row">
           <div class="col-md-8">
             <leaders-homepage />


### PR DESCRIPTION
Adds support for calling `/__render-marko-component` via XHR/fetch to render any Marko component module remotely. Unlike the theme-based remote block loader, this works for any available component (without pre-registering it) by using it’s module id and dynamically requiring it.

For example, using:
```marko
<marko-web-render-marko-component id="@parameter1/base-cms-marko-web-theme-monorail/components/blocks/most-popular-list">
    <@input foo="bar" />
</marko-web-render-marko-component>
```
would fetch `/__render-marko-component?id=@parameter1/base-cms-marko-web-theme-monorail/components/blocks/most-popular-list&input={"foo":"bar"}` and would return the component HTML (assuming it’s available in `node_modules`).

To load local components, use `require.resolve` to the relative component, e.g.
```marko
<marko-web-render-marko-component id=require.resolve("../my/cool-component")>
    <@input foo="bar" />
</marko-web-render-marko-component>
```