### PR TITLE
Add support for identifying active custom fields

### DIFF
--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -12,6 +12,7 @@
       :active-user="activeUser"
       :required-server-fields="requiredServerFields"
       :required-client-fields="requiredClientFields"
+      :active-custom-field-ids="activeCustomFieldIds"
       :hidden-fields="hiddenFields"
       :default-country-code="defaultCountryCode"
       :boolean-questions-label="booleanQuestionsLabel"
@@ -87,6 +88,10 @@ export default {
       default: () => [],
     },
     requiredClientFields: {
+      type: Array,
+      default: () => [],
+    },
+    activeCustomFieldIds: {
       type: Array,
       default: () => [],
     },
@@ -208,7 +213,7 @@ export default {
     async authenticate() {
       this.isLoading = true;
       try {
-        const { token, additionalEventData } = this;
+        const { token, additionalEventData, activeCustomFieldIds: ids } = this;
         if (!token) throw new Error('No login token was provided.');
 
         const res = await post('/authenticate', { token, additionalEventData });
@@ -219,6 +224,7 @@ export default {
         this.mustReVerifyProfile = data.user.mustReVerifyProfile;
         this.isProfileComplete = this.requiredFields.every((key) => !isEmpty(this.activeUser[key]));
         this.requiresCustomFieldAnswers = this.activeUser.customSelectFieldAnswers
+          .filter(!ids.length ? ({ field }) => ids.includes(field.id) : () => true)
           .some(({ hasAnswered, field }) => field.required && !hasAnswered);
 
         this.emitAutoSignup(data);

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -306,6 +306,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    activeCustomFieldIds: {
+      type: Array,
+      default: () => [],
+    },
     requiredCreateFields: {
       type: Array,
       default: () => [],
@@ -438,16 +442,20 @@ export default {
      *
      */
     customBooleanFieldAnswers() {
+      const { activeCustomFieldIds: ids } = this;
       const { customBooleanFieldAnswers } = this.user;
-      return isArray(customBooleanFieldAnswers) ? customBooleanFieldAnswers : [];
+      const answers = isArray(customBooleanFieldAnswers) ? customBooleanFieldAnswers : [];
+      return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true);
     },
 
     /**
      *
      */
     customSelectFieldAnswers() {
+      const { activeCustomFieldIds: ids } = this;
       const { customSelectFieldAnswers } = this.user;
-      return isArray(customSelectFieldAnswers) ? customSelectFieldAnswers : [];
+      const answers = isArray(customSelectFieldAnswers) ? customSelectFieldAnswers : [];
+      return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true);
     },
 
     showAddressBlock() {

--- a/packages/marko-web-identity-x/components/form-authenticate.marko
+++ b/packages/marko-web-identity-x/components/form-authenticate.marko
@@ -14,6 +14,7 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       redirectTo: query.redirectTo,
       requiredServerFields: identityX.config.getRequiredServerFields(),
       requiredClientFields: identityX.config.getRequiredClientFields(),
+      activeCustomFieldIds: identityX.config.getActiveCustomFieldIds(),
       defaultCountryCode: identityX.config.get("defaultCountryCode"),
       defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
       booleanQuestionsLabel: identityX.config.get("booleanQuestionsLabel"),

--- a/packages/marko-web-identity-x/components/form-profile.marko
+++ b/packages/marko-web-identity-x/components/form-profile.marko
@@ -14,6 +14,7 @@ $ const additionalEventData = defaultValue(input.additionalEventData, {});
       requiredServerFields: identityX.config.getRequiredServerFields(),
       requiredClientFields: identityX.config.getRequiredClientFields(),
       requiredCreateFields: identityX.config.getRequiredCreateFields(),
+      activeCustomFieldIds: identityX.config.getActiveCustomFieldIds(),
       defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
       hiddenFields: identityX.config.getHiddenFields(),
       defaultCountryCode: identityX.config.get('defaultCountryCode'),

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -13,6 +13,7 @@ class IdentityXConfiguration {
    * @param {string[]} [options.requiredServerFields] Required fields, server enforced.
    * @param {string[]} [options.requiredClientFields] Required fields, client-side only.
    * @param {string[]} [options.requiredCreateFields] Required fields, when creating a new user.
+   * @param {string[]} [options.activeCustomFieldIds] Limit displayed custom fields, if present.
    * @param {string[]} [options.hiddenFields] The fields to hide from the profile.
    * @param {function} [options.onHookError]
    * @param {object} options.rest
@@ -23,6 +24,7 @@ class IdentityXConfiguration {
     requiredServerFields = [],
     requiredClientFields = [],
     requiredCreateFields = [],
+    activeCustomFieldIds = [],
     defaultFieldLabels = {},
     hiddenFields = ['city', 'street', 'addressExtra', 'phoneNumber'],
     defaultCountryCode,
@@ -38,6 +40,7 @@ class IdentityXConfiguration {
       requiredServerFields,
       requiredClientFields,
       requiredCreateFields,
+      activeCustomFieldIds,
       defaultFieldLabels,
       hiddenFields,
       defaultCountryCode,
@@ -115,6 +118,10 @@ class IdentityXConfiguration {
 
   getHiddenFields() {
     return this.getAsArray('hiddenFields');
+  }
+
+  getActiveCustomFieldIds() {
+    return this.getAsArray('activeCustomFieldIds');
   }
 
   get(path, def) {

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -94,7 +94,9 @@ class IdentityX {
       }
       if (user && !access.requiresUserInput) {
         // Check if user needs to answer any globally required custom fields.
+        const ids = this.config.getActiveCustomFieldIds();
         access.requiresUserInput = user.customSelectFieldAnswers
+          .filter(!ids.length ? ({ field }) => ids.includes(field.id) : () => true)
           .some(({ hasAnswered, field }) => field.required && !hasAnswered);
       }
 

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -4,6 +4,23 @@ const { log } = console;
 
 module.exports = new IdentityXConfiguration({
   appId: process.env.IDENTITYX_APP_ID,
+  ...(process.env.IDENTITYX_CONTEXT === 'parameter1.io' ? {
+    // Parameter1.io
+    appContextId: '64483ba86ffc39e3e8cf13c4',
+    activeCustomFieldIds: [
+      '618a8a62934f8400ad4beb8f', // Favorite food
+      '626fe8854e597205b368a50f', // Favorite color
+      '62c4883255955d8d69e1b4ca', // DMN magazine
+    ],
+  } : {
+    // Parameter1.dev
+    appContextId: '64483b96361977163db5e286',
+    activeCustomFieldIds: [
+      '618ab74dcd3e2f0147386c42', // Favorite games
+      '626fe91c79d99b27544a4c9f', // Pina coladas
+      '628e98dc2da307ff2ef6a8b0', // Rain
+    ],
+  }),
   apiToken: process.env.IDENTITYX_API_TOKEN,
   requiredServerFields: ['givenName', 'familyName', 'countryCode'],
   requiredClientFields: ['regionCode', 'countryCode'],


### PR DESCRIPTION
Adds support for the `activeCustomFieldIds` configuration array, which when present will be used to determine which fields to show, and which fields should be considered for the full profile state.

*default*
<img width="984" alt="image" src="https://user-images.githubusercontent.com/1778222/234416205-19786662-d340-4e39-a1da-a217d4470de9.png">

*context 1*
<img width="983" alt="image" src="https://user-images.githubusercontent.com/1778222/234415633-72240cf7-e0df-4fcd-91fe-2dd9aea4780e.png">

*context 2*
<img width="982" alt="image" src="https://user-images.githubusercontent.com/1778222/234416128-631c3e40-3a29-4881-8c6e-de4a55392530.png">
