### PR TITLE
Update assets path to point at self

### DIFF
--- a/packages/marko-web-photoswipe/scss/main.scss
+++ b/packages/marko-web-photoswipe/scss/main.scss
@@ -1,4 +1,4 @@
-$pswp__assets-path: "/dist/assets/" !default;
+$pswp__assets-path: "photoswipe/dist/default-skin/" !default;
 $pswp__background-color: rgba(0, 0, 0, .9) !default;
 
 @import "photoswipe/src/css/main";


### PR DESCRIPTION
Now that new build process can resolve modules, the Photoswipe asset path needs to point at it’s own dist folder for resolving it’s image assets.