### PR TITLE
Port content metering feature to monorail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -350,7 +350,7 @@ services:
       SITE_ID: ${EXAMPLE_SITE_ID-5ed294c6c13a4626008b4568}
 
       # Debug logging
-      DEBUG: ${DEBUG-defer,p1events}
+      DEBUG: ${DEBUG-defer,p1events,content-meter}
 
       IDENTITYX_GRAPHQL_URI: ${EXAMPLE_IDENTITYX_GRAPHQL_URI-}
       IDENTITYX_APP_ID: ${EXAMPLE_IDENTITYX_APP_ID-5d1b86070ce467bff670a052}

--- a/packages/marko-web-theme-monorail/README.md
+++ b/packages/marko-web-theme-monorail/README.md
@@ -8,13 +8,14 @@ Monorail website theme
 To install and use this feature, you must:
 1. Import the content metering middleware and add to your content routes:
 ```diff
-# site/routes/content.js
+// site/routes/content.js
 
-+import contentMetering from '@parameter1/base-cms-marko-web-theme-monorail/middleware/content-metering';
++const contentMetering = require('@parameter1/base-cms-marko-web-theme-monorail/middleware/content-metering');
++const config = require('../config/content-meter');
 
-export default (app) => {
+module.exports (app) => {
 -  app.get('/*?:id(\\d{8})*', withContent({
-+  app.get('/*?:id(\\d{8})*', contentMetering, withContent({
++  app.get('/*?:id(\\d{8})*', contentMetering(config), withContent({
     template: content,
     queryFragment,
   }));
@@ -22,20 +23,31 @@ export default (app) => {
 
 2. Add the `contentMeter` site config object. See below table for defined options/default values.
 
+
 ```diff
-# site/config.js
+# site/config/site.js
+
++const contentMeter = require('./content-meter');
 
 module.exports = {
-+   contentMeter: {
-+    enabled: process.env.ENABLE_CONTENT_METER || false,
-+    viewLimit: 5,
-+  },
+  // ...
++  contentMeter,
+  // ...
+}
+```
+
+```js
+// site/config/content-meter.js
+
+module.exports = {
+  enabled: process.env.ENABLE_CONTENT_METER || false,
+  viewLimit: 5,
 }
 ```
 
 | Key | Default value | Description |
 | - | - | - |
-| `enable` | `false` | If the feature should be enabled. |
+| `enabled` | `false` | If the feature should be enabled. |
 | `viewLimit` |  `3` | The number of content items a viewer can see in `timeframe` without logging in. |
 | `timeframe` | `30 * 24 * 60 * 60 * 1000` (30 days in ms) | The timeframe to consider |
 | `excludeLabels` | `[]` | Content labels that should be excluded from metering. |
@@ -44,18 +56,6 @@ module.exports = {
 | `excludePrimarySectionAlias` | `[]` | Sections whose primary content should be excluded from metering. |
 | `displayOverlay` | _None_ | ??? @B77Mills what is this |
 | `promoCode` | _None_ | If present, the Omeda promo code to use with content metering events. |
-
-
-```diff
-# site/config.js
-
-module.exports = {
-+   contentMeter: {
-+    enabled: process.env.ENABLE_CONTENT_METER || false,
-+    viewLimit: 5,
-+  },
-}
-```
 
 3. Add the UI display and event tracking component to your core `document` component (ideally in above-container):
 ```marko

