### PR TITLE
Replace client-side block loader element with incoming HTML

### DIFF
--- a/packages/marko-web-theme-monorail/browser/block-loader.vue
+++ b/packages/marko-web-theme-monorail/browser/block-loader.vue
@@ -1,10 +1,8 @@
 <template>
-  <div :class="classes">
+  <div class="lazyload">
     <div v-if="isLoading">
       Loading {{ label }}...
     </div>
-    <!-- eslint-disable-next-line vue/no-v-html -->
-    <div v-else-if="html" v-html="html" />
     <div v-if="error">
       <h5>Unable to load {{ label }} block.</h5>
       <p>{{ error.message }}</p>
@@ -32,9 +30,7 @@ export default {
   data: () => ({
     error: null,
     hasLoaded: false,
-    html: null,
     isLoading: false,
-    classes: ['lazyload'],
   }),
 
   created() {
@@ -50,8 +46,12 @@ export default {
           const input = JSON.stringify(this.input);
           const href = `/__render-block/${this.name}?input=${encodeURIComponent(input)}`;
           const res = await fetch(href, { credentials: 'same-origin' });
-          this.html = await res.text();
+          const html = await res.text();
           this.hasLoaded = true;
+          const template = document.createElement('template');
+          template.innerHTML = html;
+          const toInsert = template.content.firstChild;
+          this.$el.replaceWith(toInsert);
         } catch (e) {
           this.error = e;
         } finally {

--- a/packages/marko-web-theme-monorail/components/client-side-block-loader.marko
+++ b/packages/marko-web-theme-monorail/components/client-side-block-loader.marko
@@ -1,1 +1,6 @@
-<marko-web-browser-component name="ThemeBlockLoader" props=input />
+$ const { name, label } = input;
+
+<marko-web-browser-component
+  name="ThemeBlockLoader"
+  props={ name, label, input: input.input }
+/>

--- a/packages/marko-web-theme-monorail/components/client-side-blocks/most-popular-list.marko
+++ b/packages/marko-web-theme-monorail/components/client-side-blocks/most-popular-list.marko
@@ -1,1 +1,1 @@
-<theme-client-side-block-loader name="most-popular-list" label="Most Popular Stories" ...input />
+<theme-client-side-block-loader name="most-popular-list" label="Most Popular Stories" input=input />

--- a/packages/marko-web-theme-monorail/components/client-side-blocks/most-popular.marko
+++ b/packages/marko-web-theme-monorail/components/client-side-blocks/most-popular.marko
@@ -1,1 +1,1 @@
-<theme-client-side-block-loader name="most-popular" label="Most Popular Stories" ...input />
+<theme-client-side-block-loader name="most-popular" label="Most Popular Stories" input=input />

--- a/services/example-website/server/templates/index.marko
+++ b/services/example-website/server/templates/index.marko
@@ -40,10 +40,17 @@
       </@section>
 
       <@section>
-        <theme-section-feed-block alias="design">
-          <@header>Event more in Design!</@header>
-          <@query-params skip=4 limit=4 excludeContentIds=[12345678] />
-        </theme-section-feed-block>
+        <div class="row">
+          <div class="col-lg-8">
+            <theme-section-feed-block alias="design">
+              <@header>Even more in Design!</@header>
+              <@query-params skip=4 limit=8 excludeContentIds=[12345678] />
+            </theme-section-feed-block>
+          </div>
+          <div class="col-lg-4">
+            <theme-client-side-most-popular-list-block class="sticky-top" />
+          </div>
+        </div>
       </@section>
 
       <@section>


### PR DESCRIPTION
Ensures that the loaded block HTML is _not_ wrapped by the `div` elements of the block loader Vue component. This fixes broken features like `sticky-top` classes.

In addition, adjust `input` spread so target inputs of `name` and `label` also get passed to the remote call.