### PR TITLE
Use cache website section and option loading using Redis

### DIFF
--- a/services/graphql-server/src/cache-loaders/create-option-loader.js
+++ b/services/graphql-server/src/cache-loaders/create-option-loader.js
@@ -1,0 +1,93 @@
+const redis = require('../redis');
+const { cacheKey } = require('./utils');
+const { USE_CACHE_LOADERS } = require('../env');
+
+/**
+ * @typedef {import("@parameter1/base-cms-db/src/basedb.js")} BaseDB
+ */
+
+/**
+ * @param {object} params
+ * @param {BaseDB} params.basedb
+ * @param {object} params.query
+ */
+const loadFromDb = ({ basedb, query }) => basedb.find('website.Option', query, { projection: { _id: 1 } });
+
+const { log } = console;
+
+/**
+ *
+ * @param {object} params
+ * @param {BaseDB} params.basedb
+ * @param {Function} [params.onCacheError]
+ * @param {number} [params.refreshMaxAge=3600]
+ * @param {boolean} [params.debug]
+ */
+module.exports = ({
+  basedb,
+  onCacheError,
+  refreshMaxAge = 3600, // every hour, do a background refresh of the data
+  debug = process.env.NODE_ENV === 'development',
+}) => {
+  const { tenant } = basedb;
+  return async ({
+    siteId,
+    ids = [],
+    names = [],
+  }) => {
+    if (!ids.length && !names.length) return [];
+
+    const keyParts = [];
+    if (siteId) keyParts.push(`site-${siteId}`);
+
+    const query = {
+      status: 1,
+      ...(siteId && { 'site.$id': siteId }),
+    };
+
+    if (ids.length) {
+      keyParts.push(`ids-${ids.sort().join('|')}`);
+      query._id = { $in: ids };
+    } else {
+      keyParts.push(`names-${names.sort().join('|')}`);
+      query.name = { $in: names };
+    }
+
+    const getFromCache = async (key) => {
+      if (!USE_CACHE_LOADERS) return null;
+      return redis.get(key);
+    };
+
+    const loadAndSet = async (key) => {
+      const now = Date.now();
+      const data = await loadFromDb({ basedb, query });
+      if (USE_CACHE_LOADERS) {
+        redis.set(key, JSON.stringify({ data, ts: now }), 'EX', 60 * 60 * 24 * 365).catch((e) => {
+          if (typeof onCacheError === 'function') onCacheError(e);
+        });
+      }
+      return data;
+    };
+
+    const key = cacheKey({ tenant, loaderType: 'option', parts: keyParts });
+    const response = await getFromCache(key);
+    if (response) {
+      // return the obj, then check the age and do a hit for pass
+      const { data, ts } = JSON.parse(response);
+      // age, in seconds
+      const age = Math.floor((Date.now() - ts) / 1000);
+      const stale = age > refreshMaxAge;
+      // when stale, refresh _in the background_
+      if (stale) {
+        loadAndSet(key).catch((e) => {
+          if (typeof onCacheError === 'function') onCacheError(e);
+        });
+      }
+      if (debug) log('option loader cache hit', { data, age, stale });
+      return data;
+    }
+
+    const data = await loadAndSet(key);
+    return data;
+  };
+};

--- a/services/graphql-server/src/cache-loaders/create-section-descendant-loader.js
+++ b/services/graphql-server/src/cache-loaders/create-section-descendant-loader.js
@@ -1,0 +1,82 @@
+const redis = require('../redis');
+const { cacheKey } = require('./utils');
+const { USE_CACHE_LOADERS } = require('../env');
+
+/**
+ * @typedef {import("@parameter1/base-cms-db/src/basedb.js")} BaseDB
+ */
+
+/**
+ * @param {object} params
+ * @param {BaseDB} params.basedb
+ * @param {number} params.sectionId
+ */
+const loadFromDb = async ({ basedb, sectionId }) => {
+  const section = await basedb.findById('website.Section', sectionId, {
+    projection: { descendantIds: 1 },
+  });
+  const { descendantIds } = section || {};
+  return Array.isArray(descendantIds) ? descendantIds : [];
+};
+
+const { log } = console;
+
+/**
+ *
+ * @param {object} params
+ * @param {BaseDB} params.basedb
+ * @param {Function} [params.onCacheError]
+ * @param {number} [params.refreshMaxAge=3600]
+ * @param {boolean} [params.debug]
+ */
+module.exports = ({
+  basedb,
+  onCacheError,
+  refreshMaxAge = 3600, // every hour, do a background refresh of the data
+  debug = process.env.NODE_ENV === 'development',
+}) => {
+  const { tenant } = basedb;
+  return async ({ sectionId }) => {
+    // if (!id && !alias) return null;
+
+    const keyParts = [];
+    keyParts.push(`id-${sectionId}`);
+
+    const getFromCache = async (key) => {
+      if (!USE_CACHE_LOADERS) return null;
+      return redis.get(key);
+    };
+
+    const loadAndSet = async (key) => {
+      const now = Date.now();
+      const data = await loadFromDb({ basedb, sectionId });
+      if (USE_CACHE_LOADERS) {
+        redis.set(key, JSON.stringify({ data, ts: now }), 'EX', 60 * 60 * 24 * 365).catch((e) => {
+          if (typeof onCacheError === 'function') onCacheError(e);
+        });
+      }
+      return data;
+    };
+
+    const key = cacheKey({ tenant, loaderType: 'section-descendant-ids', parts: keyParts });
+    const response = await getFromCache(key);
+    if (response) {
+      // return the obj, then check the age and do a hit for pass
+      const { data, ts } = JSON.parse(response);
+      // age, in seconds
+      const age = Math.floor((Date.now() - ts) / 1000);
+      const stale = age > refreshMaxAge;
+      // when stale, refresh _in the background_
+      if (stale) {
+        loadAndSet(key).catch((e) => {
+          if (typeof onCacheError === 'function') onCacheError(e);
+        });
+      }
+      if (debug) log('section descendant id loader cache hit', { data, age, stale });
+      return data;
+    }
+
+    const data = await loadAndSet(key);
+    return data;
+  };
+};

