### PR TITLE
Log & abort resync when customer can’t be found

### DIFF
--- a/packages/marko-web-omeda-identity-x/middleware/resync-customer-data.js
+++ b/packages/marko-web-omeda-identity-x/middleware/resync-customer-data.js
@@ -8,6 +8,8 @@ const {
   updateIdentityX,
 } = require('../omeda-data');
 
+const { log } = console;
+
 /**
  * A middleware to resync the IdentityX user data with the Omeda customer data. After syncing data,
  * sets a cookie to prevent resyncs for the configured timeframe.
@@ -36,6 +38,11 @@ module.exports = ({
     getOmedaCustomerRecord({ omedaGraphQLClient, encryptedCustomerId }),
     getOmedaLinkedFields({ identityX, brandKey }),
   ]);
+
+  if (!omedaCustomer) {
+    log(`Unable to resync Omeda customer using "${encryptedCustomerId}", aborting sync!`);
+    return next();
+  }
 
   // Update the IdentityX user record custom select fields with the Omeda user data
   await updateIdentityX({


### PR DESCRIPTION
Prevents hard error when no customer is returned via the Omeda API. This should ultimately probably remove the value from the IdX customer, but pushing this now as a triage.