### PR TITLE
Correctly handle beginningAfter||Before in queryTotalCount

### DIFF
--- a/packages/marko-web-theme-monorail/utils/query-total-count.js
+++ b/packages/marko-web-theme-monorail/utils/query-total-count.js
@@ -63,6 +63,14 @@ const validate = (params) => {
     p.ending = { after: date(p.endingAfter) };
     delete p.endingAfter;
   }
+  if (p.beginningBefore || p.beginningAfter) {
+    p.beginning = {
+      ...(p.beginningBefore && { before: date(p.beginningBefore) }),
+      ...(p.beginningAfter && { after: date(p.beginningAfter) }),
+    };
+  }
+  delete p.beginningBefore;
+  delete p.beginningAfter;
   delete p.queryFragment;
   delete p.sectionFragment;
   return p;


### PR DESCRIPTION
If beginningBefore or beginningAfter are set correctly converter them to p.beginning.after|before and delete the invalid props