### PR TITLE
Update content gating function format to match existing contentGating functions format.

### DIFF
--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -18,6 +18,12 @@ $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const displayImage = defaultValue(input.displayImage, true);
 $ const lazyload = defaultValue(input.lazyload, true);
 
+$ const pastLabel = defaultValue(input.pastLabel, "View Webinar");
+$ const upcomingLabel = defaultValue(input.pastLabel, "Register for Webinar");
+$ const { surveyType, surveyId } = getAsObject(content, "gating")
+$ const linkToWebinarFormAnchor = (surveyType && surveyId) ? defaultValue(input.linkToWebinarFormAnchor, false) : false;
+
+
 $ const imageOptions = {
   w: 250,
   h: 167,
@@ -69,13 +75,25 @@ $ const blockName = "section-feed-content-node";
           <marko-web-content-start-date tag="span" block-name=blockName obj=content />
           <marko-web-content-end-date tag="span" block-name=blockName obj=content />
         </div>
-        <if(content.linkUrl)>
+
+        <if(linkToWebinarFormAnchor)>
+          $ const cta = (isUpcoming) ? `${i18n(upcomingLabel)}` : `${i18n(pastLabel)}`;
+          <marko-web-link
+            class="btn btn-primary btn-lg"
+            title=`${cta}: ${content.name}`
+            href=`${get(content, "siteContext.path")}#webinar-form`
+            target="_blank"
+          >
+            ${cta}
+          </marko-web-link>
+        </if>
+        <else-if(content.linkUrl)>
           <theme-content-link-url
             obj=content
-            label=(isUpcoming ? `${i18n("Register for Webinar")}` : `${i18n("View Webinar")}`)
+            label=(isUpcoming ? `${i18n(upcomingLabel)}` : `${i18n(pastLabel)}`)
             target="_blank"
           />
-        </if>
+        </else-if>
       </if>
       <else-if(withDates)>
         <marko-web-content-published
@@ -84,9 +102,34 @@ $ const blockName = "section-feed-content-node";
           format="MMMM D, YYYY"
         />
       </else-if>
-      <marko-web-content-sponsors|{ node }| block-name=blockName obj=content>
-        Sponsored By: <marko-web-content-name tag="span" block-name=blockName obj=node link=true />
-      </marko-web-content-sponsors>
+      <if(content.sponsors)>
+          <marko-web-content-sponsors|{ node }| block-name=blockName obj=content>
+            <if(node.primaryImage && node.primaryImage.src)>
+              $ const sponsoreImgOptions = {
+                h: 112,
+                w: 112,
+                fit: 'fill-max',
+              }
+              $ const src = buildImgixUrl(node.primaryImage.src, sponsoreImgOptions, null, get(node.primaryImage, 'isLogo'));
+              $ const srcset = [src, `${buildImgixUrl(src, { dpr: 2 })} 2x`];
+
+              <marko-web-picture>
+                <@link href=get(content, "siteContext.path") attrs=linkAttrs />
+                <@image
+                  src=src
+                  srcset=srcset
+                  class=[`${blockName}__image--sponsore`]
+                  alt=node.primaryImage.alt
+                  lazyload=lazyload
+                  attrs={ width: "112", height: "112" }
+                />
+              </marko-web-picture>
+            </if>
+            <else>
+              <marko-web-content-name tag="span" block-name=blockName obj=node link=true />
+            </else>
+          </marko-web-content-sponsors>
+      </if>
     </marko-web-element>
   </marko-web-element>
   <if(displayImage)>

--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -19,7 +19,7 @@ $ const displayImage = defaultValue(input.displayImage, true);
 $ const lazyload = defaultValue(input.lazyload, true);
 
 $ const pastLabel = defaultValue(input.pastLabel, "View Webinar");
-$ const upcomingLabel = defaultValue(input.pastLabel, "Register for Webinar");
+$ const upcomingLabel = defaultValue(input.upcomingLabel, "Register for Webinar");
 $ const { surveyType, surveyId } = getAsObject(content, "gating")
 $ const linkToWebinarFormAnchor = (surveyType && surveyId) ? defaultValue(input.linkToWebinarFormAnchor, false) : false;
 

--- a/packages/marko-web-theme-monorail/graphql/fragments/section-feed-block.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/section-feed-block.js
@@ -28,6 +28,10 @@ fragment SectionFeedBlockContentFragment on Content {
     linkUrl
     startDate
     transcript
+    gating {
+      surveyType
+      surveyId
+    }
     sponsors {
       edges {
         node {
@@ -35,6 +39,12 @@ fragment SectionFeedBlockContentFragment on Content {
           name
           siteContext {
             path
+          }
+          primaryImage {
+            id
+            src(input: { options: { auto: "format,compress" } })
+            alt
+            isLogo
           }
         }
       }

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
@@ -85,6 +85,12 @@
       content: "Date: ";
     }
   }
+  &__content-sponsors {
+    &::before {
+      font-weight: $font-weight-bold;
+      content: "Sponsored by: ";
+    }
+  }
   &__content-start-date + #{ $self }__content-end-date {
     &::before {
       font-weight: $font-weight-normal;


### PR DESCRIPTION
Currently the contentGating middle ware uses the ({ content }) => to get content out of an object.  This will update the function call to match this format.