### PR TITLE
Pass link attrs down through to the link element from wrapper

### DIFF
--- a/packages/marko-web-theme-default/components/site-navbar/item.marko
+++ b/packages/marko-web-theme-default/components/site-navbar/item.marko
@@ -25,6 +25,7 @@ $ const containerMods = (href) => {
   $ const classNames = [elementName, ...linkMods(input.href).map(mod => `${elementName}--${mod}`)];
   <marko-web-link
     href=input.href
+    attrs=input.attrs
     title=input.title
     target=input.target
     class=classNames

--- a/packages/marko-web-theme-default/components/site-navbar/items.marko
+++ b/packages/marko-web-theme-default/components/site-navbar/items.marko
@@ -13,6 +13,7 @@ $ const hasUser = input.hasUser != null ? input.hasUser : false;
       $ const obj = asObject(item);
       <default-theme-site-navbar-item
         block-name=blockName
+        attrs=obj.attrs
         href=obj.href
         title=obj.title
         target=obj.target


### PR DESCRIPTION
Allow fro link attrs to be passed down through from the items wrapper to item into link component

