### PR TITLE
Allow passing image props to section-card-list-block

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/section-card-list.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-card-list.marko
@@ -18,7 +18,7 @@ $ const buttonClass = input.buttonClass || "btn btn-secondary";
 $ const linkHeader = input.linkHeader || false;
 $ const imageProps = getAsObject(input.imageProps);
 $ const imageFluid = defaultValue(imageProps.fluid, true);
-$ const imageWidth = defaultValue(imageProps.width, 340;
+$ const imageWidth = defaultValue(imageProps.width, 340);
 $ const imageAspectRatio = defaultValue(imageProps.ar, "3:2");
 
 <marko-web-query|{ nodes, section }| name="website-scheduled-content" params=queryParams>

--- a/packages/marko-web-theme-monorail/components/blocks/section-card-list.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-card-list.marko
@@ -1,3 +1,5 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { getAsObject } from "@parameter1/base-cms-object-path";
 import queryFragment from "../../graphql/fragments/section-card-list-block";
 import sectionFragment from "../../graphql/fragments/section-info";
 
@@ -14,10 +16,10 @@ $ const queryParams = {
 $ const blockName = "section-card-list";
 $ const buttonClass = input.buttonClass || "btn btn-secondary";
 $ const linkHeader = input.linkHeader || false;
-$ const imageProps = input.imageProps;
-$ const imageFluid = typeof imageProps.fluid === 'boolean' ? imageProps.fluid : true;
-$ const imageWidth = imageProps.width ? imageProps.width : 340;
-$ const imageAspectRatio = imageProps.ar ? imageProps.ar : "3:2"
+$ const imageProps = getAsObject(input.imageProps);
+$ const imageFluid = defaultValue(imageProps.fluid, true);
+$ const imageWidth = defaultValue(imageProps.width, 340;
+$ const imageAspectRatio = defaultValue(imageProps.ar, "3:2");
 
 <marko-web-query|{ nodes, section }| name="website-scheduled-content" params=queryParams>
   $ const heroNode = nodes.slice(0, 1)[0];

--- a/packages/marko-web-theme-monorail/components/blocks/section-card-list.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/section-card-list.marko
@@ -14,6 +14,10 @@ $ const queryParams = {
 $ const blockName = "section-card-list";
 $ const buttonClass = input.buttonClass || "btn btn-secondary";
 $ const linkHeader = input.linkHeader || false;
+$ const imageProps = input.imageProps;
+$ const imageFluid = typeof imageProps.fluid === 'boolean' ? imageProps.fluid : true;
+$ const imageWidth = imageProps.width ? imageProps.width : 340;
+$ const imageAspectRatio = imageProps.ar ? imageProps.ar : "3:2"
 
 <marko-web-query|{ nodes, section }| name="website-scheduled-content" params=queryParams>
   $ const heroNode = nodes.slice(0, 1)[0];
@@ -50,7 +54,7 @@ $ const linkHeader = input.linkHeader || false;
           modifiers=[`${blockName}-hero-image`]
           node=heroImageNode
         >
-          <@image fluid=true width=340 ar="3:2" />
+          <@image fluid=imageFluid width=imageWidth ar=imageAspectRatio />
         </theme-content-node>
       </marko-web-element>
       <marko-web-element block-name=blockName name="col">


### PR DESCRIPTION
Production:
![Screenshot from 2023-04-13 08-35-38](https://user-images.githubusercontent.com/46794001/231775637-d76fdc63-a303-4010-851f-f8ae27963089.png)

Dev:
![Screenshot from 2023-04-13 08-25-52](https://user-images.githubusercontent.com/46794001/231775551-ab364796-46f9-42a1-be23-7905209d4b16.png)

This allows `fluid` `width` and `ar` (aspect-ratio) to be passed in via `imageProps` in order to change how the image in this block renders.