### PR TITLE
Use `autocomplete.phrase` when configured appropriately.

### DIFF
--- a/packages/marko-web-search/components/query.marko
+++ b/packages/marko-web-search/components/query.marko
@@ -22,7 +22,7 @@ $ const params = {
   ),
   queryFragment: input.queryFragment,
   opSuffix: input.opSuffix,
-  enableNewSearch: site.get('enableNewSearch', false),
+  useAutocomplete: site.get('useAutocomplete', false),
 };
 
 <marko-web-resolve|{ resolved }| promise=loader({ apolloBaseCMS, apolloBaseBrowse }, params)>

--- a/packages/marko-web-search/components/query.marko
+++ b/packages/marko-web-search/components/query.marko
@@ -4,6 +4,7 @@ $ const {
   apollo: apolloBaseCMS,
   $baseBrowse: apolloBaseBrowse,
   config,
+  site
 } = out.global;
 $ const { assignedToWebsiteSectionIds } = input;
 
@@ -21,6 +22,7 @@ $ const params = {
   ),
   queryFragment: input.queryFragment,
   opSuffix: input.opSuffix,
+  enableNewSearch: site.get('enableNewSearch', false),
 };
 
 <marko-web-resolve|{ resolved }| promise=loader({ apolloBaseCMS, apolloBaseBrowse }, params)>

--- a/packages/marko-web-search/components/query.marko
+++ b/packages/marko-web-search/components/query.marko
@@ -22,7 +22,7 @@ $ const params = {
   ),
   queryFragment: input.queryFragment,
   opSuffix: input.opSuffix,
-  useAutocomplete: site.get('useAutocomplete', false),
+  useAutocomplete: site.get('search.useAutocomplete', false),
 };
 
 <marko-web-resolve|{ resolved }| promise=loader({ apolloBaseCMS, apolloBaseBrowse }, params)>

