### PR TITLE
Extract file assets found within CSS files during build

### DIFF
--- a/packages/web-cli/bin/index.js
+++ b/packages/web-cli/bin/index.js
@@ -3,7 +3,12 @@
 /* eslint-disable global-require */
 const minimist = require('minimist');
 const log = require('fancy-log');
-const { blue, gray, green } = require('chalk');
+const {
+  blue,
+  gray,
+  green,
+  red,
+} = require('chalk');
 
 const { isArray } = Array;
 log('cli starting...');
@@ -116,4 +121,7 @@ const commands = new Set(['build', 'build:css', 'build:js', 'build:ssr', 'dev', 
     return exit(`command '${blue(command)}' ${green('complete')}`);
   }
   return null;
-})().catch((e) => setImmediate(() => { throw e; }));
+})().catch((e) => {
+  log(e, '\n', red('AN ERROR OCCURED.'));
+  process.exit(1);
+});

--- a/packages/web-cli/build/css.js
+++ b/packages/web-cli/build/css.js
@@ -7,7 +7,7 @@ const {
   buildMain,
   buildManifest,
   buildPurged,
-  getMainCSSFromOutput,
+  getMainCSSFromRollup,
   logBuildStep,
   minify,
   write,
@@ -17,6 +17,7 @@ const { log } = console;
 
 /**
  * @typedef {import("./utils/css.js").RollupWatcher} RollupWatcher
+ * @typedef {import("./utils/css.js").MainCSSResult} MainCSSResult
  *
  * @param {object} params
  * @param {string} params.cwd
@@ -36,14 +37,18 @@ module.exports = async ({
 
   /**
    *
-   * @param {object} params
-   * @param {CSSOutputAsset} params.main
+   * @param {MainCSSResult} result
    */
-  const build = async ({ main }) => {
+  const build = async ({ main, assets }) => {
     const purged = await buildPurged({ cwd, source: main.source, contentDirs: purgeContentDirs });
     const criticals = await buildCriticals({ source: purged.source });
     const minified = await minify({ assets: [main, purged, ...criticals] });
-    const written = await write({ cwd, dir, assets: minified });
+    const written = await write({
+      cwd,
+      dir,
+      assets: minified,
+      files: assets,
+    });
     await buildManifest({ cwd, dir, written });
     return written;
   };
@@ -53,11 +58,12 @@ module.exports = async ({
     logBuildStep();
 
     // clean directory
+    await rm(path.resolve(cwd, dir, 'assets'), { recursive: true, force: true });
     await rm(path.resolve(cwd, dir), { recursive: true, force: true });
 
-    /** @type {CSSOutputAsset} */
+    /** @type {MainCSSResult} */
     const main = await buildMain({ cwd, entry, watch: false });
-    await build({ main });
+    await build(main);
     return;
   }
 
@@ -77,16 +83,23 @@ module.exports = async ({
     if (code === 'BUNDLE_END') {
       const start = process.hrtime();
       await (async () => {
-        const { output } = await event.result.generate({
+        const result = await event.result.generate({
+          assetFileNames: '[name]-[hash][extname]',
           dir: path.resolve(cwd, dir),
         });
 
-        const main = getMainCSSFromOutput(output);
-        const written = await build({ main });
+        const main = await getMainCSSFromRollup(entry, result);
+        const written = await build(main);
 
         // clean old files
-        const pathsToDelete = written.map(({ file }) => `!${path.resolve(dir, file)}`);
-        await del([path.resolve(dir, './*.css'), ...pathsToDelete]);
+        await del([
+          path.resolve(dir, './*.css'),
+          ...written.css.map(({ file }) => `!${path.resolve(dir, file)}`),
+        ]);
+        await del([
+          path.resolve(dir, './assets/*'),
+          ...written.assets.map(({ file }) => `!${path.resolve(dir, file)}`),
+        ]);
         const [secs, ns] = process.hrtime(start);
         log(cyan(`built css in ${Math.ceil((secs * 1000) + (ns / 1000000))}ms.`));
       })().then(() => {

--- a/packages/web-cli/build/css.js
+++ b/packages/web-cli/build/css.js
@@ -97,8 +97,8 @@ module.exports = async ({
   });
 
   await new Promise((resolve, reject) => {
-    watcher.on('event', ({ code }) => {
-      if (code === 'ERROR') reject();
+    watcher.on('event', ({ code, error }) => {
+      if (code === 'ERROR') reject(error);
       if (code === 'END') resolve();
     });
   });

--- a/packages/web-cli/package.json
+++ b/packages/web-cli/package.json
@@ -45,6 +45,7 @@
     "mkdirp": "^2.1.3",
     "postcss": "^8.4.21",
     "postcss-critical-split": "mrnocreativity/postcss-critical-split#51bb6d62bc75d635e32dcce90f30ba3ef6299081",
+    "postcss-url": "^10.1.3",
     "purgecss": "^5.0.0",
     "sass": "^1.58.3",
     "vite": "^4.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3587,6 +3587,11 @@ csstype@^3.1.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==
+
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
@@ -7460,7 +7465,7 @@ macos-release@^2.2.0:
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.0.tgz#067c2c88b5f3fb3c56a375b2ec93826220fa1ff2"
   integrity sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==
 
-make-dir@3.1.0:
+make-dir@3.1.0, make-dir@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -7728,6 +7733,11 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mime@~2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
+  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -7785,6 +7795,13 @@ minimatch@^5.0.1:
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimatch@~3.0.4:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.8.tgz#5e6a59bd11e2ab0de1cfb843eb2d82e546c321c1"
+  integrity sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimist-options@4.1.0:
   version "4.1.0"
@@ -9420,6 +9437,16 @@ postcss-unique-selectors@^5.1.1:
   integrity sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==
   dependencies:
     postcss-selector-parser "^6.0.5"
+
+postcss-url@^10.1.3:
+  version "10.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-url/-/postcss-url-10.1.3.tgz#54120cc910309e2475ec05c2cfa8f8a2deafdf1e"
+  integrity sha512-FUzyxfI5l2tKmXdYc6VTu3TWZsInayEKPbiyW+P6vmmIrrb4I6CGX0BFoewgYHLK+oIL5FECEK02REYRpBvUCw==
+  dependencies:
+    make-dir "~3.1.0"
+    mime "~2.5.2"
+    minimatch "~3.0.4"
+    xxhashjs "~0.2.2"
 
 postcss-value-parser@^4.2.0:
   version "4.2.0"
@@ -11893,6 +11920,13 @@ xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+xxhashjs@~0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
Fixes an issue where CSS file assets via `url()` calls were not being properly extracted and saved. Found file assets are now saved to the `dist/css/assets` folder and their corresponding `url()` references within the CSS files are rewritten to be relative to the root CSS file. This ensures that the assets will be found when being served by the CDN or locally from Express.