### PR TITLE
Add regByPass & contentGatingHandler support to content metering middleware

### DIFF
--- a/packages/marko-web-theme-monorail/middleware/content-metering.js
+++ b/packages/marko-web-theme-monorail/middleware/content-metering.js
@@ -2,7 +2,7 @@ const debug = require('debug')('content-meter');
 const parser = require('ua-parser-js');
 const Joi = require('@parameter1/joi');
 const { validate } = require('@parameter1/joi/utils');
-const { asyncRoute } = require('@parameter1/base-cms-utils');
+const { asyncRoute, isFunction } = require('@parameter1/base-cms-utils');
 const { content: loader } = require('@parameter1/base-cms-web-common/page-loaders');
 const { get, getAsArray } = require('@parameter1/base-cms-object-path');
 const buildContentInput = require('@parameter1/base-cms-marko-web/utils/build-content-input');
@@ -33,7 +33,6 @@ const cookieName = 'contentMeter';
 const now = new Date().getTime();
 const { error } = console;
 
-const isFn = (f) => typeof f === 'function';
 const defaultRegFn = ({ content }) => get(content, 'userRegistration.isCurrentlyRequired', false);
 const shouldMeter = async (req, config) => {
   const { apollo, params } = req;
@@ -46,7 +45,7 @@ const shouldMeter = async (req, config) => {
   // Check for local contentGatingHandler and use it or use the defaultRegFn
   const localFn = req.app.locals.contentGatingHandler;
   // Get the globally avaiable one if set and is function
-  const contentGatingHandler = (localFn && isFn(localFn)) ? localFn : defaultRegFn;
+  const contentGatingHandler = (localFn && isFunction(localFn)) ? localFn : defaultRegFn;
   // bypass if content is already gated by reg of some sort
   if (contentGatingHandler({ content })) {
     return false;


### PR DESCRIPTION
Account for when content is already gated by reg, either by default or by the global contentGatingHandler.  In this case if it is already gated return showGate of false as it will already force the user to fill out registration to access. 