### PR TITLE
Adjust Identity X events emitter

### DIFF
--- a/packages/marko-web-gtm/browser/index.js
+++ b/packages/marko-web-gtm/browser/index.js
@@ -11,47 +11,4 @@ export default (Browser) => {
   Browser.register('GTMTrackBusEvent', GTMTrackBusEvent, {
     provide: { EventBus },
   });
-
-  // Send emitted IdentityX events to the datalayer
-  window.dataLayer = window.dataLayer || [];
-  [
-    // Views
-    'identity-x-authenticate-mounted',
-    'identity-x-comment-stream-mounted',
-    'identity-x-comment-post-mounted',
-    'identity-x-comment-create-mounted',
-    'identity-x-login-mounted',
-    'identity-x-logout-mounted',
-    'identity-x-profile-mounted',
-    // Actions/submissions
-    'identity-x-authenticated',
-    'identity-x-auto-signup',
-    'identity-x-comment-post-submitted',
-    'identity-x-comment-report-submitted',
-    'identity-x-comment-stream-loaded',
-    'identity-x-comment-stream-loaded-more',
-    'identity-x-login-link-sent',
-    'identity-x-logout',
-    'identity-x-profile-updated',
-    // Errors
-    'identity-x-authenticate-errored',
-    'identity-x-comment-post-errored',
-    'identity-x-comment-report-errored',
-    'identity-x-comment-stream-errored',
-    'identity-x-login-errored',
-    'identity-x-logout-errored',
-    'identity-x-profile-errored',
-  ].forEach((event) => {
-    EventBus.$on(event, (args) => {
-      if (!window.IdentityX) return;
-      window.dataLayer.push({
-        event,
-        'identity-x': {
-          ...(args && args),
-          event,
-          loginSource: window.IdentityX.getLoginSource(),
-        },
-      });
-    });
-  });
 };

--- a/packages/marko-web-gtm/browser/index.js
+++ b/packages/marko-web-gtm/browser/index.js
@@ -11,46 +11,4 @@ export default (Browser) => {
   Browser.register('GTMTrackBusEvent', GTMTrackBusEvent, {
     provide: { EventBus },
   });
-
-  // Send emitted IdentityX events to the datalayer
-  window.dataLayer = window.dataLayer || [];
-  [
-    // Views
-    'identity-x-authenticate-mounted',
-    'identity-x-comment-stream-mounted',
-    'identity-x-comment-post-mounted',
-    'identity-x-comment-create-mounted',
-    'identity-x-login-mounted',
-    'identity-x-logout-mounted',
-    'identity-x-profile-mounted',
-    // Actions/submissions
-    'identity-x-authenticated',
-    'identity-x-comment-post-submitted',
-    'identity-x-comment-report-submitted',
-    'identity-x-comment-stream-loaded',
-    'identity-x-comment-stream-loaded-more',
-    'identity-x-login-link-sent',
-    'identity-x-logout',
-    'identity-x-profile-updated',
-    // Errors
-    'identity-x-authenticate-errored',
-    'identity-x-comment-post-errored',
-    'identity-x-comment-report-errored',
-    'identity-x-comment-stream-errored',
-    'identity-x-login-errored',
-    'identity-x-logout-errored',
-    'identity-x-profile-errored',
-  ].forEach((event) => {
-    EventBus.$on(event, (args) => {
-      if (!window.IdentityX) return;
-      window.dataLayer.push({
-        event,
-        'identity-x': {
-          ...(args && args),
-          event,
-          loginSource: window.IdentityX.getLoginSource(),
-        },
-      });
-    });
-  });
 };

