### PR TITLE
Support route sub-kinds (types) for critical CSS

### DIFF
--- a/packages/marko-web/components/document/components/styles.marko
+++ b/packages/marko-web/components/document/components/styles.marko
@@ -9,8 +9,8 @@ $ const { kind } = route;
   <link rel="stylesheet" href=css.purged() />
 </else-if>
 <else>
-  $ const critical = css.critical({ kind });
-  $ const optimized = css.optimized({ kind });
+  $ const critical = css.critical(route);
+  $ const optimized = css.optimized(route);
   <if(critical)>
     <style>${critical}</style>
   </if>

--- a/packages/web-cli/build/utils/css.js
+++ b/packages/web-cli/build/utils/css.js
@@ -114,14 +114,18 @@ const buildPurged = async ({ cwd, source, contentDirs = [] }) => {
  * @returns {Promise<CSSOutputAsset[]>}
  */
 const buildCriticals = async ({ source }) => {
-  // extract the critical modules names that are in-use (if any)
-  /** @type {string[]} */
-  const modules = [...(source.match(/\/\*!\s*?critical.*?\s*?\*\//g) || []).reduce((set, match) => {
-    if (/:end/.test(match)) return set;
+  // extract the critical module kinds (to sub-types, if present) that are in-use (if any)
+  /** @type {Map<string, Set<string>>} */
+  const modules = (source.match(/\/\*!\s*?critical.*?\s*?\*\//g) || []).reduce((map, match) => {
+    if (/:end/.test(match)) return map;
     const matches = /\|(.+[^\s*?])\s*?\*\//.exec(match);
-    if (matches && matches[1]) set.add(matches[1]);
-    return set;
-  }, new Set())];
+    if (matches && matches[1]) {
+      const [kind, type] = matches[1].split('.');
+      if (!map.has(kind)) map.set(kind, new Set());
+      if (type) map.get(kind).add(type);
+    }
+    return map;
+  }, new Map());
 
   const keys = ['critical', 'optimized'];
   const settings = [];
@@ -132,12 +136,20 @@ const buildCriticals = async ({ source }) => {
       output: key === 'critical' ? key : 'rest',
     };
     settings.push(opts);
-    modules.forEach((name) => {
+    modules.forEach((types, kind) => {
       settings.push({
         ...opts,
-        key: `${key}-${name}`,
-        modules: [name],
+        key: `${key}-${kind}`,
+        modules: [kind],
         separator: '|',
+      });
+      types.forEach((type) => {
+        settings.push({
+          ...opts,
+          key: `${key}-${kind}-${type}`,
+          modules: [kind, `${kind}.${type}`],
+          separator: '|',
+        });
       });
     });
   });
@@ -182,7 +194,8 @@ const write = async ({ cwd, dir, assets }) => {
     // ensure charset is present. critical files will likely drop this.
     const s = /^@charset/.test(source) ? source : `@charset "UTF-8";${source}`;
     const hash = createHash(s);
-    const file = `${asset.key}-${hash}.css`;
+    // ensure asset key is safe to save
+    const file = `${asset.key.replace(/[^a-z0-9_-]/gi, '-')}-${hash}.css`;
 
     const compressed = await new Promise((resolve, reject) => {
       gzip(s, (err, r) => {

--- a/packages/web-cli/build/utils/css.js
+++ b/packages/web-cli/build/utils/css.js
@@ -146,7 +146,7 @@ const buildCriticals = async ({ source }) => {
       types.forEach((type) => {
         settings.push({
           ...opts,
-          key: `${key}-${kind}-${type}`,
+          key: `${key}-${kind}.${type}`,
           modules: [kind, `${kind}.${type}`],
           separator: '|',
         });


### PR DESCRIPTION
Critical extraction can now be refined by not only the route kind (e.g. `content` or `website-section`) but by the types of content or sections being loaded. Given the following example: 

```scss

p {
  /*! critical|content.article */
  /*! critical|content.company */
  color: red;
}

/*! critical:start|content.article */
strong {
  font-weight: bolder;
}
/*! critical:end */


/*! critical:start|content */
h1 {
  column-rule: 0cap;
}
/*! critical:end */

/*! critical:start|website-section.foo */
em {
  color: yellow;
}
/*! critical:end */

i {
  /*! critical|dynamic-page */
  color: red
}


/*! critical:start */
body {
  -webkit-font-smoothing: antialiased;
  letter-spacing: .25px;
}

.document-container {
  padding-top: 0;
}

.page {
  &:first-child {
    padding-top: 1rem;
  }
  &:last-child {
    padding-bottom: 1rem;
  }
  &--home {
    &:first-child {
      padding-top: 0;
    }
  }
}
/*! critical:end */
```

The following would be true:
- _all_ pages would have the `body`, `.document-container` and `.page` declarations treated as critical
- all _content_ pages would extract the `h1` as critical
- content _article_ pages would extract the `h1` (since all content has it), `p` and `strong` declarations
- content _company_ pages would extract the `h1` (since all content has it) and `p` declarations
- only the `foo` alias on _website-section_ pages would extract the `em` declaration.