### PR TITLE
Line up structured data for Companies with Schema.org definition for `Organization`

### DIFF
--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -109,7 +109,7 @@ module.exports = (node) => {
       ...(get(node, 'metadata.description') && { description: get(node, 'metadata.description') }),
       ...(getImages(node) && { image: getImages(node) }),
       url: canonicalUrl,
-      ...(siteUrl !== canonicalUrl && { url: siteUrl }),
+      ...(siteUrl !== canonicalUrl && { url: { url: siteUrl, isBasedOn: canonicalUrl } }),
       ...(address && { address }),
       ...(telephone && { telephone }),
       ...(get(node, 'email') && { email: get(node, 'email') }),

--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -30,7 +30,7 @@ module.exports = (node) => {
   const siteUrl = get(node, 'siteContext.url');
   const canonicalUrl = get(node, 'siteContext.canonicalUrl');
 
-  const defaultStruturedData = {
+  const defaultStructuredData = {
     '@context': 'https://schema.org',
     '@type': 'Article',
     mainEntityOfPage: {
@@ -51,7 +51,7 @@ module.exports = (node) => {
 
   if (node.type === 'video') {
     return JSON.stringify({
-      ...defaultStruturedData,
+      ...defaultStructuredData,
       '@type': 'VideoObject',
       uploadDate: publishedISOString,
       contentUrl: get(node, 'siteContext.canonicalUrl'),
@@ -70,7 +70,7 @@ module.exports = (node) => {
       }
       : undefined;
     return JSON.stringify({
-      ...defaultStruturedData,
+      ...defaultStructuredData,
       '@type': 'PodcastEpisode',
       headline: get(node, 'metadata.title'),
       ...(associatedMedia && { associatedMedia }),
@@ -99,19 +99,28 @@ module.exports = (node) => {
     const telephone = get(node, 'tollfree') || get(node, 'phone');
 
     return JSON.stringify({
-      ...defaultStruturedData,
+      '@context': 'https://schema.org',
       '@type': 'Organization',
-      address,
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': get(node, 'siteContext.canonicalUrl'),
+      },
+      name: get(node, 'metadata.title'),
+      ...(get(node, 'metadata.description') && { description: get(node, 'metadata.description') }),
+      ...(getImages(node) && { image: getImages(node) }),
+      url: canonicalUrl,
+      ...(siteUrl !== canonicalUrl && { url: siteUrl }),
+      ...(address && { address }),
       ...(telephone && { telephone }),
-      ...(get(node, 'metadata.image.src') && { logo: get(node, 'metadata.image.src') }),
       ...(get(node, 'email') && { email: get(node, 'email') }),
+      ...(get(node, 'metadata.image.src') && { logo: get(node, 'metadata.image.src') }),
       ...(get(node, 'fax') && { faxNumber: get(node, 'fax') }),
     });
   }
 
   if (['article', 'news'].includes(node.type)) {
     return JSON.stringify({
-      ...defaultStruturedData,
+      ...defaultStructuredData,
       '@type': 'NewsArticle',
       headline: get(node, 'metadata.title'),
     });


### PR DESCRIPTION
Removes the following:

`datePublished
dateModified
thumbnailUrl
headline`

MOVES the following `isBasedOn` from `root` to `url.isBasedOn`

Previously these were inheriting the same fields as `"@type": 'Article'` through spreading `defaultStruturedData` (now corrected to `defaultStructuredData`) prior to the additions of any company/organization specific fields, however due to https://schema.org/Article inheriting from https://schema.org/CreativeWork and https://schema.org/Organization **not** this causes some of those included schema definitions like `datePublished` or `headline` to be invalid as they aren't a part of the definition for https://schema.org/Organization additionally this alters the location for `isBasedOn` from the root of the schema to `url.isBasedOn` when working with the Organization schema type/definition.

PROD:
![Screenshot from 2023-03-23 11-17-05](https://user-images.githubusercontent.com/46794001/227267473-bed550a0-86ae-4d75-9202-5c292f3af495.png)

DEV:
![Screenshot from 2023-03-23 11-17-11](https://user-images.githubusercontent.com/46794001/227267507-77837e43-00ed-48bb-a56a-d6eda8ce3187.png)

Ref:
https://schema.org/Organization
https://schema.org/Article
https://github.com/parameter1/pmmi-prosource/pull/29
https://github.com/parameter1/pmmi-prosource/pull/30
https://trello.com/c/BNFf0dgc/491-seo-prosource-18-structure-data-items-are-invalid