### PR TITLE
Add unique ID to all website and graphql requests

### DIFF
--- a/packages/marko-web/express/apollo.js
+++ b/packages/marko-web/express/apollo.js
@@ -1,5 +1,6 @@
 const { apolloClient } = require('@parameter1/base-cms-express-apollo');
 const { parseBooleanHeader } = require('@parameter1/base-cms-utils');
+const pkg = require('../package.json');
 
 module.exports = (app, uri, config = {}) => {
   /**
@@ -13,7 +14,17 @@ module.exports = (app, uri, config = {}) => {
       if (!value) return o; // do nothing if no cookie or query param is set.
       // otherwise parse the value and set the GraphQL header to match.
       return { ...o, [key]: parseBooleanHeader(value) };
-    }, {});
+    }, {
+      'x-marko-web-request': JSON.stringify({
+        id: req.id,
+        env: process.env.NODE_ENV || 'unknonwn',
+        ua: req.get('user-agent'),
+        origin: `${req.protocol}://${req.get('host')}`,
+        path: req.path,
+        query: req.query,
+      }),
+      'user-agent': `marko-web-express-apollo/${pkg.version} via node-fetch/1.0`,
+    });
     return { headers };
   };
   app.use(apolloClient(uri, config, config.link, contextFn));

--- a/packages/marko-web/express/index.js
+++ b/packages/marko-web/express/index.js
@@ -5,6 +5,7 @@ const cookieParser = require('cookie-parser');
 const express = require('express');
 const path = require('path');
 const helmet = require('helmet');
+const { nanoid } = require('nanoid');
 const apollo = require('./apollo');
 const graphqlProxy = require('./graphql-proxy');
 const embeddedMedia = require('./embedded-media');
@@ -33,6 +34,12 @@ module.exports = (config = {}) => {
   const distDir = path.resolve(rootDir, 'dist');
   const app = express();
   const serverDir = path.resolve(rootDir, 'server');
+
+  app.use((req, res, next) => {
+    // set unique request id.
+    req.id = nanoid();
+    next();
+  });
 
   // Add async block error handler.
   app.locals.onAsyncBlockError = config.onAsyncBlockError;

--- a/packages/marko-web/package.json
+++ b/packages/marko-web/package.json
@@ -49,6 +49,7 @@
     "http-errors": "^1.8.1",
     "jquery": "^3.6.3",
     "marko": "~4.20.0",
+    "nanoid": "^3.3.4",
     "node-fetch": "^2.6.9",
     "vue": "^2.7.14",
     "vue-server-renderer": "^2.7.14"

--- a/services/graphql-server/package.json
+++ b/services/graphql-server/package.json
@@ -47,6 +47,7 @@
     "micro": "^9.4.1",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.40",
+    "nanoid": "^3.3.4",
     "newrelic": "^9.10.1",
     "node-fetch": "^2.6.9",
     "object-hash": "^1.3.1",

--- a/services/graphql-server/src/app.js
+++ b/services/graphql-server/src/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
+const { nanoid } = require('nanoid');
 const routes = require('./routes');
 
 const app = express();
@@ -12,6 +13,12 @@ const CORS = cors({
 app.use(helmet());
 app.use(CORS);
 app.options('*', CORS);
+
+app.use((req, res, next) => {
+  // set unique request id.
+  req.id = nanoid();
+  next();
+});
 
 routes(app);
 

--- a/services/graphql-server/src/routes/graphql.js
+++ b/services/graphql-server/src/routes/graphql.js
@@ -45,6 +45,7 @@ const server = new ApolloServer({
     const { body } = req;
     const { tenant, siteId } = getFromRequest(req);
     const dbContext = {
+      requestId: req.id,
       type: 'Apollo GraphQL Request',
       clientName: req.get('apollographql-client-name'),
       clientVersion: req.get('apollographql-client-version'),
@@ -71,6 +72,7 @@ const server = new ApolloServer({
     const auth = await createAuthContext({ req, userService });
 
     return {
+      requestId: req.id,
       tenant,
       basedb,
       base4rest,


### PR DESCRIPTION
And pass website metadata when making requests to GraphQL from the websites.

This allows for better debugging and logging of website GraphQL requests