### PR TITLE
Update contentGating fn format to match middleware

### DIFF
--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -90,7 +90,7 @@ ${processedFragment}
 `;
 
 $ const buildStructuredData = isFunction(input.buildStructuredData) ? input.buildStructuredData : defaultBuildStructuredData;
-$ const defaultFn = (node) => get(node, 'userRegistration.isCurrentlyRequired', false);
+$ const defaultFn = ({ content }) => get(content, 'userRegistration.isCurrentlyRequired', false);
 $ const { contentGatingHandler: globalContentGatingHandler } = out.global;
 $ const contentGatingHandler = isFunction(globalContentGatingHandler) ? globalContentGatingHandler : defaultFn;
 

--- a/packages/marko-web/components/page/metadata/google-structured-data/content.js
+++ b/packages/marko-web/components/page/metadata/google-structured-data/content.js
@@ -47,7 +47,7 @@ module.exports = (node, contentGatingHandler) => {
     url: canonicalUrl,
     ...(siteUrl !== canonicalUrl && { url: siteUrl, isBasedOn: canonicalUrl }),
     ...(getAuthor(node) && { author: getAuthor(node) }),
-    ...(contentGatingHandler(node) && {
+    ...(contentGatingHandler({ content: node }) && {
       isAccessibleForFree: false,
       hasPart: {
         '@type': 'WebPageElement',


### PR DESCRIPTION
The contentGating middle ware is currently using the ({ content }) => passing in an object with content this will update additional ones to match