--- a/packages/marko-web-theme-monorail/README.md
+++ b/packages/marko-web-theme-monorail/README.md
@@ -1,0 +1,103 @@
+Monorail website theme
+===
+
+## Features
+
+### Content Metering
+
+To install and use this feature, you must:
+1. Import the content metering middleware and add to your content routes:
+```diff
+# site/routes/content.js
+
++import contentMetering from '@parameter1/base-cms-marko-web-theme-monorail/middleware/content-metering';
+
+export default (app) => {
+-  app.get('/*?:id(\\d{8})*', withContent({
++  app.get('/*?:id(\\d{8})*', contentMetering, withContent({
+    template: content,
+    queryFragment,
+  }));
+```
+
+2. Add the `contentMeter` site config object. See below table for defined options/default values.
+
+```diff
+# site/config.js
+
+module.exports = {
++   contentMeter: {
++    enabled: process.env.ENABLE_CONTENT_METER || false,
++    viewLimit: 5,
++  },
+}
+```
+
+| Key | Default value | Description |
+| - | - | - |
+| `enable` | `false` | If the feature should be enabled. |
+| `viewLimit` |  `3` | The number of content items a viewer can see in `timeframe` without logging in. |
+| `timeframe` | `30 * 24 * 60 * 60 * 1000` (30 days in ms) | The timeframe to consider |
+| `excludeLabels` | `[]` | Content labels that should be excluded from metering. |
+| `excludeContentTypes` | `[]` | Content types that should be excluded from metering. |
+| `excludePrimarySectionIds` | `[]` | Sections whose primary content should be excluded from metering. |
+| `excludePrimarySectionAlias` | `[]` | Sections whose primary content should be excluded from metering. |
+| `displayOverlay` | _None_ | ??? @B77Mills what is this |
+| `promoCode` | _None_ | If present, the Omeda promo code to use with content metering events. |
+
+
+```diff
+# site/config.js
+
+module.exports = {
++   contentMeter: {
++    enabled: process.env.ENABLE_CONTENT_METER || false,
++    viewLimit: 5,
++  },
+}
+```
+
+3. Add the UI display and event tracking component to your core `document` component (ideally in above-container):
+```marko
+<!-- site/server/components/document.marko -->
+
+$ const { contentMeterState } = out.global;
+<if(contentMeterState && !contentMeterState.isLoggedIn)>
+  <theme-content-meter-block
+    views=contentMeterState.views
+    view-limit=contentMeterState.viewLimit
+    display-overlay=contentMeterState.displayOverlay
+    display-gate=contentMeterState.displayGate
+  />
+</if>
+```
+
+5. Adjust the content body template/layout to truncate the body and/or show inline gating options:
+```marko
+<!-- site/components/layouts/content.marko -->
+
+import cm from "@parameter1/base-cms-marko-web-theme-monorail/utils/content-meter-helpers";
+
+$ const { content, blockName } = input;
+$ const { contentGatingHandler, contentMeterState, req } = out.global;
+
+$ const showOverlay = cm.shouldOverlay(contentMeterState);
+$ const requiresReg = cm.restrictContentByReg(contentMeterState, contentGatingHandler, content);
+
+$ let body = content.body;
+<if(cm.shouldTruncate(contentMeterState))>
+  $ if (showOverlay) body = getContentPreview({ body: content.body, selector: "p:lt(7)" });
+  <marko-web-content-body block-name=blockName obj={ body } />
+  <div class="content-page-preview-overlay" />
+  <if(!showOverlay)>
+    <theme-content-page-gate
+      can-access=context.canAccess
+      is-logged-in=context.isLoggedIn
+      $ // ...
+    />
+  </if>
+</if>
+<else-if(!context.canAccess || context.requiresUserInput)>
+  $ // ...
+
+```

--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -1,0 +1,59 @@
+<template>
+  <div id="content-meter-gtm-event" />
+</template>
+
+<script>
+
+export default {
+  props: {
+    views: {
+      type: Number,
+      default: 0,
+    },
+    viewLimit: {
+      type: Number,
+      default: 3,
+    },
+    displayGate: {
+      type: Boolean,
+      default: false,
+    },
+    displayOverlay: {
+      type: Boolean,
+      required: false,
+    },
+  },
+  computed: {
+    remaining() {
+      const { viewLimit, views } = this;
+      return viewLimit - views;
+    },
+    overlayDisplayed() {
+      const { displayGate, displayOverlay } = this;
+      return displayGate && displayOverlay;
+    },
+  },
+  created() {
+    const { views, remaining, overlayDisplayed } = this;
+    this.observer = new IntersectionObserver((event) => {
+      if (event[0].isIntersecting) {
+        const { dataLayer } = window;
+        if (dataLayer) {
+          dataLayer.push({
+            event: 'identity-x-content-meter-view',
+            'identity-x': {
+              label: 'content-meter',
+              views,
+              remaining,
+              overlayDisplayed,
+            },
+          });
+        }
+      }
+    });
+  },
+  mounted() {
+    this.observer.observe(this.$el);
+  },
+};
+</script>

--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -8,6 +8,7 @@ import IdentityX from '@parameter1/base-cms-marko-web-identity-x/browser';
 import OmedaIdentityX from '@parameter1/base-cms-marko-web-omeda-identity-x/browser';
 import P1Events from '@parameter1/base-cms-marko-web-p1-events/browser';
 import IdentityXNewsletterForms from './idx-newsletter-form/index';
+import ContentMeterTrack from './content-meter-track.vue';
 
 const CommentToggleButton = () => import(/* webpackChunkName: "theme-comment-toggle-button" */ './comment-toggle-button.vue');
 const BlockLoader = () => import(/* webpackChunkName: "theme-block-loader" */ './block-loader.vue');
