### PR TITLE
Fix display of IdentityX custom form controls

### DIFF
--- a/packages/marko-web-identity-x/browser/form/fields/custom-select-group.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/custom-select-group.vue
@@ -23,12 +23,3 @@ export default {
   },
 };
 </script>
-
-<style>
-.csmulti-legend {
-  font-size: 1rem;
-}
-div.checkbox-group + fieldset.csmulti-group {
-  margin-top: 0.5rem;
-}
-</style>

--- a/packages/marko-web-identity-x/browser/form/fields/custom-select-multiple.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/custom-select-multiple.vue
@@ -5,7 +5,7 @@
       <strong v-if="required" class="text-danger">*</strong>
     </legend>
 
-    <div class="csmulti-wrapper border p-2">
+    <div class="csmulti-wrapper p-2">
       <div class="csmulti-inner">
         <label class="text-muted">
           Select all that apply...

--- a/packages/marko-web-identity-x/browser/form/fields/custom-select-multiple.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/custom-select-multiple.vue
@@ -95,20 +95,3 @@ export default {
   },
 };
 </script>
-
-<style>
-.csmulti-legend {
-  font-size: 1rem;
-}
-.csmulti-wrapper {
-  max-height: 150px;
-  overflow: hidden;
-}
-.csmulti-inner {
-  overflow-y: auto;
-  max-height: 132px;
-}
-.csmulti + .input-group {
-  margin-top: 0.5rem;
-}
-</style>

--- a/packages/marko-web-theme-monorail/scss/components/_identity-x.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_identity-x.scss
@@ -25,13 +25,28 @@
       font-size: 18px;
       margin-bottom: 1rem;
     }
+    .csmulti-legend {
+      font-size: 1rem;
+    }
+    .csmulti-inner {
+      overflow-y: auto;
+      max-height: 132px;
+    }
+    .csmulti + .input-group {
+      margin-top: 0.5rem;
+    }
+    div.checkbox-group + fieldset.csmulti-group {
+      margin-top: 0.5rem;
+    }
     .csmulti-wrapper {
-      border: 1px solid #91939c !important;
-      border-radius: 4px;
+      max-height: 150px;
+      overflow: hidden;
+      border: $input-border-width solid $input-border-color;
+      @include border-radius($input-border-radius, 0);
       background-color: #f8f8f8;
     }
     fieldset {
-      border-radius: 4px;
+      @include border-radius($input-border-radius, 0);
     }
   }
   &--profile {

--- a/packages/marko-web-theme-monorail/scss/variables/_inputs.scss
+++ b/packages/marko-web-theme-monorail/scss/variables/_inputs.scss
@@ -1,6 +1,7 @@
 $input-bg: #f8f8f8 !default;
 $input-border-color: $gray-500 !default;
 $input-border-radius: 4px !default;
+$custom-select-border-radius: $input-border-radius;
 $input-border-width: 1px !default;
 $input-box-shadow: none !default;
 $input-color: $gray-800 !default;


### PR DESCRIPTION
When the CSS changes were made in #577, the SFC CSS within Vue components was not extracted/moved. This resulted in the controls relying on this to be displayed incorrectly (as compared to original implementation in #301):
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/1778222/233179434-e090a48c-b29c-4f01-ad77-b57151f3906d.png">
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/1778222/233180274-277d0791-d494-4cef-9f9e-c7f441eec7fa.png">


This PR corrects this by moving the CSS out of the Vue components and into the Monorail IdentityX SCSS file. It also addresses the incorrect border color and radius of the multiple select component.

| `$enable-rounded: true`  | `$enable-rounded: false` |
| - | - |
| ![screencapture-www-p1-sandbox-dev-parameter1-51269-user-profile-2023-04-19-14_15_08](https://user-images.githubusercontent.com/1778222/233180034-c6210576-6239-4e01-959b-89815d9c0217.png) | ![screencapture-www-p1-sandbox-dev-parameter1-51269-user-profile-2023-04-19-14_22_09](https://user-images.githubusercontent.com/1778222/233180062-e464fc2b-7113-43a2-9d4d-99a0eb6b212e.png) |

