### PR TITLE
IdentityX: Support required fields when creating new user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -350,7 +350,7 @@ services:
       SITE_ID: ${EXAMPLE_SITE_ID-5ed294c6c13a4626008b4568}
 
       # Debug logging
-      DEBUG: ${DEBUG-defer,p1events}
+      DEBUG: ${DEBUG-defer,p1events,omeda}
 
       IDENTITYX_GRAPHQL_URI: ${EXAMPLE_IDENTITYX_GRAPHQL_URI-}
       IDENTITYX_APP_ID: ${EXAMPLE_IDENTITYX_APP_ID-5d1b86070ce467bff670a052}

--- a/packages/marko-web-identity-x/api/queries/load-user.js
+++ b/packages/marko-web-identity-x/api/queries/load-user.js
@@ -1,0 +1,11 @@
+const gql = require('graphql-tag');
+const userFragment = require('../fragments/active-user');
+
+module.exports = gql`
+  query LoadUserByEmail($email: String!) {
+    appUser(input: { email: $email }) {
+      ...ActiveUserFragment
+    }
+  }
+  ${userFragment}
+`;

--- a/packages/marko-web-identity-x/browser/comments/stream.vue
+++ b/packages/marko-web-identity-x/browser/comments/stream.vue
@@ -43,6 +43,8 @@
           :app-context-id="appContextId"
           :regional-consent-policies="regionalConsentPolicies"
           :button-labels="loginButtonLabels"
+          :required-create-fields="requiredCreateFields"
+          :default-field-labels="defaultFieldLabels"
           @login-link-sent="showLoginMessage = false"
         />
       </div>
@@ -187,6 +189,14 @@ export default {
     regionalConsentPolicies: {
       type: Array,
       default: () => [],
+    },
+    requiredCreateFields: {
+      type: Array,
+      default: () => [],
+    },
+    defaultFieldLabels: {
+      type: Object,
+      default: () => ({}),
     },
   },
 

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -215,6 +215,8 @@
       :email-consent-request="emailConsentRequest"
       :email-consent-request-enabled="emailConsentRequestEnabled"
       :regional-consent-policies="regionalConsentPolicies"
+      :required-create-fields="requiredCreateFields"
+      :default-field-labels="defaultFieldLabels"
     />
   </div>
 </template>
@@ -289,6 +291,10 @@ export default {
       default: () => [],
     },
     requiredClientFields: {
+      type: Array,
+      default: () => [],
+    },
+    requiredCreateFields: {
       type: Array,
       default: () => [],
     },

--- a/packages/marko-web-identity-x/components/comment-stream.marko
+++ b/packages/marko-web-identity-x/components/comment-stream.marko
@@ -21,6 +21,8 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       consentPolicy: get(application, "organization.consentPolicy"),
       regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
       appContextId: identityX.config.get("appContextId"),
+      requiredCreateFields: identityX.config.getRequiredCreateFields(),
+      defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
     };
     <if(isEnabled && identityX.config.commentsEnabled())>
       <marko-web-browser-component name="IdentityXCommentStream" props=props />

--- a/packages/marko-web-identity-x/components/form-login.marko
+++ b/packages/marko-web-identity-x/components/form-login.marko
@@ -17,6 +17,8 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       redirect: input.redirect,
       loginEmailLabel: input.loginEmailLabel,
       loginEmailPlaceholder: input.loginEmailPlaceholder,
+      defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
+      requiredCreateFields: identityX.config.getRequiredCreateFields(),
       consentPolicy: get(application, "organization.consentPolicy"),
       emailConsentRequest: get(application, "organization.emailConsentRequest"),
       regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),

--- a/packages/marko-web-identity-x/components/form-profile.marko
+++ b/packages/marko-web-identity-x/components/form-profile.marko
@@ -13,6 +13,7 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       activeUser: user,
       requiredServerFields: identityX.config.getRequiredServerFields(),
       requiredClientFields: identityX.config.getRequiredClientFields(),
