### PR TITLE
Adjust magazine issue page cover image css to checks screen height/width and sizes accordingly.  

### DIFF
--- a/packages/marko-web-theme-monorail-magazine/scss/index.scss
+++ b/packages/marko-web-theme-monorail-magazine/scss/index.scss
@@ -187,6 +187,20 @@
         }
       }
     }
+    &.sticky-top {
+      @media (max-height: 650px) and (min-width: 992px) {
+        .node {
+          &__image-inner-wrapper {
+            max-height: calc(100vh - 150px);
+            width: auto;
+            margin: 0 auto;
+            &--fluid-3by4 {
+              aspect-ratio: 3/4;
+            }
+          }
+        }
+      }
+    }
   }
 }
 

--- a/packages/marko-web-theme-monorail-magazine/scss/index.scss
+++ b/packages/marko-web-theme-monorail-magazine/scss/index.scss
@@ -189,16 +189,7 @@
     }
     &.sticky-top {
       @media (max-height: 650px) and (min-width: 992px) {
-        .node {
-          &__image-inner-wrapper {
-            max-height: calc(100vh - 150px);
-            width: auto;
-            margin: 0 auto;
-            &--fluid-3by4 {
-              aspect-ratio: 3/4;
-            }
-          }
-        }
+        position: initial;
       }
     }
   }


### PR DESCRIPTION
Currently it is targeting cover image using the 3x4 aspect ration.  If there are new sizes added we will have to account for them here as well.  

<img width="1703" alt="Screen Shot 2023-04-04 at 2 40 59 PM" src="https://user-images.githubusercontent.com/3845869/229904214-9245f911-da00-421a-af05-0a961c1bf1bc.png">
<img width="1702" alt="Screen Shot 2023-04-04 at 2 41 16 PM" src="https://user-images.githubusercontent.com/3845869/229904219-e9fa0afd-2127-4e6c-91bc-7f6d6c41eb41.png">
<img width="1792" alt="Screen Shot 2023-04-04 at 2 41 25 PM" src="https://user-images.githubusercontent.com/3845869/229904220-693a58ff-e53f-4def-a1c0-54f61e55e01e.png">