--- a/services/graphql-server/src/cache-loaders/create-section-loader.js
+++ b/services/graphql-server/src/cache-loaders/create-section-loader.js
@@ -1,0 +1,101 @@
+const redis = require('../redis');
+const { cacheKey } = require('./utils');
+const { USE_CACHE_LOADERS } = require('../env');
+
+/**
+ * @typedef {import("@parameter1/base-cms-db/src/basedb.js")} BaseDB
+ */
+
+/**
+ * @param {object} params
+ * @param {BaseDB} params.basedb
+ * @param {object} params.query
+ * @param {boolean} params.strict
+ */
+const loadFromDb = ({ basedb, query, strict }) => {
+  const type = 'website.Section';
+  const projection = { _id: 1 };
+  if (strict) {
+    return basedb.strictFindOne(type, query, { projection });
+  }
+  return basedb.findOne(type, query, { projection });
+};
+
+const { log } = console;
+
+/**
+ *
+ * @param {object} params
+ * @param {BaseDB} params.basedb
+ * @param {Function} [params.onCacheError]
+ * @param {number} [params.refreshMaxAge=3600]
+ * @param {boolean} [params.debug]
+ */
+module.exports = ({
+  basedb,
+  onCacheError,
+  refreshMaxAge = 3600, // every hour, do a background refresh of the data
+  debug = process.env.NODE_ENV === 'development',
+}) => {
+  const { tenant } = basedb;
+  return async ({
+    siteId,
+    id,
+    alias,
+    strict = true,
+  }) => {
+    if (!id && !alias) return null;
+
+    const keyParts = [];
+    if (siteId) keyParts.push(`site-${siteId}`);
+
+    const query = {
+      status: 1,
+      ...(siteId && { 'site.$id': siteId }),
+    };
+    if (alias) {
+      keyParts.push(`alias-${alias}`);
+      query.alias = alias;
+    } else {
+      keyParts.push(`id-${id}`);
+      query._id = id;
+    }
+
+    const getFromCache = async (key) => {
+      if (!USE_CACHE_LOADERS) return null;
+      return redis.get(key);
+    };
+
+    const loadAndSet = async (key) => {
+      const now = Date.now();
+      const data = await loadFromDb({ basedb, query, strict });
+      if (USE_CACHE_LOADERS) {
+        redis.set(key, JSON.stringify({ data, ts: now }), 'EX', 60 * 60 * 24 * 365).catch((e) => {
+          if (typeof onCacheError === 'function') onCacheError(e);
+        });
+      }
+      return data;
+    };
+
+    const key = cacheKey({ tenant, loaderType: 'section', parts: keyParts });
+    const response = await getFromCache(key);
+    if (response) {
+      // return the obj, then check the age and do a hit for pass
+      const { data, ts } = JSON.parse(response);
+      // age, in seconds
+      const age = Math.floor((Date.now() - ts) / 1000);
+      const stale = age > refreshMaxAge;
+      // when stale, refresh _in the background_
+      if (stale) {
+        loadAndSet(key).catch((e) => {
+          if (typeof onCacheError === 'function') onCacheError(e);
+        });
+      }
+      if (debug) log('section loader cache hit', { data, age, stale });
+      return data;
+    }
+
+    const data = await loadAndSet(key);
+    return data;
+  };
+};

--- a/services/graphql-server/src/cache-loaders/index.js
+++ b/services/graphql-server/src/cache-loaders/index.js
@@ -1,4 +1,5 @@
 const createSectionLoader = require('./create-section-loader');
