### PR TITLE
Add teaser cta support for section feed node

### DIFF
--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -19,6 +19,7 @@ $ const withAddress = defaultValue(input.withAddress, (content.type === "company
 $ const withDates = defaultValue(input.withDates, true);
 $ const dateFormat = defaultValue(input.dateFormat, "MMMM D, YYYY");
 $ const isUpcoming = content.startDate > Date.now();
+$ if (isUpcoming) modifiers.push("upcoming");
 $ const withSection = defaultValue(input.withSection, true);
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const displayImage = defaultValue(input.displayImage, true);

--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -75,6 +75,15 @@ $ const blockName = "section-feed-content-node";
           obj=content
           link={ field: linkField, target: linkTarget, attrs: linkAttrs }
         />
+        <if(input.teaserCTA)>
+          <marko-web-link
+            class="teaser-link"
+            href=content.siteContext.path
+            title=content.shortName
+          >
+            ${input.teaserCTA}
+          </marko-web-link>
+        </if>
       </if>
       <if(withBody)>
         <marko-web-content-body


### PR DESCRIPTION
Add the ability to pass in a teaserCTA prop. This will simply place to CTA link right after the teaser field.  



<img width="904" alt="Screen Shot 2023-05-09 at 2 31 58 PM" src="https://github.com/parameter1/base-cms/assets/3845869/490cd20b-455b-4372-b227-fa3801f3640e">