--- a/packages/marko-web-gtm/browser/index.js
+++ b/packages/marko-web-gtm/browser/index.js
@@ -25,6 +25,7 @@ export default (Browser) => {
     'identity-x-profile-mounted',
     // Actions/submissions
     'identity-x-authenticated',
+    'identity-x-auto-signup',
     'identity-x-comment-post-submitted',
     'identity-x-comment-report-submitted',
     'identity-x-comment-stream-loaded',

--- a/packages/marko-web-gtm/browser/index.js
+++ b/packages/marko-web-gtm/browser/index.js
@@ -11,4 +11,46 @@ export default (Browser) => {
   Browser.register('GTMTrackBusEvent', GTMTrackBusEvent, {
     provide: { EventBus },
   });
+
+  // Send emitted IdentityX events to the datalayer
+  window.dataLayer = window.dataLayer || [];
+  [
+    // Views
+    'identity-x-authenticate-mounted',
+    'identity-x-comment-stream-mounted',
+    'identity-x-comment-post-mounted',
+    'identity-x-comment-create-mounted',
+    'identity-x-login-mounted',
+    'identity-x-logout-mounted',
+    'identity-x-profile-mounted',
+    // Actions/submissions
+    'identity-x-authenticated',
+    'identity-x-comment-post-submitted',
+    'identity-x-comment-report-submitted',
+    'identity-x-comment-stream-loaded',
+    'identity-x-comment-stream-loaded-more',
+    'identity-x-login-link-sent',
+    'identity-x-logout',
+    'identity-x-profile-updated',
+    // Errors
+    'identity-x-authenticate-errored',
+    'identity-x-comment-post-errored',
+    'identity-x-comment-report-errored',
+    'identity-x-comment-stream-errored',
+    'identity-x-login-errored',
+    'identity-x-logout-errored',
+    'identity-x-profile-errored',
+  ].forEach((event) => {
+    EventBus.$on(event, (args) => {
+      if (!window.IdentityX) return;
+      window.dataLayer.push({
+        event,
+        'identity-x': {
+          ...(args && args),
+          event,
+          loginSource: window.IdentityX.getLoginSource(),
+        },
+      });
+    });
+  });
 };

--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -212,7 +212,6 @@ export default {
 
         const res = await post('/authenticate', { token, additionalEventData });
         const data = await res.json();
-
         if (!res.ok) throw new AuthenticationError(data.message, res.status);
 
         this.activeUser = data.user;
@@ -227,7 +226,7 @@ export default {
           mustReVerifyProfile: this.mustReVerifyProfile,
           isProfileComplete: this.isProfileComplete,
           requiresCustomFieldAnswers: this.requiresCustomFieldAnswers,
-          loginSource: data.loginSource,
+          actionSource: data.loginSource,
           additionalEventData: {
             ...(this.additionalEventData || {}),
             ...(data.additionalEventData || {}),

--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -227,6 +227,7 @@ export default {
           mustReVerifyProfile: this.mustReVerifyProfile,
           isProfileComplete: this.isProfileComplete,
           requiresCustomFieldAnswers: this.requiresCustomFieldAnswers,
+          loginSource: data.loginSource,
           additionalEventData: {
             ...(this.additionalEventData || {}),
             ...(data.additionalEventData || {}),

--- a/packages/marko-web-identity-x/browser/index.js
+++ b/packages/marko-web-identity-x/browser/index.js
@@ -74,7 +74,7 @@ export default (Browser, {
       window.dataLayer.push({
         event,
         'identity-x': {
-          ...(args && args),
+          ...args,
           event,
         },
       });

--- a/packages/marko-web-identity-x/browser/index.js
+++ b/packages/marko-web-identity-x/browser/index.js
@@ -38,4 +38,46 @@ export default (Browser, {
 
   // Ensure the client-side IdX context is refreshed when the authentication event occurs
   EventBus.$on('identity-x-authenticated', () => window.IdentityX.refreshContext());
+
+  // Send emitted IdentityX events to the datalayer
+  window.dataLayer = window.dataLayer || [];
+  [
+    // Views
+    'identity-x-authenticate-mounted',
+    'identity-x-comment-stream-mounted',
+    'identity-x-comment-post-mounted',
+    'identity-x-comment-create-mounted',
+    'identity-x-login-mounted',
+    'identity-x-logout-mounted',
+    'identity-x-profile-mounted',
+    // Actions/submissions
+    'identity-x-authenticated',
+    'identity-x-auto-signup',
+    'identity-x-comment-post-submitted',
+    'identity-x-comment-report-submitted',
+    'identity-x-comment-stream-loaded',
+    'identity-x-comment-stream-loaded-more',
+    'identity-x-login-link-sent',
+    'identity-x-logout',
+    'identity-x-profile-updated',
+    // Errors
+    'identity-x-authenticate-errored',
+    'identity-x-comment-post-errored',
+    'identity-x-comment-report-errored',
+    'identity-x-comment-stream-errored',
+    'identity-x-login-errored',
+    'identity-x-logout-errored',
+    'identity-x-profile-errored',
+  ].forEach((event) => {
+    EventBus.$on(event, (args) => {
+      if (!window.IdentityX) return;
+      window.dataLayer.push({
+        event,
+        'identity-x': {
+          ...(args && args),
+          event,
+        },
+      });
+    });
+  });
 };

--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -85,6 +85,7 @@ import post from './utils/post';
 import cookiesEnabled from './utils/cookies-enabled';
 import FormError from './errors/form';
 import FeatureError from './errors/feature';
+import AutoSignupEventEmitter from './mixins/global-auto-signup-event-emitter';
 import EventEmitter from './mixins/global-event-emitter';
 
 export default {
@@ -100,7 +101,7 @@ export default {
   /**
    *
    */
-  mixins: [EventEmitter],
+  mixins: [EventEmitter, AutoSignupEventEmitter],
 
   /**
    *
@@ -307,6 +308,7 @@ export default {
           throw new FormError(data.message, res.status);
         }
         this.complete = true;
+        this.emitAutoSignup(data);
         this.emit('login-link-sent', {
           data,
           email: this.email,

--- a/packages/marko-web-identity-x/browser/mixins/global-auto-signup-event-emitter.js
+++ b/packages/marko-web-identity-x/browser/mixins/global-auto-signup-event-emitter.js
@@ -1,4 +1,4 @@
-import getAsArray from '@parameter1/base-cms-object-path';
+import getAsArray from '../../utils/get-as-array';
 
 export default {
   inject: ['EventBus'],

--- a/packages/marko-web-identity-x/browser/mixins/global-auto-signup-event-emitter.js
+++ b/packages/marko-web-identity-x/browser/mixins/global-auto-signup-event-emitter.js
@@ -1,0 +1,18 @@
+import getAsArray from '../../utils/get-as-array';
+
+export default {
+  inject: ['EventBus'],
+  methods: {
+    emitAutoSignup(data) {
+      const { EventBus } = this;
+      // See if there are any autoSignups added to the additionalEventData
+      // Trigger related autoSignup events for each productId being applied.
+      const autoSignups = getAsArray(data, 'additionalEventData.autoSignups');
+      if (autoSignups && autoSignups.length) {
+        autoSignups.forEach((autoSignup) => {
+          EventBus.$emit('identity-x-auto-signup', autoSignup);
+        });
+      }
+    },
+  },
+};

--- a/packages/marko-web-identity-x/browser/mixins/global-auto-signup-event-emitter.js
+++ b/packages/marko-web-identity-x/browser/mixins/global-auto-signup-event-emitter.js
@@ -1,4 +1,4 @@
-import getAsArray from '../../utils/get-as-array';
+import getAsArray from '@parameter1/base-cms-object-path';
 
 export default {
   inject: ['EventBus'],

--- a/packages/marko-web-identity-x/browser/mixins/global-event-emitter.js
+++ b/packages/marko-web-identity-x/browser/mixins/global-event-emitter.js
@@ -9,8 +9,8 @@ export default {
   methods: {
     emit(name, data) {
       const source = this.loginSource || this.source;
-      const actionSource = window.IdentityX.getLoginSource() || source;
-      console.warn('actionSource: ', actionSource, data, this.token);
+      const dataActionSource = data ? data.actionSource : undefined;
+      const actionSource = dataActionSource || window.IdentityX.getLoginSource() || source;
       const payload = {
         ...data,
         ...this.additionalEventData,

--- a/packages/marko-web-identity-x/browser/mixins/global-event-emitter.js
+++ b/packages/marko-web-identity-x/browser/mixins/global-event-emitter.js
@@ -8,12 +8,16 @@ export default {
   },
   methods: {
     emit(name, data) {
+      const source = this.loginSource || this.source;
+      const actionSource = window.IdentityX.getLoginSource() || source;
+      console.warn('actionSource: ', actionSource, data, this.token);
       const payload = {
         ...data,
         ...this.additionalEventData,
-        // Ensure the `actionSource` is emitted with client-side events
-        ...(this.source && { actionSource: this.source }),
-        ...(this.loginSource && { actionSource: this.loginSource }),
+        additionalEventData: this.additionalEventData,
+        actionSource,
+        loginSource: actionSource,
+        source: actionSource,
       };
       const { EventBus } = this;
       this.$emit(name, payload);

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -252,6 +252,7 @@ import Login from './login.vue';
 
 import FeatureError from './errors/feature';
 import FormError from './errors/form';
+import AutoSignupEventEmitter from './mixins/global-auto-signup-event-emitter';
 import EventEmitter from './mixins/global-event-emitter';
 
 const { isArray } = Array;
@@ -275,7 +276,7 @@ export default {
   /**
    *
    */
-  mixins: [EventEmitter],
+  mixins: [EventEmitter, AutoSignupEventEmitter],
 
   /**
    *
@@ -628,6 +629,7 @@ export default {
         // force scroll to top of page when form and success message toggle
         window.scrollTo(0, 0);
 
+        this.emitAutoSignup(data);
         this.emit('profile-updated', {
           additionalEventData: {
             ...(this.additionalEventData || {}),

--- a/packages/marko-web-identity-x/package.json
+++ b/packages/marko-web-identity-x/package.json
@@ -26,7 +26,8 @@
     "express": "^4.18.2",
     "graphql-tag": "^2.12.6",
     "jsonwebtoken": "^8.5.1",
-    "node-fetch": "^2.6.9"
+    "node-fetch": "^2.6.9",
+    "object-path": "^0.11.8"
   },
   "peerDependencies": {
     "@parameter1/base-cms-marko-core": "^4.0.0",

--- a/packages/marko-web-identity-x/package.json
+++ b/packages/marko-web-identity-x/package.json
@@ -26,8 +26,7 @@
     "express": "^4.18.2",
     "graphql-tag": "^2.12.6",
     "jsonwebtoken": "^8.5.1",
-    "node-fetch": "^2.6.9",
-    "object-path": "^0.11.8"
+    "node-fetch": "^2.6.9"
   },
   "peerDependencies": {
     "@parameter1/base-cms-marko-core": "^4.0.0",

--- a/packages/marko-web-identity-x/utils/get-as-array.js
+++ b/packages/marko-web-identity-x/utils/get-as-array.js
@@ -1,0 +1,6 @@
+import { get } from 'object-path';
+
+export default (obj, path) => {
+  const v = get(obj, path, []);
+  return Array.isArray(v) ? v : [];
+};

--- a/packages/marko-web-identity-x/utils/get-as-array.js
+++ b/packages/marko-web-identity-x/utils/get-as-array.js
@@ -1,6 +1,0 @@
-import { get } from 'object-path';
-
-export default (obj, path) => {
-  const v = get(obj, path, []);
-  return Array.isArray(v) ? v : [];
-};


### PR DESCRIPTION
Adjust how Identity X event emitter handles loginSource, source & actionSource.  
```js
const source = this.loginSource || this.source;
const dataActionSource = data ? data.actionSource : undefined;
const actionSource = dataActionSource || window.IdentityX.getLoginSource() || source;
```
It will then also set actionSource, loginSource & source to the calculated actionSource. 

I also add new mixin to the identityX package to handle the event for the auto signup from additionalEvent Data.  This specifically deals with the identity-x-auto-signup event.  