+const createSectionDescendantIdLoader = require('./create-section-descendant-loader');
 const createOptionLoader = require('./create-option-loader');
 
 /**
@@ -23,6 +24,13 @@ module.exports = ({
   }),
 
   websiteSection: createSectionLoader({
+    basedb,
+    onCacheError,
+    refreshMaxAge,
+    debug,
+  }),
+
+  websiteSectionDescendantIds: createSectionDescendantIdLoader({
     basedb,
     onCacheError,
     refreshMaxAge,

--- a/services/graphql-server/src/cache-loaders/index.js
+++ b/services/graphql-server/src/cache-loaders/index.js
@@ -1,4 +1,5 @@
 const createSectionLoader = require('./create-section-loader');
+const createOptionLoader = require('./create-option-loader');
 
 /**
  *
@@ -14,6 +15,13 @@ module.exports = ({
   refreshMaxAge = 3600,
   debug = process.env.NODE_ENV === 'development',
 }) => ({
+  websiteOption: createOptionLoader({
+    basedb,
+    onCacheError,
+    refreshMaxAge,
+    debug,
+  }),
+
   websiteSection: createSectionLoader({
     basedb,
     onCacheError,

--- a/services/graphql-server/src/cache-loaders/index.js
+++ b/services/graphql-server/src/cache-loaders/index.js
@@ -1,0 +1,23 @@
+const createSectionLoader = require('./create-section-loader');
+
+/**
+ *
+ * @param {object} params
+ * @param {import("@parameter1/base-cms-db/src/basedb.js")} params.basedb
+ * @param {Function} [params.onCacheError]
+ * @param {number} [params.refreshMaxAge=3600]
+ * @param {boolean} [params.debug]
+ */
+module.exports = ({
+  basedb,
+  onCacheError,
+  refreshMaxAge = 3600,
+  debug = process.env.NODE_ENV === 'development',
+}) => ({
+  websiteSection: createSectionLoader({
+    basedb,
+    onCacheError,
+    refreshMaxAge,
+    debug,
+  }),
+});

--- a/services/graphql-server/src/cache-loaders/utils.js
+++ b/services/graphql-server/src/cache-loaders/utils.js
@@ -1,0 +1,5 @@
+const cacheKeyPrefix = ({ tenant, loaderType }) => `base_gql_cache_loader:${tenant}:${loaderType}`;
+
+const cacheKey = ({ tenant, loaderType, parts }) => `${cacheKeyPrefix({ tenant, loaderType })}:${parts.join(':')}`;
+
+module.exports = { cacheKeyPrefix, cacheKey };

--- a/services/graphql-server/src/env.js
+++ b/services/graphql-server/src/env.js
@@ -36,4 +36,5 @@ module.exports = cleanEnv(process.env, {
   CDN_ASSET_HOSTNAME: nonemptystr({ desc: 'The default CDN hostname for asset delivery', default: 'cdn.base.parameter1.com' }),
   IMAGE_IMPORT_URL: nonemptystr({ desc: 'The BASE image import URL.', default: 'https://opq20fu9p2.execute-api.us-east-1.amazonaws.com/default/base-media-importer' }),
   MOST_POPULAR_CONTENT_API_URL: nonemptystr({ desc: 'The most popular content API URL.', default: 'https://most-popular-content.base.parameter1.com' }),
+  USE_CACHE_LOADERS: bool({ desc: 'Whether to use Redis cache loaders for website section and option loading', default: true }),
 });

--- a/services/graphql-server/src/routes/graphql.js
+++ b/services/graphql-server/src/routes/graphql.js
@@ -13,6 +13,7 @@ const basedbFactory = require('../basedb');
 const createLoaders = require('../dataloaders');
 const schema = require('../graphql/schema');
 const loadSiteContext = require('../site-context/load');
+const createCacheLoaders = require('../cache-loaders');
 const {
   GRAPHQL_ENDPOINT,
   NEW_RELIC_ENABLED,

--- a/services/graphql-server/src/routes/graphql.js
+++ b/services/graphql-server/src/routes/graphql.js
@@ -54,6 +54,10 @@ const server = new ApolloServer({
     };
     const basedb = basedbFactory(tenant, dbContext);
     const loaders = createLoaders(basedb);
+    const cacheLoaders = createCacheLoaders({
+      basedb,
+      onCacheError: newrelic.noticeError.bind(newrelic),
+    });
 
     // Load the (optional) site context from the database.
     const site = await loadSiteContext({
@@ -79,6 +83,7 @@ const server = new ApolloServer({
       site,
       auth,
       userService,
+      cacheLoaders,
       load: async (loader, id, projection, criteria = {}) => {
         if (!loaders[loader]) throw new Error(`No dataloader found for '${loader}'`);
 


### PR DESCRIPTION
The `websiteScheduledContent` query (among others) are querying for sections by alias, options by names, and subsequently loading the section's descendant IDs. These queries are _very_ repetitive, and return datasets that **very** rarely change. To mitigate this, cache loaders were added in front of these queries.

By default, the cache is evaluated every hour by the loader for staleness and, when stale, refreshes the data from MongoDB _in the background_. The net result is that MongoDB queries are reduced by three for every `websiteScheduledContent` GraphQL operation, and the average response time was cut in half (on dev using production MongoDB and Redis, so some network latency does exist with that test). Since these queries are extremely prevalent on implementing websites, the benefits should be significant.

Timing tests (in milliseconds):
<img width="654" alt="image" src="https://user-images.githubusercontent.com/3289485/222991839-4b1bd409-2ff7-4b0a-a1bd-39f6d64982c2.png">
