### PR TITLE
Optimize RSS queries

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -553,6 +553,8 @@ input AllPublishedContentQueryInput {
   ending: ContentEndingInput = {}
   "Limit results using the updated (modified) date."
   updated: ContentUpdatedInput = {}
+  "Whether the query should be optimized for RSS."
+  rssOptimized: Boolean
 }
 
 input AllPublishedContentDatesQueryInput {
@@ -702,6 +704,8 @@ input WebsiteScheduledContentQueryInput {
   ending: ContentEndingInput = {}
   "Limit results using the updated (modified) date."
   updated: ContentUpdatedInput = {}
+  "Whether the query should be optimized for RSS."
+  rssOptimized: Boolean
 }
 
 input RelatedPublishedContentQueryInput {

--- a/services/graphql-server/src/graphql/instropection/get-return-type.js
+++ b/services/graphql-server/src/graphql/instropection/get-return-type.js
@@ -1,0 +1,4 @@
+module.exports = function getReturnType(type) {
+  if (type.ofType) return getReturnType(type.ofType);
+  return type;
+}

--- a/services/graphql-server/src/graphql/instropection/get-return-type.js
+++ b/services/graphql-server/src/graphql/instropection/get-return-type.js
@@ -1,4 +1,4 @@
 module.exports = function getReturnType(type) {
   if (type.ofType) return getReturnType(type.ofType);
   return type;
-}
+};

--- a/services/graphql-server/src/graphql/instropection/has-selections.js
+++ b/services/graphql-server/src/graphql/instropection/has-selections.js
@@ -1,0 +1,5 @@
+module.exports = function hasSelections(paths, introspected) {
+  return paths.reduce((o, path) => ({
+    ...o, [path]: introspected.has(path),
+  }), {});
+};

--- a/services/graphql-server/src/graphql/instropection/index.js
+++ b/services/graphql-server/src/graphql/instropection/index.js
@@ -1,0 +1,11 @@
+const getReturnType = require('./get-return-type');
+const hasSelections = require('./has-selections');
+const introspect = require('./introspect');
+const introspectFromInfo = require('./introspect-from-info');
+
+module.exports = {
+  getReturnType,
+  hasSelections,
+  introspect,
+  introspectFromInfo,
+};

--- a/services/graphql-server/src/graphql/instropection/introspect-from-info.js
+++ b/services/graphql-server/src/graphql/instropection/introspect-from-info.js
@@ -1,0 +1,7 @@
+const introspect = require('./introspect');
+
+module.exports = (info, { shallow = false } = {}) => introspect({
+  ...info,
+  selectionSet: info.fieldNodes[0].selectionSet,
+  shallow,
+});

--- a/services/graphql-server/src/graphql/instropection/introspect.js
+++ b/services/graphql-server/src/graphql/instropection/introspect.js
@@ -1,0 +1,78 @@
+const { Kind } = require('graphql/language');
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+const getReturnType = require('./get-return-type');
+
+module.exports = function introspect({
+  selectionSet,
+  returnType,
+  schema,
+  fragments,
+  shallow = false,
+}, { parentFieldPath = '', map = new Map() } = {}) {
+  const selections = getAsArray(selectionSet, 'selections');
+  if (!selections.length) return map;
+
+  const typeObj = getReturnType(returnType);
+  const typeObjFieldMap = typeObj.getFields();
+
+  selections.forEach((selection) => {
+    if (selection.kind === Kind.FIELD) {
+      const { value: fieldName } = selection.name;
+      const field = typeObjFieldMap[fieldName];
+      if (!field) return; // special fields, such as __typename, will not have a field
+      const path = parentFieldPath ? `${parentFieldPath}.${fieldName}` : fieldName;
+
+      if (parentFieldPath) {
+        const parent = map.get(parentFieldPath);
+        parent.children.add(path);
+      }
+
+      if (!map.has(path)) {
+        // set...
+        map.set(path, {
+          field,
+          selections: [],
+          isRoot: Boolean(!parentFieldPath),
+          children: new Set(),
+        });
+      }
+      // then merge...
+      const currentSelections = map.get(path).selections;
+      // eslint-disable-next-line no-param-reassign
+      map.get(path).selections = [
+        ...currentSelections,
+        ...getAsArray(selection, 'selectionSet.selections'),
+      ];
+
+      if (!shallow) {
+        introspect({
+          selectionSet: selection.selectionSet,
+          returnType: field.type,
+          schema,
+          fragments,
+        }, { parentFieldPath: path, map });
+      }
+    }
+
+    if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const fragment = fragments[selection.name.value];
+
+      introspect({
+        selectionSet: fragment.selectionSet,
+        returnType: schema.getType(fragment.typeCondition.name.value),
+        schema,
+        fragments,
+      }, { parentFieldPath, map });
+    }
+
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      introspect({
+        selectionSet: selection.selectionSet,
+        returnType: schema.getType(selection.typeCondition.name.value),
+        schema,
+        fragments,
+      }, { parentFieldPath, map });
+    }
+  });
+  return map;
+};

