### PR TITLE
Move change email button and display address

### DIFF
--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -5,6 +5,25 @@
     </p>
     <form v-if="!didSubmit" @submit.prevent="handleSubmit">
       <fieldset :disabled="isLoading">
+        <div v-if="enableChangeEmail" class="row">
+          <div class="col-12">
+            <label>Email address</label>
+            <div class="form-group">
+              <div class="input-group">
+                <input disabled :value="user.email" class="form-control">
+                <div class="input-group-append">
+                  <a
+                    :href="endpoints.changeEmail"
+                    class="btn btn-outline-secondary d-flex justify-content-center flex-column"
+                    title="Change your login email address"
+                  >
+                    Change email
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="row">
           <div
             v-if="givenNameSettings.visible"
@@ -161,14 +180,6 @@
           <button type="submit" class="btn btn-primary">
             {{ buttonLabel }}
           </button>
-          <a
-            v-if="enableChangeEmail"
-            :href="endpoints.changeEmail"
-            class="ml-3 btn btn-secondary"
-            title="Change your login email address"
-          >
-            Change email
-          </a>
         </div>
       </fieldset>
       <p v-if="error" class="mt-3 text-danger">


### PR DESCRIPTION
If enabled, display the user's current email address and move the "change" button next to it.

![image](https://user-images.githubusercontent.com/1778222/230668246-3bc97148-97aa-4af7-86ac-04bcde7a8ace.png)
![image](https://user-images.githubusercontent.com/1778222/230668220-6ff496c6-7488-467c-b5ef-91c255a5f258.png)
