### PR TITLE
Add gated content support for  google structured data

### DIFF
--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -31,6 +31,9 @@ fragment ContentPageMetadataFragment on Content {
       src(input: { options: { auto: "format,compress", w: "1200", fit: "max", q: 70 } })
     }
   }
+  userRegistration {
+    isCurrentlyRequired
+  }
   ... on ContentVideo {
     embedSrc
     transcript
@@ -87,6 +90,9 @@ ${processedFragment}
 `;
 
 $ const buildStructuredData = isFunction(input.buildStructuredData) ? input.buildStructuredData : defaultBuildStructuredData;
+$ const defaultFn = ({ content }) => get(content, 'userRegistration.isCurrentlyRequired', false);
+$ const { contentGatingHandler: globalContentGatingHandler } = out.global;
+$ const contentGatingHandler = isFunction(globalContentGatingHandler) ? globalContentGatingHandler : defaultFn;
 
 <if(id)>
   <marko-web-query|{ node }| name="content" params={ id, queryFragment }>
@@ -123,7 +129,7 @@ $ const buildStructuredData = isFunction(input.buildStructuredData) ? input.buil
       </if>
     </else>
 
-    $ const structuredData = buildStructuredData(node);
+    $ const structuredData = buildStructuredData(node, contentGatingHandler);
     <if(structuredData)>
       <script type="application/ld+json">
         ${structuredData}

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -90,7 +90,7 @@ ${processedFragment}
 `;
 
 $ const buildStructuredData = isFunction(input.buildStructuredData) ? input.buildStructuredData : defaultBuildStructuredData;
-$ const defaultFn = ({ content }) => get(content, 'userRegistration.isCurrentlyRequired', false);
+$ const defaultFn = (node) => get(node, 'userRegistration.isCurrentlyRequired', false);
 $ const { contentGatingHandler: globalContentGatingHandler } = out.global;
 $ const contentGatingHandler = isFunction(globalContentGatingHandler) ? globalContentGatingHandler : defaultFn;
 

--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -24,7 +24,7 @@ const getImages = (node) => {
   return images.length ? images : undefined;
 };
 
-module.exports = (node) => {
+module.exports = (node, contentGatingHandler) => {
   const publishedISOString = node.published ? (new Date(node.published)).toISOString() : undefined;
   const updatedISOString = node.updated ? (new Date(node.updated)).toISOString() : undefined;
   const siteUrl = get(node, 'siteContext.url');
@@ -47,6 +47,14 @@ module.exports = (node) => {
     url: canonicalUrl,
     ...(siteUrl !== canonicalUrl && { url: siteUrl, isBasedOn: canonicalUrl }),
     ...(getAuthor(node) && { author: getAuthor(node) }),
+    ...(contentGatingHandler(node) && {
+      isAccessibleForFree: false,
+      hasPart: {
+        '@type': 'WebPageElement',
+        isAccessibleForFree: false,
+        cssSelector: '.page-contents__content-body--ld-json',
+      },
+    }),
   };
 
   if (node.type === 'video') {


### PR DESCRIPTION
Add the ability to get the content gating function from out.global or use the defaultFn which just looks at the nodes 'userRegistration.isCurrentlyRequired' property.

By default nothing should change.  In the case of AB it will utilize the global function to apply the content gating of all article content types.

<img width="1505" alt="Screen Shot 2023-04-04 at 10 36 13 AM" src="https://user-images.githubusercontent.com/3845869/229844283-161b9eca-9182-46bc-900d-f6e63861709a.png">

<img width="1501" alt="Screen Shot 2023-04-04 at 10 36 39 AM" src="https://user-images.githubusercontent.com/3845869/229844298-0ded291d-1365-4b3f-aa01-9ecc617e8b7e.png">