--- a/services/graphql-server/src/graphql/utils/optimize-for-rss.js
+++ b/services/graphql-server/src/graphql/utils/optimize-for-rss.js
@@ -1,0 +1,29 @@
+const preloadRelMany = require('./preload-rel-many');
+
+module.exports = async (paginated, { basedb, info }) => {
+  const edges = paginated.edges();
+
+  const preloaded = await preloadRelMany({
+    basedb,
+    owningEdges: edges,
+    info,
+    targets: [
+      {
+        dbPath: 'images',
+        selectionPath: 'edges.node.images.edges.node',
+        modelName: 'platform.Asset',
+        criteria: { type: 'Image' },
+      },
+      {
+        dbPath: 'authors',
+        selectionPath: 'edges.node.authors.edges.node',
+        modelName: 'platform.Content',
+        criteria: { type: 'Contact', status: 1 },
+      },
+    ],
+  });
+  return {
+    ...paginated,
+    edges: preloaded,
+  };
+};

--- a/services/graphql-server/src/graphql/utils/preload-rel-many.js
+++ b/services/graphql-server/src/graphql/utils/preload-rel-many.js
@@ -1,0 +1,79 @@
+const { BaseDB } = require('@parameter1/base-cms-db');
+const { getAsArray, set } = require('@parameter1/base-cms-object-path');
+const { introspectFromInfo, getReturnType } = require('../instropection');
+const getProjection = require('./get-projection');
+
+/**
+ * @typedef PaginatedEdge
+ * @prop {object} node
+ * @prop {Function} cursor
+ *
+ * @typedef PreloadRelManyTarget
+ * @prop {string} dbPath
+ * @prop {string} selectionPath
+ * @prop {string} modelName
+ * @prop {object} [criteria]
+ *
+ * @param {object} params
+ * @param {BaseDB} params.basedb
+ * @param {PaginatedEdge[]} params.owningEdges
+ * @param {import("graphql").GraphQLResolveInfo} params.info
+ * @param {PreloadRelManyTarget[]} params.targets
+ */
+module.exports = async ({
+  basedb,
+  owningEdges,
+  info,
+  targets,
+}) => {
+  const introspected = introspectFromInfo(info);
+
+  const maps = await Promise.all(targets.map(async ({
+    dbPath,
+    selectionPath,
+    modelName,
+    criteria,
+  }) => {
+    const { selections = [], field } = introspected.get(selectionPath) || {};
+    if (!selections.length) return new Map(); // nothing selected for this field.
+
+    // extract the mongodb projection
+    const projection = getProjection(
+      info.schema,
+      getReturnType(field.type),
+      { selections },
+      info.fragments,
+    );
+
+    // extract the referenced/related IDs.
+    const ids = owningEdges.reduce((arr, { node }) => {
+      arr.push(...BaseDB.extractRefIds(getAsArray(node, dbPath)));
+      return arr;
+    }, []);
+
+    // load all related models using the projection based on the selection set.
+    const docs = ids.length
+      ? await basedb.find(modelName, { _id: { $in: ids }, ...criteria }, { projection })
+      : [];
+
+    // map related models by ID.
+    return {
+      dbPath,
+      mapped: docs.reduce((map, doc) => {
+        map.set(`${doc._id}`, doc);
+        return map;
+      }, new Map()),
+    };
+  }));
+
+  return owningEdges.map((edge) => {
+    const node = { ...edge.node };
+    maps.forEach(({ dbPath, mapped }) => {
+      set(node, dbPath, BaseDB.extractRefIds(getAsArray(node, dbPath)).map((id) => {
+        const doc = mapped.get(`${id}`);
+        return doc;
+      }).filter((doc) => doc));
+    });
+    return { ...edge, node };
+  });
+};

--- a/services/rss/src/routes/all-published-content.js
+++ b/services/rss/src/routes/all-published-content.js
@@ -26,7 +26,9 @@ module.exports = asyncRoute(async (req, res) => {
     mountHref,
   } = res.locals;
 
-  const { data } = await apollo.query({ query, variables: { input } });
+  const { data } = await apollo.query({
+    query, variables: { input: { ...input, rssOptimized: true } },
+  });
   const { edges } = data.allPublishedContent;
 
   const parts = [

--- a/services/rss/src/routes/website-scheduled-content.js
+++ b/services/rss/src/routes/website-scheduled-content.js
@@ -43,7 +43,9 @@ module.exports = asyncRoute(async (req, res) => {
     mountHref,
   } = res.locals;
 
-  const { data } = await apollo.query({ query, variables: { input } });
+  const { data } = await apollo.query({
+    query, variables: { input: { ...input, rssOptimized: true } },
+  });
   const { section, edges } = data.websiteScheduledContent;
 
   const parts = [


### PR DESCRIPTION
Adds the `optimizeRss` input to `websiteScheduledContent` and `allPublishedContent` queries where, when set, the `authors` and `images` for the returned content documents are preloaded, thereby preventing the O(n) ref-many issue.

The `optimizeRss` input is off be default except for in the Apollo queries that originate from the RSS service.

To accomplish these tasks, `introspection` utilities were created for reading the GraphQL operation selection sets.