+      requiredCreateFields: identityX.config.getRequiredCreateFields(),
       defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
       hiddenFields: identityX.config.getHiddenFields(),
       defaultCountryCode: identityX.config.get('defaultCountryCode'),

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -12,6 +12,7 @@ class IdentityXConfiguration {
    * @param {string} [options.apiToken] An API token to use. Only required when doing write ops.
    * @param {string[]} [options.requiredServerFields] Required fields, server enforced.
    * @param {string[]} [options.requiredClientFields] Required fields, client-side only.
+   * @param {string[]} [options.requiredCreateFields] Required fields, when creating a new user.
    * @param {string[]} [options.hiddenFields] The fields to hide from the profile.
    * @param {function} [options.onHookError]
    * @param {object} options.rest
@@ -21,6 +22,7 @@ class IdentityXConfiguration {
     apiToken,
     requiredServerFields = [],
     requiredClientFields = [],
+    requiredCreateFields = [],
     defaultFieldLabels = {},
     hiddenFields = ['city', 'street', 'addressExtra', 'phoneNumber'],
     defaultCountryCode,
@@ -35,6 +37,7 @@ class IdentityXConfiguration {
       enableChangeEmail: false,
       requiredServerFields,
       requiredClientFields,
+      requiredCreateFields,
       defaultFieldLabels,
       hiddenFields,
       defaultCountryCode,
@@ -104,6 +107,10 @@ class IdentityXConfiguration {
 
   getRequiredClientFields() {
     return this.getAsArray('requiredClientFields');
+  }
+
+  getRequiredCreateFields() {
+    return this.getAsArray('requiredCreateFields');
   }
 
   getHiddenFields() {

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -83,6 +83,12 @@ module.exports = asyncRoute(async (req, res) => {
     await identityX.client.mutate({ mutation, variables: { input } });
   }
 
+  // Refresh the user for verification/new field state
+  if (additionalEventData.createdNewUser) {
+    const r = await identityX.client.query({ query, variables });
+    appUser = r.data.appUser;
+  }
+
   // Send login link.
   await identityX.sendLoginLink({
     appUser,

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -26,7 +26,6 @@ module.exports = asyncRoute(async (req, res) => {
     redirectTo,
     additionalEventData = {},
   } = body;
-  const { forceProfileReVerification } = additionalEventData;
   let appUser = await identityX.loadAppUserByEmail(email);
 
   // Check for required creation fields
@@ -48,7 +47,7 @@ module.exports = asyncRoute(async (req, res) => {
     additionalEventData.createdNewUser = true;
   }
 
-  if (forceProfileReVerification) {
+  if (additionalEventData.forceProfileReVerification) {
     const { id } = appUser;
     await identityX.client.mutate({
       mutation: forceProfileReVerificationUser,
@@ -71,7 +70,7 @@ module.exports = asyncRoute(async (req, res) => {
   }
 
   // Refresh the user for verification/new field state
-  if (additionalEventData.createdNewUser) {
+  if (additionalEventData.forceProfileReVerification || additionalEventData.createdNewUser) {
     appUser = await identityX.loadAppUserByEmail(email);
   }
 

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -2,6 +2,14 @@ const gql = require('graphql-tag');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const userFragment = require('../api/fragments/active-user');
 
+const mutation = gql`
+  mutation SetPreLoginFields($input: SetAppUserUnverifiedDataMutationInput!) {
+    setAppUserUnverifiedData(input: $input) {
+      id
+    }
+  }
+`;
+
 const buildQuery = () => gql`
   query LoginCheckAppUser($email: String!) {
     appUser(input: { email: $email }) {
@@ -34,7 +42,20 @@ module.exports = asyncRoute(async (req, res) => {
   const { data } = await identityX.client.query({ query, variables });
   let { appUser } = data;
 
-  if (!appUser) {
+  // Check for required creation fields
+  const required = identityX.config.getRequiredCreateFields();
+  if (required.length) {
+    // If we don't have a user, or the user is missing some of the required fields
+    if (!appUser || (appUser && !required.every((key) => appUser[key]))) {
+      additionalEventData.createdNewUser = true;
+      // And they weren't presented in the login request, require them.
+      if (!required.every((key) => body[key])) {
+        return res.status(400).json({ ok: false, requiresUserInput: true });
+      }
+    }
+  }
+
+  if (!appUser || (appUser && !required.every((key) => appUser[key]))) {
     // Create the user.
     appUser = await identityX.createAppUser({ email });
     additionalEventData.createdNewUser = true;
@@ -46,6 +67,20 @@ module.exports = asyncRoute(async (req, res) => {
       mutation: forceProfileReVerificationUser,
       variables: { input: { id } },
     });
+  }
+
+  // Set the fields as unverified app data and continue login.
+  if (required.length && additionalEventData.createdNewUser) {
+    const regionalConsentAnswers = Array.isArray(body.regionalConsentAnswers)
+      ? body.regionalConsentAnswers
+      : [];
+    const input = {
+      ...(required.reduce((obj, key) => ({ ...obj, [key]: body[key] }), {})),
+      regionalConsentAnswers: regionalConsentAnswers
+        .map((answer) => ({ policyId: answer.id, given: answer.given })),
+      email,
+    };
+    await identityX.client.mutate({ mutation, variables: { input } });
   }
 
   // Send login link.

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -2,6 +2,7 @@ const { get, getAsObject } = require('@parameter1/base-cms-object-path');
 const createClient = require('./utils/create-client');
 const getActiveContext = require('./api/queries/get-active-context');
 const checkContentAccess = require('./api/queries/check-content-access');
+const loadUser = require('./api/queries/load-user');
 const addExternalUserId = require('./api/mutations/add-external-user-id');
 const setCustomAttributes = require('./api/mutations/set-custom-attributes');
 const impersonateAppUser = require('./api/mutations/impersonate-app-user');
@@ -56,6 +57,18 @@ class IdentityX {
       activeContext,
     });
     return activeContext;
+  }
+
+  /**
+   * Returns an IdentityX user record by email address
+   */
+  async loadAppUserByEmail(email) {
+    const { data } = await this.client.query({
+      query: loadUser,
+      variables: { email },
+      fetchPolicy: 'no-cache',
+    });
+    return data.appUser;
   }
 
   /**

--- a/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
+++ b/packages/marko-web-omeda-identity-x/integration-hooks/on-login-link-sent.js
@@ -52,6 +52,8 @@ module.exports = async (params = {}) => {
     cookies: req.cookies,
   });
 
+  const requiredCreateFields = identityX.config.getRequiredCreateFields();
+
   const [omedaLinkedFields, { encryptedCustomerId }] = await Promise.all([
     getOmedaLinkedFields({ identityX, brandKey }),
     idxOmedaRapidIdentify(await formatter({
@@ -59,7 +61,11 @@ module.exports = async (params = {}) => {
       req,
       source,
       payload: {
-        user: user.verified ? user : { id: user.id, email: user.email },
+        user: user.verified ? user : {
+          ...(requiredCreateFields.reduce((obj, key) => ({ ...obj, [key]: user[key] }), {})),
+          id: user.id,
+          email: user.email,
+        },
         behavior,
         promoCode,
         appendBehaviors,

--- a/packages/marko-web-omeda/package.json
+++ b/packages/marko-web-omeda/package.json
@@ -19,6 +19,7 @@
     "@parameter1/base-cms-utils": "^4.5.12",
     "@parameter1/omeda-graphql-client": "^0.7.2",
     "body-parser": "^1.20.1",
+    "debug": "^4.3.4",
     "express": "^4.18.2",
     "graphql": "^14.7.0",
     "graphql-tag": "^2.12.6",

--- a/packages/marko-web-omeda/rapid-identify.js
+++ b/packages/marko-web-omeda/rapid-identify.js
@@ -1,4 +1,5 @@
 const gql = require('graphql-tag');
+const debug = require('debug')('omeda');
 
 const RAPID_IDENT = gql`
   mutation RapidIdentityX($input: RapidCustomerIdentificationMutationInput!) {
@@ -65,5 +66,6 @@ module.exports = async (omedaGraphQLClient, {
     mutation: RAPID_IDENT,
     variables: { input },
   });
+  debug('rapid-identify', input, data);
   return data.result;
 };

--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
@@ -24,6 +24,8 @@
             :consent-policy="consentPolicy"
             :email-consent-request-enabled="true"
             :email-consent-request="emailConsentRequest"
+            :required-create-fields="requiredCreateFields"
+            :default-field-labels="defaultFieldLabels"
             :regional-consent-policies="regionalConsentPolicies"
             :app-context-id="appContextId"
             :login-email-label="translateEmail"
@@ -160,6 +162,14 @@ export default {
     actionText: {
       type: String,
       default: 'signing up to receive your email notifications',
+    },
+    requiredCreateFields: {
+      type: Array,
+      default: () => [],
+    },
+    defaultFieldLabels: {
+      type: Object,
+      default: () => ({}),
     },
   },
 

--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
@@ -29,6 +29,8 @@
             :consent-policy="consentPolicy"
             :email-consent-request-enabled="true"
             :email-consent-request="emailConsentRequest"
+            :required-create-fields="requiredCreateFields"
+            :default-field-labels="defaultFieldLabels"
             :regional-consent-policies="regionalConsentPolicies"
             :app-context-id="appContextId"
             :action-text="actionText"
@@ -163,6 +165,14 @@ export default {
     regionalConsentPolicies: {
       type: Array,
       default: () => [],
+    },
+    requiredCreateFields: {
+      type: Array,
+      default: () => [],
+    },
+    defaultFieldLabels: {
+      type: Object,
+      default: () => ({}),
     },
   },
 

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-footer.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-footer.marko
@@ -47,6 +47,8 @@ $ const lang = site.config.lang || "en";
           emailConsentRequest: get(application, "organization.emailConsentRequest"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
           appContextId: identityX.config.get("appContextId"),
+          requiredCreateFields: identityX.config.getRequiredCreateFields(),
+          defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
         }
       />
     </if>

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
@@ -57,6 +57,8 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
           emailConsentRequest: get(application, "organization.emailConsentRequest"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
           appContextId: identityX.config.get("appContextId"),
+          requiredCreateFields: identityX.config.getRequiredCreateFields(),
+          defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
         }
       />
     </if>

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
@@ -54,6 +54,8 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
           emailConsentRequest: get(application, "organization.emailConsentRequest"),
           regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
           appContextId: identityX.config.get("appContextId"),
+          requiredCreateFields: identityX.config.getRequiredCreateFields(),
+          defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
         }
         ssr=true
       />

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -7,6 +7,7 @@ module.exports = new IdentityXConfiguration({
   apiToken: process.env.IDENTITYX_API_TOKEN,
   requiredServerFields: ['givenName', 'familyName', 'countryCode'],
   requiredClientFields: ['regionCode', 'countryCode'],
+  requiredCreateFields: ['givenName', 'familyName'],
   booleanQuestionsLabel: 'Choose your subscriptions:',
   enableChangeEmail: true,
   defaultFieldLabels: {

--- a/services/example-website/config/search.js
+++ b/services/example-website/config/search.js
@@ -4,23 +4,23 @@ module.exports = {
   sponsorLogos: {
     navbar: {
       alt: 'Search Sposored by ProfiNet',
-      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress',
+      src: 'https://p1-cms-assets.imgix.net/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress',
       srcset: [
-        'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress&dpr=2 2x',
+        'https://p1-cms-assets.imgix.net/files/base/pmmi/aw/profinet_black.png?h=24&auto=format,compress&dpr=2 2x',
       ],
     },
     siteMenu: {
       alt: 'Search Sposored by ProfiNet',
-      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress',
+      src: 'https://p1-cms-assets.imgix.net/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress',
       srcset: [
-        'https://img.automationworld.com/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress&dpr=2 2x',
+        'https://p1-cms-assets.imgix.net/files/base/pmmi/aw/profinet_black.png?h=34&auto=format,compress&dpr=2 2x',
       ],
     },
     page: {
       alt: 'Search Sposored by ProfiNet',
-      src: 'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress',
+      src: 'https://p1-cms-assets.imgix.net/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress',
       srcset: [
-        'https://img.automationworld.com/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress&dpr=2 2x',
+        'https://p1-cms-assets.imgix.net/files/base/pmmi/aw/profinet_green.png?h=48&auto=format,compress&dpr=2 2x',
       ],
     },
   },

--- a/services/example-website/server/templates/content.marko
+++ b/services/example-website/server/templates/content.marko
@@ -29,6 +29,7 @@ $ const { recaptcha } = out.global;
                 block-name=blockName
                 preventHTMLInjection=false
               />
+              <identity-x-newsletter-form-inline type="inlineContent" />
               <theme-identity-x-comment-stream content=content />
             </theme-page-contents>
           </div>


### PR DESCRIPTION
This feature allows a site to be configured to require additional fields before sending a login link to a new user. Currently this only supports `givenName` and `familyName`, but can be expanded as needed to support additional fields.

To use, specify the fields that should be required under the `requiredCreateFields` array in the IdentityX config:
```js
module.exports = new IdentityXConfiguration({
  // ...
  requiredCreateFields: ['givenName'],
});
```
When a new user is encountered during the login, and these fields are required, they will be prompted to input them:
![image](https://user-images.githubusercontent.com/1778222/230431764-1ece6511-2ab2-4374-b765-48c7b46e9361.png)

## Status
- [x] Prompt for required create fields if missing
- [x] Send required fields with login-link-sent event (unverified data!)
- [x] Update login link hook to send to Omeda rapid ident
- [x] Verify working: Regular login component
- [x] Verify working: in-profile login component
- [x] Verify working: newsletter pushdown login component
- [x] Verify working: newsletter inline (section) login component
- [x] Verify working: newsletter inline (content) login component
- [x] Verify working: newsletter footer login component
- [x] Verify working: metered content prompt login component
- [x] Verify working: (hard) gated content inline login component