### PR TITLE
Allow Leaders Contextual to load sections by content schedules.

### DIFF
--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -328,7 +328,7 @@ export default {
         const scheduledSections = getAsArray(r1, 'data.content.websiteSchedules');
         if (scheduledSections.length) {
           sectionIds.push(
-            ...scheduledSections.map((scheduledSection) => scheduledSection.section.id)
+            ...scheduledSections.map((scheduledSection) => scheduledSection.section.id),
           );
         }
       }

--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -57,6 +57,7 @@ import fromIdsQuery from '../graphql/queries/sections-from-ids';
 import contentQuery from '../graphql/queries/content';
 import getEdgeNodes from '../utils/get-edge-nodes';
 import getAsObject from '../utils/get-as-object';
+import getAsArray from '../utils/get-as-array';
 
 export default {
   components: {
@@ -172,6 +173,10 @@ export default {
       default: 3,
     },
     useContentPrimarySection: {
+      type: Boolean,
+      default: false,
+    },
+    useContentSchedules: {
       type: Boolean,
       default: false,
     },
@@ -318,6 +323,12 @@ export default {
       if (this.useContentPrimarySection) {
         const primarySection = getAsObject(r1, 'data.content.primarySection');
         if (primarySection.id) sectionIds.push(primarySection.id);
+      }
+      if (this.useContentSchedules) {
+        const scheduledSections = getAsArray(r1, 'data.content.websiteSchedules');
+        if (scheduledSections.length) {
+          sectionIds.push(...scheduledSections.map((scheduledSection) => scheduledSection.section.id));
+        }
       }
       if (!taxonomyIds.length && !sectionIds.length) return [];
       const v2 = { taxonomyIds, relatedSectionIds: sectionIds };

--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -327,7 +327,9 @@ export default {
       if (this.useContentSchedules) {
         const scheduledSections = getAsArray(r1, 'data.content.websiteSchedules');
         if (scheduledSections.length) {
-          sectionIds.push(...scheduledSections.map((scheduledSection) => scheduledSection.section.id));
+          sectionIds.push(
+            ...scheduledSections.map((scheduledSection) => scheduledSection.section.id)
+          );
         }
       }
       if (!taxonomyIds.length && !sectionIds.length) return [];

--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -325,11 +325,9 @@ export default {
         if (primarySection.id) sectionIds.push(primarySection.id);
       }
       if (this.useContentSchedules) {
-        const scheduledSections = getAsArray(r1, 'data.content.websiteSchedules');
-        if (scheduledSections.length) {
-          sectionIds.push(
-            ...scheduledSections.map((scheduledSection) => scheduledSection.section.id),
-          );
+        const schedules = getAsArray(r1, 'data.content.websiteSchedules');
+        if (schedules.length) {
+          sectionIds.push(...schedules.map((schedule) => schedule.section.id));
         }
       }
       if (!taxonomyIds.length && !sectionIds.length) return [];

--- a/packages/leaders-program/src/graphql/queries/content.js
+++ b/packages/leaders-program/src/graphql/queries/content.js
@@ -15,6 +15,11 @@ query LeadersContentTaxonomyIds($contentId: Int!) {
     primarySection {
       id
     }
+    websiteSchedules {
+      section {
+        id
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The comment `// Look up leadership sections by content taxonomy, scheduling, and primary section` is presently false as the respective function `loadContentSections` was only accounting for taxonomy and primary section as shown due to the necessary changes to the fragment found in https://github.com/parameter1/base-cms/blob/master/packages/leaders-program/src/graphql/queries/content.js. This now corrects this and allows for the functionality to be opted into using the `useContentSchedules` prop with defaults to false (exactly like `useContentPrimarySection`)

PRODUCTION:
![Screenshot from 2023-03-31 09-34-11](https://user-images.githubusercontent.com/46794001/229150819-02982beb-6eb9-4264-8f93-afa7f6d94525.png)

DEVELOPMENT:
![Screenshot from 2023-03-31 09-34-14](https://user-images.githubusercontent.com/46794001/229150856-408ef3f3-197c-44f2-89bb-cc9bf8f410e8.png)
