### PR TITLE
Drop `max-height` from line-clamp mixins

### DIFF
--- a/packages/marko-web-theme-default/scss/_mixins.scss
+++ b/packages/marko-web-theme-default/scss/_mixins.scss
@@ -250,14 +250,9 @@
   $breakpoint: $theme-responsive-text-max-lines-breakpoint,
 ) {
   display: -webkit-box;
-  max-height: ($font-size * $line-height) * $num;
   overflow: hidden;
-  text-overflow: $text-overflow;
   -webkit-line-clamp: $num;
   -webkit-box-orient: vertical;
-  @include media-breakpoint-down($breakpoint) {
-    max-height: ($font-size-sm * $line-height-sm) * $num;
-  }
 }
 // stylelint-enable value-no-vendor-prefix, property-no-vendor-prefix
 

--- a/packages/marko-web-theme-monorail/scss/theme-default/_mixins.scss
+++ b/packages/marko-web-theme-monorail/scss/theme-default/_mixins.scss
@@ -250,14 +250,9 @@
   $breakpoint: $theme-responsive-text-max-lines-breakpoint,
 ) {
   display: -webkit-box;
-  max-height: ($font-size * $line-height) * $num;
   overflow: hidden;
-  text-overflow: $text-overflow;
   -webkit-line-clamp: $num;
   -webkit-box-orient: vertical;
-  @include media-breakpoint-down($breakpoint) {
-    max-height: ($font-size-sm * $line-height-sm) * $num;
-  }
 }
 // stylelint-enable value-no-vendor-prefix, property-no-vendor-prefix
 


### PR DESCRIPTION
Now that our browser targets are [modern](https://caniuse.com/css-line-clamp), there's no need to fallback to max-height values when line clamping.