### PR TITLE
Add auto-signup-event-emitter to authenticated

### DIFF
--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -46,6 +46,7 @@ import post from './utils/post';
 import ProfileForm from './profile.vue';
 import AuthenticationError from './errors/authentication';
 import FeatureError from './errors/feature';
+import AutoSignupEventEmitter from './mixins/global-auto-signup-event-emitter';
 import EventEmitter from './mixins/global-event-emitter';
 
 const isEmpty = (v) => v == null || v === '';
@@ -59,7 +60,7 @@ export default {
   /**
    *
    */
-  mixins: [EventEmitter],
+  mixins: [EventEmitter, AutoSignupEventEmitter],
 
   /**
    *
@@ -220,6 +221,7 @@ export default {
         this.requiresCustomFieldAnswers = this.activeUser.customSelectFieldAnswers
           .some(({ hasAnswered, field }) => field.required && !hasAnswered);
 
+        this.emitAutoSignup(data);
         this.emit('authenticated', {
           id: this.activeUser.id,
           email: this.activeUser.email,


### PR DESCRIPTION
This will replace org level on authenticated auto-signup hooks.  Like in [this](https://github.com/parameter1/randall-reilly-websites/pull/533).