### PR TITLE
Ensure the `failure` and `success` notifiers fire

### DIFF
--- a/packages/web-cli/github-actions/templates/deploy-production.yml.js
+++ b/packages/web-cli/github-actions/templates/deploy-production.yml.js
@@ -26,7 +26,7 @@ jobs:
 
   post-deploy-failure:
     if: failure()
-    needs: [notify-start, deploy-sites]
+    needs: [notify-start, build-sites, deploy-sites]
     uses: parameter1/actions/.github/workflows/notify-fail.yml@main
     secrets: inherit
     with:
@@ -34,7 +34,7 @@ jobs:
 
   post-deploy-complete:
     if: success()
-    needs: [notify-start, deploy-sites]
+    needs: [notify-start, build-sites, deploy-sites]
     uses: parameter1/actions/.github/workflows/notify-complete.yml@main
     secrets: inherit
     with:

--- a/packages/web-cli/github-actions/templates/deploy-staging.yml.js
+++ b/packages/web-cli/github-actions/templates/deploy-staging.yml.js
@@ -25,7 +25,7 @@ jobs:
 
   post-deploy-failure:
     if: failure()
-    needs: [notify-start, deploy-sites]
+    needs: [notify-start, build-sites, deploy-sites]
     uses: parameter1/actions/.github/workflows/notify-fail.yml@main
     secrets: inherit
     with:
@@ -33,7 +33,7 @@ jobs:
 
   post-deploy-complete:
     if: success()
-    needs: [notify-start, deploy-sites]
+    needs: [notify-start, build-sites, deploy-sites]
     uses: parameter1/actions/.github/workflows/notify-complete.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Currently if the build fails on the `build-sites` step, the failure handler is never called (due to the step it needs being skipped). See https://github.com/parameter1/watt-global-media-websites/actions/runs/4756185664