### PR TITLE
Add display of content company on section feed nodes

### DIFF
--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -5,6 +5,8 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 $ const { site, i18n } = out.global;
 
 $ const content = getAsObject(input, "node");
+$ const { company } = content;
+$ const withCompany = (company) ? defaultValue(input.withCompany, true) : false;
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
 $ const containerAttrs = getAsObject(input, "containerAttrs");
@@ -96,6 +98,10 @@ $ const blockName = "section-feed-content-node";
           format="MMMM D, YYYY"
         />
       </else-if>
+
+      <if(withCompany)>
+        <theme-content-attribution obj=content elements=["company"] />
+      </if>
 
       <marko-web-content-sponsors|{ node }| block-name=blockName obj=content>
         Sponsored By: <marko-web-content-name tag="span" block-name=blockName obj=node link=true />

--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -100,7 +100,7 @@ $ const blockName = "section-feed-content-node";
       </else-if>
 
       <if(withCompany)>
-        <theme-content-attribution obj=content elements=["company"] />
+        <marko-web-content-name class=`${blockName}__content-company` obj=content.company link=true />
       </if>
 
       <marko-web-content-sponsors|{ node }| block-name=blockName obj=content>

--- a/packages/marko-web-theme-monorail/graphql/fragments/section-feed-block.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/section-feed-block.js
@@ -24,6 +24,11 @@ fragment SectionFeedBlockContentFragment on Content {
     alt
     isLogo
   }
+  company {
+    id
+    name
+    canonicalPath
+  }
   ... on ContentWebinar {
     linkUrl
     startDate

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
@@ -98,6 +98,7 @@
       margin-right: $theme-content-attribution-prefix-margin;
       font-weight: $theme-content-attribution-prefix-font-weight;
       content: "From";
+      text-transform: "uppercase";
     }
   }
 

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
@@ -92,6 +92,15 @@
     }
   }
 
+  &__content-company {
+    font-weight: $theme-content-attribution-prefix-font-weight;
+    &::before {
+      margin-right: $theme-content-attribution-prefix-margin;
+      font-weight: $theme-content-attribution-prefix-font-weight;
+      content: "From";
+    }
+  }
+
   .btn-primary {
     margin-top: 10px;
   }

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
@@ -98,7 +98,6 @@
       margin-right: $theme-content-attribution-prefix-margin;
       font-weight: $theme-content-attribution-prefix-font-weight;
       content: "From";
-      text-transform: "uppercase";
     }
   }
 


### PR DESCRIPTION
This will add From ${companyName} under the teaser/dates being displayed on section feed pages.

<img width="1351" alt="Screen Shot 2023-04-21 at 8 59 28 AM" src="https://user-images.githubusercontent.com/3845869/233657144-6cedfdf7-7389-4da4-97d6-0c6d5408325b.png">
<img width="243" alt="Screen Shot 2023-04-21 at 9 09 14 AM" src="https://user-images.githubusercontent.com/3845869/233657516-ddc0108a-d5ff-474c-806d-bedce082b7fe.png">

<img width="1375" alt="Screen Shot 2023-04-21 at 8 59 45 AM" src="https://user-images.githubusercontent.com/3845869/233657169-a3698c13-9134-4313-bda2-b41c2cc3e37f.png">
<img width="203" alt="Screen Shot 2023-04-21 at 9 02 47 AM" src="https://user-images.githubusercontent.com/3845869/233657174-03c6968b-50fd-4cbd-956f-1ef4ca63331e.png">