@@ -129,4 +130,5 @@ export default (Browser, config = {
   Browser.register('ThemeTopStoriesMenu', TopStoriesMenu);
   Browser.register('WufooForm', WufooForm);
   Browser.register('RevealAdHandler', RevealAdHandler);
+  Browser.register('ContentMeterTrack', ContentMeterTrack);
 };

--- a/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
@@ -1,0 +1,74 @@
+$ const { config, site, contentMeterState } = out.global;
+$ const {
+  displayGate,
+  displayOverlay,
+  viewLimit,
+  views,
+} = contentMeterState;
+$ const additionalEventData = {
+  promoCode: site.get("contentMeter.promoCode", undefined),
+  views,
+  viewLimit,
+  displayGate,
+  displayOverlay,
+};
+
+$ const setTextVariables = () => {
+  // Set title based on views remaining
+  let dynamicTitle = "Create an account"
+  if (views < viewLimit) dynamicTitle = `You have ${viewLimit - views} article views remaining.`;
+  if (viewLimit - views === 1) dynamicTitle = `You have 1 article view remaining.`;
+  if (viewLimit === views && !displayOverlay) dynamicTitle = `This is your last free article.`;
+
+  return [
+    dynamicTitle,
+    "Create a free account",
+    `Create a free <span class="content-meter__call-to-action--site-name">${config.siteName()}</span> account to continue reading`,
+    "Continue",
+  ];
+}
+$ const [title, collapsedTitle, callToAction, registerText] = setTextVariables();
+
+$ const classes = [
+  "content-meter",
+  "content-meter--open",
+  `${(displayGate && displayOverlay) ? "content-meter--display-overlay" : "" }`,
+].join(" ");
+
+<if(displayGate)>
+  <div class=classes>
+    <if(displayOverlay)>
+      <div class="content-meter__overlay"/>
+    </if>
+    <div class="content-meter__bar" role="region" aria-label="Content Meter">
+      <marko-web-browser-component name="ContentMeterTrack" props=contentMeterState />
+      <div class="content-meter__title">
+        <theme-menu-toggle-button
+          class="content-meter__toggler"
+          targets=[
+            ".content-meter"
+          ]
+          beforeExpanded=`${title}`
+          beforeCollapsed=`${collapsedTitle}`
+          toggle-class="content-meter--open"
+          icon-modifiers=["xl"]
+          initially-expanded=true
+          icon-name="chevron-up"
+          expanded-icon-name="chevron-down"
+        />
+      </div>
+      <p class="content-meter__call-to-action">
+        $!{callToAction}
+      </p>
+      <div class="content-meter__body">
+        <div class="content-meter__login-form">
+          <marko-web-identity-x-form-login
+            login-email-placeholder="your@email.com"
+            source="content_meter_login"
+            additional-event-data=additionalEventData
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</if>

--- a/packages/marko-web-theme-monorail/components/blocks/marko.json
+++ b/packages/marko-web-theme-monorail/components/blocks/marko.json
@@ -190,5 +190,8 @@
   },
   "<theme-white-papers-block>": {
     "template": "./white-papers.marko"
+  },
+  "<theme-content-meter-block>": {
+    "template": "./content-meter.marko"
   }
 }

