### PR TITLE
Add `lazyload-first-image` option to embedded images in content bodies

### DIFF
--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -67,7 +67,14 @@ $ const gamAdInjection = (GAM) ? [
   to-render=MarkoWebContentBody
   selector=`#${selector}`
 >
-  <@component-input block-name=blockName modifiers=modifiers obj=content attrs={ id: selector } />
+  <@component-input
+    block-name=blockName
+    modifiers=modifiers
+    obj=content
+    attrs={ id: selector }
+    embedOptions=input.embedOptions
+    firstImageEmbedOptions=input.firstImageEmbedOptions
+  />
   <if(!preventHTMLInjection)>
     <for|adInjection| of=gamAdInjection>
       $ const { counts, name, modifiers } = adInjection;

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -72,8 +72,8 @@ $ const gamAdInjection = (GAM) ? [
     modifiers=modifiers
     obj=content
     attrs={ id: selector }
-    embedOptions=input.embedOptions
-    firstImageEmbedOptions=input.firstImageEmbedOptions
+    embed-options=input.embedOptions
+    lazyload-first-image=input.lazyloadFirstImage
   />
   <if(!preventHTMLInjection)>
     <for|adInjection| of=gamAdInjection>

--- a/packages/marko-web/components/element/content/body.marko
+++ b/packages/marko-web/components/element/content/body.marko
@@ -1,4 +1,5 @@
 import { get, getAsObject } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import extractRender from "../extract-render";
 
 $ const { parseEmbeddedMedia, res } = out.global;
@@ -6,7 +7,7 @@ $ const { parseEmbeddedMedia, res } = out.global;
 $ const body = get(input.obj, "body");
 $ const v = body == null ? "" : `${body}`.trim();
 $ const embedOptions = getAsObject(input, "embedOptions");
-$ const lazyloadFirstImage = getAsObject(input, "lazyloadFirstImage");
+$ const lazyloadFirstImage = defaultValue(input.lazyloadFirstImage, true);
 $ const obj = { body: parseEmbeddedMedia(v, res, embedOptions, lazyloadFirstImage) };
 
 <marko-web-obj-text

--- a/packages/marko-web/components/element/content/body.marko
+++ b/packages/marko-web/components/element/content/body.marko
@@ -5,8 +5,9 @@ $ const { parseEmbeddedMedia, res } = out.global;
 
 $ const body = get(input.obj, "body");
 $ const v = body == null ? "" : `${body}`.trim();
-$ const obj = { body: parseEmbeddedMedia(v, res, embedOptions) };
 $ const embedOptions = getAsObject(input, "embedOptions");
+$ const firstImageEmbedOptions = getAsObject(input, "firstImageEmbedOptions");
+$ const obj = { body: parseEmbeddedMedia(v, res, embedOptions, firstImageEmbedOptions) };
 
 <marko-web-obj-text
   type="content"

--- a/packages/marko-web/components/element/content/body.marko
+++ b/packages/marko-web/components/element/content/body.marko
@@ -5,8 +5,8 @@ $ const { parseEmbeddedMedia, res } = out.global;
 
 $ const body = get(input.obj, "body");
 $ const v = body == null ? "" : `${body}`.trim();
-$ const embedOptions = getAsObject(input, "embedOptions")
 $ const obj = { body: parseEmbeddedMedia(v, res, embedOptions) };
+$ const embedOptions = getAsObject(input, "embedOptions");
 
 <marko-web-obj-text
   type="content"

--- a/packages/marko-web/components/element/content/body.marko
+++ b/packages/marko-web/components/element/content/body.marko
@@ -6,8 +6,8 @@ $ const { parseEmbeddedMedia, res } = out.global;
 $ const body = get(input.obj, "body");
 $ const v = body == null ? "" : `${body}`.trim();
 $ const embedOptions = getAsObject(input, "embedOptions");
-$ const firstImageEmbedOptions = getAsObject(input, "firstImageEmbedOptions");
-$ const obj = { body: parseEmbeddedMedia(v, res, embedOptions, firstImageEmbedOptions) };
+$ const lazyloadFirstImage = getAsObject(input, "lazyloadFirstImage");
+$ const obj = { body: parseEmbeddedMedia(v, res, embedOptions, lazyloadFirstImage) };
 
 <marko-web-obj-text
   type="content"

--- a/packages/marko-web/express/embedded-media.js
+++ b/packages/marko-web/express/embedded-media.js
@@ -11,13 +11,14 @@ module.exports = (app, { image, oembed, invalid } = {}) => {
   };
 
   // eslint-disable-next-line no-param-reassign
-  app.locals.parseEmbeddedMedia = (body, res, options) => {
+  app.locals.parseEmbeddedMedia = (body, res, options, firstImageOptions) => {
     const $global = buildMarkoGlobal(res);
 
-    const replacements = extractEmbeddedTags(body).map((tag) => {
+    const replacements = extractEmbeddedTags(body).map((tag, index) => {
       const type = ['image', 'oembed'].includes(tag.type) && tag.isValid() ? tag.type : 'invalid';
       const pattern = tag.getRegExp();
-      const replacement = handlers[type](tag, $global, options);
+      const replacementOptions = (index === 0 && type === 'image') ? firstImageOptions : options;
+      const replacement = handlers[type](tag, $global, replacementOptions);
       return { pattern, replacement };
     });
 

--- a/packages/marko-web/express/embedded-media.js
+++ b/packages/marko-web/express/embedded-media.js
@@ -11,13 +11,13 @@ module.exports = (app, { image, oembed, invalid } = {}) => {
   };
 
   // eslint-disable-next-line no-param-reassign
-  app.locals.parseEmbeddedMedia = (body, res, options, firstImageOptions) => {
+  app.locals.parseEmbeddedMedia = (body, res, options, lazyloadFirstImage = true) => {
     const $global = buildMarkoGlobal(res);
 
     const replacements = extractEmbeddedTags(body).map((tag, index) => {
       const type = ['image', 'oembed'].includes(tag.type) && tag.isValid() ? tag.type : 'invalid';
       const pattern = tag.getRegExp();
-      const replacementOptions = (index === 0 && type === 'image') ? firstImageOptions : options;
+      const replacementOptions = (index === 0 && type === 'image' && !lazyloadFirstImage) ? { ...options, lazyloadImages: false } : options;
       const replacement = handlers[type](tag, $global, replacementOptions);
       return { pattern, replacement };
     });


### PR DESCRIPTION
Allows `{ lazyloadFirstImage: false }` to be optionally passed through and applied if the first detected embed is an image.

Use case is where the primary image is not automatically included above the content body.