--- a/packages/marko-web-search/loaders/search.js
+++ b/packages/marko-web-search/loaders/search.js
@@ -64,17 +64,16 @@ module.exports = async ({ apolloBaseCMS, apolloBaseBrowse } = {}, {
 
   queryFragment,
   opSuffix,
+  enableNewSearch = false,
 } = {}) => {
   if (!apolloBaseCMS || !apolloBaseBrowse) throw new Error('Both the BaseCMS and Base Browse Apollo clients must be provided.');
-  const query = (!searchQuery.match(/^".+"$/) && !searchQuery.match(/^'.+'$/)) ? searchQuery : '';
-  const phrase = (searchQuery.match(/^".+"$/) || searchQuery.match(/^'.+'$/)) ? searchQuery : '';
   const input = {
     omitScheduledAndExpiredContent: true,
     statuses: ['PUBLISHED'],
     contentTypes,
     countryCodes,
-    ...(query && { search: { query } }),
-    ...(phrase && { autocomplete: { phrase } }),
+    ...(!enableNewSearch && searchQuery && { search: { query: searchQuery } }),
+    ...(enableNewSearch && searchQuery && { autocomplete: { phrase: searchQuery }}),
     ...((assignedToWebsiteSiteIds.length || assignedToWebsiteSectionIds.length) && {
       assignedToWebsites: {
         ...(assignedToWebsiteSiteIds.length && { siteIds: assignedToWebsiteSiteIds }),

--- a/packages/marko-web-search/loaders/search.js
+++ b/packages/marko-web-search/loaders/search.js
@@ -67,14 +67,14 @@ module.exports = async ({ apolloBaseCMS, apolloBaseBrowse } = {}, {
 } = {}) => {
   if (!apolloBaseCMS || !apolloBaseBrowse) throw new Error('Both the BaseCMS and Base Browse Apollo clients must be provided.');
   const query = (!searchQuery.match(/^".+"$/) && !searchQuery.match(/^'.+'$/)) ? searchQuery : '';
-  const phrase = (searchQuery.match(/^".+"$/) || searchQuery.match(/^'.+'$/)) ? searchQuery.replace(/[",']/g, '') : '';
+  const phrase = (searchQuery.match(/^".+"$/) || searchQuery.match(/^'.+'$/)) ? searchQuery : '';
   const input = {
     omitScheduledAndExpiredContent: true,
     statuses: ['PUBLISHED'],
     contentTypes,
     countryCodes,
     ...(query && { search: { query } }),
-    ...(phrase && { autocomplete: { phrase }}),
+    ...(phrase && { autocomplete: { phrase } }),
     ...((assignedToWebsiteSiteIds.length || assignedToWebsiteSectionIds.length) && {
       assignedToWebsites: {
         ...(assignedToWebsiteSiteIds.length && { siteIds: assignedToWebsiteSiteIds }),

--- a/packages/marko-web-search/loaders/search.js
+++ b/packages/marko-web-search/loaders/search.js
@@ -73,7 +73,7 @@ module.exports = async ({ apolloBaseCMS, apolloBaseBrowse } = {}, {
     contentTypes,
     countryCodes,
     ...(!enableNewSearch && searchQuery && { search: { query: searchQuery } }),
-    ...(enableNewSearch && searchQuery && { autocomplete: { phrase: searchQuery }}),
+    ...(enableNewSearch && searchQuery && { autocomplete: { phrase: searchQuery } }),
     ...((assignedToWebsiteSiteIds.length || assignedToWebsiteSectionIds.length) && {
       assignedToWebsites: {
         ...(assignedToWebsiteSiteIds.length && { siteIds: assignedToWebsiteSiteIds }),

--- a/packages/marko-web-search/loaders/search.js
+++ b/packages/marko-web-search/loaders/search.js
@@ -66,12 +66,15 @@ module.exports = async ({ apolloBaseCMS, apolloBaseBrowse } = {}, {
   opSuffix,
 } = {}) => {
   if (!apolloBaseCMS || !apolloBaseBrowse) throw new Error('Both the BaseCMS and Base Browse Apollo clients must be provided.');
+  const query = (!searchQuery.match(/^".+"$/) && !searchQuery.match(/^'.+'$/)) ? searchQuery : '';
+  const phrase = (searchQuery.match(/^".+"$/) || searchQuery.match(/^'.+'$/)) ? searchQuery.replace(/[",']/g, '') : '';
   const input = {
     omitScheduledAndExpiredContent: true,
     statuses: ['PUBLISHED'],
     contentTypes,
     countryCodes,
-    ...(searchQuery && { search: { query: searchQuery } }),
+    ...(query && { search: { query } }),
+    ...(phrase && { autocomplete: { phrase }}),
     ...((assignedToWebsiteSiteIds.length || assignedToWebsiteSectionIds.length) && {
       assignedToWebsites: {
         ...(assignedToWebsiteSiteIds.length && { siteIds: assignedToWebsiteSiteIds }),

--- a/packages/marko-web-search/loaders/search.js
+++ b/packages/marko-web-search/loaders/search.js
@@ -64,7 +64,7 @@ module.exports = async ({ apolloBaseCMS, apolloBaseBrowse } = {}, {
 
   queryFragment,
   opSuffix,
-  enableNewSearch = false,
+  useAutocomplete = false,
 } = {}) => {
   if (!apolloBaseCMS || !apolloBaseBrowse) throw new Error('Both the BaseCMS and Base Browse Apollo clients must be provided.');
   const input = {
@@ -72,8 +72,8 @@ module.exports = async ({ apolloBaseCMS, apolloBaseBrowse } = {}, {
     statuses: ['PUBLISHED'],
     contentTypes,
     countryCodes,
-    ...(!enableNewSearch && searchQuery && { search: { query: searchQuery } }),
-    ...(enableNewSearch && searchQuery && { autocomplete: { phrase: searchQuery } }),
+    ...(!useAutocomplete && searchQuery && { search: { query: searchQuery } }),
+    ...(useAutocomplete && searchQuery && { autocomplete: { phrase: searchQuery } }),
     ...((assignedToWebsiteSiteIds.length || assignedToWebsiteSectionIds.length) && {
       assignedToWebsites: {
         ...(assignedToWebsiteSiteIds.length && { siteIds: assignedToWebsiteSiteIds }),


### PR DESCRIPTION
This is not an end all be all "magic silver bullet" regarding search however this at the very least better lines up the entered input with the returned results.

PRODUCTION:
![Screenshot from 2023-04-13 13-17-48](https://user-images.githubusercontent.com/46794001/231849677-de204924-39a2-4ab1-a85b-d06a7a4da5e1.png)

DEVELOPMENT:
![Screenshot from 2023-04-13 13-17-00](https://user-images.githubusercontent.com/46794001/231849867-f918a9de-8b1e-4bcf-9dae-82657296d1b0.png)

We may however want to investigate how "boosts", sorts, etc. are applied in either case (see: https://github.com/parameter1/base-browse/blob/main/api/src/graphql/search-content.js#L234)