--- a/packages/marko-web-theme-monorail/middleware/content-gating.js
+++ b/packages/marko-web-theme-monorail/middleware/content-gating.js
@@ -5,7 +5,7 @@ const defaultFn = ({ content }) => get(content, 'userRegistration.isCurrentlyReq
 
 /**
  * Installs the configured content gating handler in the Express app instance.
- * If not customized, content only be gated when set as gated in the CMS.
+ * If not customized, content will only be gated when set as gated in the CMS.
  */
 module.exports = (app, enabled = true, fn) => { // eslint-disable-line
   const contentGatingHandler = enabled && isFn(fn) ? fn : defaultFn;

--- a/packages/marko-web-theme-monorail/middleware/content-metering.js
+++ b/packages/marko-web-theme-monorail/middleware/content-metering.js
@@ -1,0 +1,133 @@
+const debug = require('debug')('content-meter');
+const parser = require('ua-parser-js');
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const { content: loader } = require('@parameter1/base-cms-web-common/page-loaders');
+const { get, getAsArray } = require('@parameter1/base-cms-object-path');
+const buildContentInput = require('@parameter1/base-cms-marko-web/utils/build-content-input');
+const queryFragment = require('../graphql/fragments/content-meter');
+
+const cookieName = 'contentMeter';
+const now = new Date().getTime();
+const { error } = console;
+
+const shouldMeter = async (req, config) => {
+  const { apollo, params } = req;
+  const { id } = params;
+  const additionalInput = buildContentInput({ req });
+  // @todo error handling!
+  const content = await loader(apollo, { id, additionalInput, queryFragment });
+  if (!content) return false;
+
+  // excludeContentTypes: Excludes content metering on page if type matches exclusions
+  if (getAsArray(config, 'excludeContentTypes').includes(content.type)) {
+    return false;
+  }
+  // excludePrimarySectionIds: Excludes content metering on page that matches primarySection
+  if (getAsArray(config, 'excludePrimarySectionIds').includes(content.primarySection.id)) {
+    return false;
+  }
+  // excludePrimarySectionAliass: Excludes content metering on page that matches primarySection
+  if (getAsArray(config, 'excludePrimarySectionAliass').includes(content.primarySection.alias)) {
+    return false;
+  }
+  // excludeLabels: Excludes content metering on page that matches labels
+  if (getAsArray(config, 'excludeLabels').some((r) => getAsArray(content, 'labels').includes(r))) {
+    return false;
+  }
+  return true;
+};
+
+const hasOmedaId = ({ query, cookies }) => {
+  const getOmedaId = (value) => {
+    if (!value) return null;
+    const trimmed = `${value}`.trim();
+    return /^[a-z0-9]{15}$/i.test(trimmed) ? trimmed : null;
+  };
+  const idFromQuery = getOmedaId(query.oly_enc_id);
+  const idFromCookie = cookies.oly_enc_id ? getOmedaId(cookies.oly_enc_id.replace(/^"/, '').replace(/"$/, '')) : undefined;
+  return Boolean(idFromQuery || idFromCookie);
+};
+
+/**
+ * Installs the configured content metering handler in the Express app instance.
+ * To utilize, chain this middleware on a content route.
+ */
+module.exports = asyncRoute(async (req, res, next) => {
+  const { app, identityX, params: { id } } = req;
+  const config = app.locals.site.getAsObject('contentMeter');
+  const viewLimit = get(config, 'viewLimit', 3);
+  const timeframe = get(config, 'timeframe', 30 * 24 * 60 * 60 * 1000); // 30 days
+
+  if (!get(config, 'enabled', false)) return next();
+
+  if (!identityX) {
+    error('IdentityX middleware must be loaded before content metering middleware!');
+    return next();
+  }
+  const idxObj = { isEnabled: true, requiredAccessLevelIds: [] };
+  const { isLoggedIn, requiresUserInput } = await identityX.checkContentAccess(idxObj);
+
+  const bypassOmeda = hasOmedaId(req);
+  const bypassQuery = ['1', 'true'].includes(get(req, 'query.bypassContentMetering'));
+  const bypassFacebook = parser(req.headers['user-agent']).browser.name === 'Facebook';
+  const bypassPushdown = Boolean(get(res, 'locals.newsletterState.canBeInitiallyExpanded'));
+
+  debug({
+    config,
+    isLoggedIn,
+    requiresUserInput,
+    bypassOmeda,
+    bypassQuery,
+    bypassFacebook,
+    bypassPushdown,
+  });
+
+  // Facebook UA or query parameter present
+  if (bypassQuery || bypassFacebook) return next();
+  // Logged in and all required fields are present.
+  if (isLoggedIn && !requiresUserInput) return next();
+  // Not logged in, but identified.
+  if (!isLoggedIn && bypassOmeda) return next();
+
+  res.locals.contentMeterState = {
+    ...config,
+    isLoggedIn,
+    requiresUserInput,
+    displayGate: false,
+    displayOverlay: true,
+  };
+
+  // Fall back to inline gate form for user data collection
+  if (isLoggedIn && requiresUserInput) return next();
+
+  const shouldShowMeter = await shouldMeter(req, config);
+
+  debug({ shouldShowMeter });
+
+  if (shouldShowMeter) {
+    const hasCookie = Boolean(get(req, `cookies.${cookieName}`));
+    const value = (hasCookie) ? JSON.parse(get(req, `cookies.${cookieName}`)) : [];
+    let valid = value.filter((pageView) => pageView.viewed > now - timeframe);
+
+    if (valid.find((v) => v.id === id)) {
+      valid = valid.map((pageview) => {
+        const { id: viewId } = pageview;
+        if (viewId === id) return { id, viewed: now };
+        return pageview;
+      });
+    } else if (valid.length <= viewLimit) {
+      valid.push({ id, viewed: now });
+    }
+
+    const displayOverlay = (valid.length >= viewLimit && !valid.find((v) => v.id === id));
+
+    res.locals.contentMeterState = {
+      ...res.locals.contentMeterState,
+      views: valid.length,
+      displayGate: !bypassPushdown,
+      displayOverlay,
+    };
+    res.cookie(cookieName, JSON.stringify(valid), { maxAge: timeframe });
+  }
+  return next();
+});

--- a/packages/marko-web-theme-monorail/middleware/content-metering.js
+++ b/packages/marko-web-theme-monorail/middleware/content-metering.js
@@ -68,7 +68,7 @@ module.exports = (config) => asyncRoute(async (req, res, next) => {
 
   const bypassOmeda = hasOmedaId(req);
   const bypassQuery = ['1', 'true'].includes(get(req, 'query.bypassContentMetering'));
-  const bypassFacebook = parser(req.headers['user-agent']).browser.name === 'Facebook';
+  const bypassFacebook = get(parser(req.headers['user-agent']), 'browser.name') === 'Facebook';
   const bypassPushdown = Boolean(get(res, 'locals.newsletterState.canBeInitiallyExpanded'));
 
   debug({

--- a/packages/marko-web-theme-monorail/middleware/content-metering.js
+++ b/packages/marko-web-theme-monorail/middleware/content-metering.js
@@ -52,9 +52,8 @@ const hasOmedaId = ({ query, cookies }) => {
  * Installs the configured content metering handler in the Express app instance.
  * To utilize, chain this middleware on a content route.
  */
-module.exports = asyncRoute(async (req, res, next) => {
-  const { app, identityX, params: { id } } = req;
-  const config = app.locals.site.getAsObject('contentMeter');
+module.exports = (config) => asyncRoute(async (req, res, next) => {
+  const { identityX, params: { id } } = req;
   const viewLimit = get(config, 'viewLimit', 3);
   const timeframe = get(config, 'timeframe', 30 * 24 * 60 * 60 * 1000); // 30 days
 

--- a/packages/marko-web-theme-monorail/middleware/content-metering.js
+++ b/packages/marko-web-theme-monorail/middleware/content-metering.js
@@ -15,13 +15,13 @@ const configSchema = Joi.object({
     .description('The number of views allowed within the timeframe before restricting access.'),
   timeframe: Joi.number().min(0).default(30 * 24 * 60 * 60 * 1000) // 30 days
     .description('Milliseconds to consider content accesses within.'),
-  excludeLabels: Joi.array().items(Joi.string().required())
+  excludeLabels: Joi.array().items(Joi.string())
     .description('Content labels that should be excluded from metering.'),
-  excludeContentTypes: Joi.array().items(Joi.string().required())
+  excludeContentTypes: Joi.array().items(Joi.string())
     .description('Content types that should be excluded from metering.'),
-  excludePrimarySectionIds: Joi.array().items(Joi.number().required())
+  excludePrimarySectionIds: Joi.array().items(Joi.number())
     .description('Sections whose primary content should be excluded from metering.'),
-  excludePrimarySectionAlias: Joi.array().items(Joi.string().required())
+  excludePrimarySectionAlias: Joi.array().items(Joi.string())
     .description('Sections whose primary content should be excluded from metering.'),
   displayOverlay: Joi.boolean().default(false)
     .description('If the metering overlay should be displayed.'),

--- a/packages/marko-web-theme-monorail/package.json
+++ b/packages/marko-web-theme-monorail/package.json
@@ -36,10 +36,12 @@
     "@trevoreyre/autocomplete-vue": "^2.4.1",
     "bootstrap": "^4.6.2",
     "cheerio": "^1.0.0-rc.12",
+    "debug": "^4.3.4",
     "graphql-tag": "^2.12.6",
     "http-errors": "^1.8.1",
     "moment": "^2.29.1",
-    "node-fetch": "^2.6.9"
+    "node-fetch": "^2.6.9",
+    "ua-parser-js": "^1.0.33"
   },
   "peerDependencies": {
     "@parameter1/base-cms-marko-core": "^4.0.0",

--- a/packages/marko-web-theme-monorail/package.json
+++ b/packages/marko-web-theme-monorail/package.json
@@ -33,6 +33,7 @@
     "@parameter1/base-cms-object-path": "^4.5.12",
     "@parameter1/base-cms-utils": "^4.5.12",
     "@parameter1/base-cms-web-common": "^4.5.12",
+    "@parameter1/joi": "^1.2.10",
     "@trevoreyre/autocomplete-vue": "^2.4.1",
     "bootstrap": "^4.6.2",
     "cheerio": "^1.0.0-rc.12",

--- a/packages/marko-web-theme-monorail/scss/components/_content-meter.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_content-meter.scss
@@ -1,0 +1,141 @@
+$content-meter-mobile-breakpoint: 600px !default;
+
+.content-meter {
+  $self: &;
+  &__overlay {
+    z-index: 1499;
+    position: fixed;
+    background-color: rgba(0, 0, 0, .7);
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    visibility: visible;
+    transition: visibility 0s, opacity 0.5s linear;
+  }
+  &__bar {
+    #{ $self } {
+      &__call-to-action {
+        @include skin-typography($style: "content-meter-cta");
+        display: none;
+        @media (max-width: $content-meter-mobile-breakpoint) {
+          text-align: left;
+        }
+        &--site-name {
+          font-style: italic;
+        }
+      }
+      &__body {
+        display: none;
+        #{ $self }__login-form {
+          form > .form-group:first-child label {
+            display: none;
+          }
+          @media (max-width: $content-meter-mobile-breakpoint) {
+            width: 100%;
+          }
+          .btn {
+            @media (max-width: $content-meter-mobile-breakpoint) {
+              width: 100%;
+            }
+          }
+        }
+      }
+    }
+    padding: map-get($spacers, 3);
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    text-align: center;
+    color: $white;
+    background: $black;
+    // footer zindex is set to 1500 ;)
+    z-index: 1501;
+  }
+  &__toggler {
+    border: none;
+    background: initial;
+    &:focus {
+      outline: none;
+
+    }
+    .marko-web-icon svg {
+      fill: $white;
+    };
+    @media (max-width: $content-meter-mobile-breakpoint) {
+      display: flex;
+      width: 100%;
+    }
+    span:not(.marko-web-icon) {
+      @media (max-width: $content-meter-mobile-breakpoint) {
+        flex-grow: 2;
+        text-align: left;
+      }
+      color: $white;
+      font-family: $skin-font-family-secondary;
+      font-weight: $font-weight-bold;
+      font-size: 18px;
+      line-height: 38px;
+      letter-spacing: .3px;
+      text-transform: none;
+    }
+  }
+
+  &__login-form {
+    max-width: 700px;
+    p {
+      font-family: $skin-font-family-secondary;
+      font-weight: $font-weight-medium;
+    }
+    fieldset {
+      @media (min-width: $content-meter-mobile-breakpoint) {
+        display: flex;
+        .form-group {
+          margin-bottom: 0;
+          margin-right: 1rem;
+        }
+      }
+    }
+  }
+
+  &--open {
+    #{ $self } {
+      &__bar {
+        padding-bottom: map-get($spacers, 4);
+      }
+      &__toggler {
+        span {
+          @include skin-typography($style: "content-meter-header");
+          margin-bottom: map-get($spacers, block);
+        }
+      }
+      &__call-to-action {
+        display: block;
+      }
+      &__body {
+        display: flex;
+        min-height: 108px;
+        @media (min-width: $content-meter-mobile-breakpoint) {
+          justify-content: center;
+          min-height: 48px;
+        }
+      }
+    }
+  }
+}
+
+.marko-web-gam-fixed-ad-bottom--visible ~ .content-meter {
+  .content-meter__bar{
+    padding-bottom: 120px;
+    @media (max-width: $content-meter-mobile-breakpoint) {
+      padding-bottom: 70px;
+    }
+  }
+}
+
+.content-meter--display-overlay~.document-container {
+  height: 0;
+  overflow: hidden;
+}
+.content-meter--display-overlay ~ .document-container ~ .site-footer {
+  display: none;
+}

--- a/packages/marko-web-theme-monorail/utils/content-meter-helpers.js
+++ b/packages/marko-web-theme-monorail/utils/content-meter-helpers.js
@@ -1,0 +1,58 @@
+const debug = require('debug')('content-meter');
+const { get } = require('@parameter1/base-cms-object-path');
+const { isFunction: isFn } = require('@parameter1/base-cms-utils');
+
+const shouldOverlay = (contentMeterState) => {
+  if (!contentMeterState) return false;
+  if (!contentMeterState.displayOverlay) return false;
+  if (!contentMeterState.isLoggedIn && !contentMeterState.displayGate) return false;
+  if (contentMeterState.isLoggedIn) return false;
+  return true;
+};
+
+const defaultHandler = ({ content }) => get(content, 'userRegistration.isCurrentlyRequired');
+
+const restrictContentByReg = (contentMeterState, handler, content) => {
+  if (!contentMeterState) return false;
+
+  // If content is gated by reg return true all the time
+  const contentReg = isFn(handler) ? handler({ content }) : defaultHandler({ content });
+  if (contentReg === true) return true;
+
+  const { isLoggedIn, requiresUserInput } = contentMeterState;
+  const displayOverlay = shouldOverlay(contentMeterState);
+  // if the overlay is displayed require reg
+  if (displayOverlay) return true;
+  // if the user is logged in but doesnt have the required fields display gate
+  if (isLoggedIn && requiresUserInput) return true;
+
+  return false;
+};
+
+const shouldTruncate = (contentMeterState) => {
+  if (!contentMeterState) return false;
+
+  const { isLoggedIn, requiresUserInput } = contentMeterState;
+  const displayOverlay = shouldOverlay(contentMeterState);
+  if (!displayOverlay) return false;
+  if (isLoggedIn && !requiresUserInput) return false;
+  return true;
+};
+
+module.exports = {
+  shouldOverlay: (...args) => {
+    const out = shouldOverlay(...args);
+    debug('shouldOverlay', out, args);
+    return out;
+  },
+  restrictContentByReg: (...args) => {
+    const out = restrictContentByReg(...args);
+    debug('restrictContentByReg', out);
+    return out;
+  },
+  shouldTruncate: (...args) => {
+    const out = shouldTruncate(...args);
+    debug('shouldTruncate', out);
+    return out;
+  },
+};

--- a/services/example-website/config/content-meter.js
+++ b/services/example-website/config/content-meter.js
@@ -1,4 +1,6 @@
 module.exports = {
   enabled: true,
-  viewLimit: 1,
+  excludeLabels: [
+    'foobar',
+  ],
 };

--- a/services/example-website/config/content-meter.js
+++ b/services/example-website/config/content-meter.js
@@ -1,0 +1,4 @@
+module.exports = {
+  enabled: true,
+  viewLimit: 1,
+};

--- a/services/example-website/config/site.js
+++ b/services/example-website/config/site.js
@@ -13,6 +13,10 @@ module.exports = {
     clientSecret: process.env.AUTH0_SECRET,
     issuerBaseURL: process.env.AUTH0_ISSUER_URL,
   },
+  contentMeter: {
+    enabled: true,
+    viewLimit: 1,
+  },
   omedaIdentityX,
   identityX,
   nativeX,

--- a/services/example-website/config/site.js
+++ b/services/example-website/config/site.js
@@ -5,6 +5,7 @@ const nativeX = require('./native-x');
 const navigation = require('./navigation');
 const newsletter = require('./newsletter');
 const search = require('./search');
+const contentMeter = require('./content-meter');
 
 module.exports = {
   auth0: {
@@ -13,10 +14,7 @@ module.exports = {
     clientSecret: process.env.AUTH0_SECRET,
     issuerBaseURL: process.env.AUTH0_ISSUER_URL,
   },
-  contentMeter: {
-    enabled: true,
-    viewLimit: 1,
-  },
+  contentMeter,
   omedaIdentityX,
   identityX,
   nativeX,

--- a/services/example-website/server/components/document.marko
+++ b/services/example-website/server/components/document.marko
@@ -1,7 +1,7 @@
 import createOmedaIdentityBuilder from "@parameter1/base-cms-marko-web-p1-events/utils/create-omeda-identity-builder";
 import omedaConfig from "../../config/omeda";
 
-$ const { nativeX, cdn } = out.global;
+$ const { nativeX, cdn, contentMeterState } = out.global;
 
 <marko-web-document ...input>
   <@head>
@@ -67,7 +67,14 @@ $ const { nativeX, cdn } = out.global;
       <theme-site-menu has-user=hasUser reg-enabled=isEnabled />
     </marko-web-identity-x-context>
     <marko-web-leaders-dropdown-portal />
-
+    <if(contentMeterState && !contentMeterState.isLoggedIn)>
+      <theme-content-meter-block
+        views=contentMeterState.views
+        view-limit=contentMeterState.viewLimit
+        display-overlay=contentMeterState.displayOverlay
+        display-gate=contentMeterState.displayGate
+      />
+    </if>
     <${input.aboveContainer} />
   </@above-container>
   <@below-container>

--- a/services/example-website/server/routes/index.js
+++ b/services/example-website/server/routes/index.js
@@ -4,6 +4,7 @@ const search = require('@parameter1/base-cms-marko-web-theme-monorail/routes/sea
 const print = require('@parameter1/base-cms-marko-web-theme-monorail/routes/print');
 const contentMetering = require('@parameter1/base-cms-marko-web-theme-monorail/middleware/content-metering');
 const nativeX = require('./native-x');
+const contentMeteringCfg = require('../../config/content-meter');
 
 const index = require('../templates/index');
 const content = require('../templates/content');
@@ -33,7 +34,7 @@ module.exports = (app, config) => {
 
   // Content
   print(app, queryFragment);
-  app.get('/*?:id(\\d{8})*', contentMetering, withContent({
+  app.get('/*?:id(\\d{8})*', contentMetering(contentMeteringCfg), withContent({
     template: content,
     queryFragment,
   }));

--- a/services/example-website/server/routes/index.js
+++ b/services/example-website/server/routes/index.js
@@ -2,6 +2,7 @@ const { withContent, withWebsiteSection } = require('@parameter1/base-cms-marko-
 const renderBlock = require('@parameter1/base-cms-marko-web-theme-monorail/routes/render-block');
 const search = require('@parameter1/base-cms-marko-web-theme-monorail/routes/search');
 const print = require('@parameter1/base-cms-marko-web-theme-monorail/routes/print');
+const contentMetering = require('@parameter1/base-cms-marko-web-theme-monorail/middleware/content-metering');
 const nativeX = require('./native-x');
 
 const index = require('../templates/index');
@@ -32,7 +33,7 @@ module.exports = (app, config) => {
 
   // Content
   print(app, queryFragment);
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?:id(\\d{8})*', contentMetering, withContent({
     template: content,
     queryFragment,
   }));

--- a/services/example-website/server/styles/index.scss
+++ b/services/example-website/server/styles/index.scss
@@ -4,6 +4,7 @@ $skin-font-family-secondary: informapro, informapro-fallback, sans-serif;
 @import "@parameter1/base-cms-marko-web/scss/fonts/solitaire-mvb-pro-fallback";
 @import "@parameter1/base-cms-marko-web/scss/fonts/informapro-fallback";
 @import "@parameter1/base-cms-marko-web-theme-monorail/scss/core";
+@import "@parameter1/base-cms-marko-web-theme-monorail/scss/components/content-meter";
 @import "@parameter1/base-cms-marko-web-leaders/scss/leaders";
 
 /*! critical:start */

--- a/services/example-website/server/templates/components/content-body.marko
+++ b/services/example-website/server/templates/components/content-body.marko
@@ -1,11 +1,13 @@
 import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
+import cm from "@parameter1/base-cms-marko-web-theme-monorail/utils/content-meter-helpers";
 
 $ const { content, blockName } = input;
-$ const { contentGatingHandler, req } = out.global;
+$ const { contentGatingHandler, contentMeterState, req } = out.global;
 
-$ const requiresReg = contentGatingHandler({ content, req });
+$ const showOverlay = cm.shouldOverlay(contentMeterState);
+$ const requiresReg = cm.restrictContentByReg(contentMeterState, contentGatingHandler, content);
 $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
 $ const authors = getAsArray(content, "authors.edges").map((edge) => edge.node);
 $ const sidebars = getAsArray(content, "sidebars").map((sidebar) => sidebar.body);
@@ -25,7 +27,26 @@ $ const displaySocialShare = defaultValue(input.displaySocialShare, true);
   <if(input.beforeBody)>
     <${input.beforeBody} context=context />
   </if>
-  <if(!context.canAccess || context.requiresUserInput)>
+  <if(cm.shouldTruncate(contentMeterState))>
+    $ const body = showOverlay ? getContentPreview({ body: content.body, selector: "p:lt(7)" }) : getContentPreview({ body: content.body, selector: "p:lt(3)" });
+    <marko-web-content-body block-name=blockName obj={ body } />
+    <div class="content-page-preview-overlay" />
+    <if(!showOverlay)>
+      <theme-content-page-gate
+        can-access=context.canAccess
+        is-logged-in=context.isLoggedIn
+        has-required-access-level=context.hasRequiredAccessLevel
+        requires-access-level=context.requiresAccessLevel
+        requires-user-input=context.requiresUserInput
+        messages=context.messages
+        user-input-title="Step 2 of 2"
+        profile-call-to-action=""
+        profile-button-label="Create Account"
+        profile-event-name="content_meter_profile"
+      />
+    </if>
+  </if>
+  <else-if(!context.canAccess || context.requiresUserInput)>
     $ const body = getContentPreview({ body: content.body, selector: "p:lt(3)" });
     <marko-web-content-body block-name=blockName obj={ body } />
 
@@ -41,7 +62,7 @@ $ const displaySocialShare = defaultValue(input.displaySocialShare, true);
       additional-event-data=additionalEventData
       content-gate-type=contentGateType
     />
-  </if>
+  </else-if>
   <else>
     $ const bodyId = `content-body-${content.id}`;
     <if(shouldInjectAds)>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11304,6 +11304,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
+ua-parser-js@^1.0.33:
+  version "1.0.35"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.35.tgz#c4ef44343bc3db0a3cbefdf21822f1b1fc1ab011"
+  integrity sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==
+
 uglify-js@^3.1.4:
   version "3.17.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"


### PR DESCRIPTION
To install and use this feature, you must:
1. Import the content metering middleware and add to your content routes:
```diff
// site/routes/content.js

+const contentMetering = require('@parameter1/base-cms-marko-web-theme-monorail/middleware/content-metering');
+const config = require('../config/content-meter');

module.exports (app) => {
-  app.get('/*?:id(\\d{8})*', withContent({
+  app.get('/*?:id(\\d{8})*', contentMetering(config), withContent({
    template: content,
    queryFragment,
  }));
```

2. Add the `contentMeter` site config object. See the [README](packages/marko-web-theme-monorail/README.md#content-metering) for defined options/default values.


```diff
# site/config/site.js

+const contentMeter = require('./content-meter');

module.exports = {
  // ...
+  contentMeter,
  // ...
}
```

```js
// site/config/content-meter.js

module.exports = {
  enabled: process.env.ENABLE_CONTENT_METER || false,
  viewLimit: 5,
}
```

| Key | Default value | Description |
| - | - | - |
| `enabled` | `false` | If the feature should be enabled. |
| `viewLimit` |  `3` | The number of content items a viewer can see in `timeframe` without logging in. |
| `timeframe` | `30 * 24 * 60 * 60 * 1000` (30 days in ms) | The timeframe to consider |
| `excludeLabels` | `[]` | Content labels that should be excluded from metering. |
| `excludeContentTypes` | `[]` | Content types that should be excluded from metering. |
| `excludePrimarySectionIds` | `[]` | Sections whose primary content should be excluded from metering. |
| `excludePrimarySectionAlias` | `[]` | Sections whose primary content should be excluded from metering. |
| `displayOverlay` | _None_ | ??? @B77Mills what is this |
| `promoCode` | _None_ | If present, the Omeda promo code to use with content metering events. |

3. Add the UI display and event tracking component to your core `document` component (ideally in above-container):
```marko
<!-- site/server/components/document.marko -->

$ const { contentMeterState } = out.global;
<if(contentMeterState && !contentMeterState.isLoggedIn)>
  <theme-content-meter-block
    views=contentMeterState.views
    view-limit=contentMeterState.viewLimit
    display-overlay=contentMeterState.displayOverlay
    display-gate=contentMeterState.displayGate
  />
</if>
```

5. Adjust the content body template/layout to truncate the body and/or show inline gating options:
```marko
<!-- site/components/layouts/content.marko -->

import cm from "@parameter1/base-cms-marko-web-theme-monorail/utils/content-meter-helpers";

$ const { content, blockName } = input;
$ const { contentGatingHandler, contentMeterState, req } = out.global;

$ const showOverlay = cm.shouldOverlay(contentMeterState);
$ const requiresReg = cm.restrictContentByReg(contentMeterState, contentGatingHandler, content);

$ let body = content.body;
<if(cm.shouldTruncate(contentMeterState))>
  $ if (showOverlay) body = getContentPreview({ body: content.body, selector: "p:lt(7)" });
  <marko-web-content-body block-name=blockName obj={ body } />
  <div class="content-page-preview-overlay" />
  <if(!showOverlay)>
    <theme-content-page-gate
      can-access=context.canAccess
      is-logged-in=context.isLoggedIn
      $ // ...
    />
  </if>
</if>
<else-if(!context.canAccess || context.requiresUserInput)>
  $ // ...

```
