### PR TITLE
Add p1 event tracking to idX content download component

### DIFF
--- a/packages/marko-web-p1-events/browser/index.js
+++ b/packages/marko-web-p1-events/browser/index.js
@@ -1,10 +1,15 @@
 const TrackContentBodyLinks = () => import(/* webpackChunkName: "p1-events-track-content-body-links" */ './track-content-body-links.vue');
+const TrackDownloadSubmission = () => import(/* webpackChunkName: "p1-events-track-download-submission" */ './track-download-submission.vue');
 const TrackInquirySubmission = () => import(/* webpackChunkName: "p1-events-track-inquiry-submission" */ './track-inquiry-submission.vue');
 
 export default (Browser) => {
   const { EventBus } = Browser;
   Browser.register('P1EventsTrackContentBodyLinks', TrackContentBodyLinks);
   Browser.register('P1EventsTrackInquirySubmission', TrackInquirySubmission, {
+    provide: { EventBus },
+  });
+
+  Browser.register('P1EventsTrackDownloadSubmission', TrackDownloadSubmission, {
     provide: { EventBus },
   });
 

--- a/packages/marko-web-p1-events/browser/track-download-submission.vue
+++ b/packages/marko-web-p1-events/browser/track-download-submission.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="marko-web-p1-events-download-listener" style="display: none;" />
+</template>
+
+<script>
+export default {
+  inject: ['EventBus'],
+
+  props: {
+    entity: {
+      type: String,
+      required: true,
+    },
+    eventName: {
+      type: String,
+      default: 'download-form-submit',
+    },
+  },
+
+  created() {
+    if (!window.p1events) return;
+
+    this.EventBus.$on(this.eventName, ({ payload } = {}) => {
+      const props = { ...payload };
+      delete props.token;
+      window.p1events('track', {
+        category: 'Download',
+        action: 'Submit',
+        entity: this.entity,
+        props,
+      });
+    });
+  },
+};
+</script>

--- a/packages/marko-web-p1-events/components/marko.json
+++ b/packages/marko-web-p1-events/components/marko.json
@@ -47,6 +47,20 @@
     },
     "@event-name": "string"
   },
+  "<marko-web-p1-events-track-download-submission>": {
+    "template": "./track-download-submission.marko",
+    "<content>": {
+      "@id": {
+        "type": "number",
+        "required": true
+      },
+      "@type": {
+        "type": "string",
+        "required": true
+      }
+    },
+    "@event-name": "string"
+  },
   "<marko-web-p1-events-track-website-section>": {
     "template": "./track-website-section.marko",
     "@node": "object"

--- a/packages/marko-web-p1-events/components/track-download-submission.marko
+++ b/packages/marko-web-p1-events/components/track-download-submission.marko
@@ -1,0 +1,12 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import eventEntity from "../utils/base-content-entity";
+
+$ const content = getAsObject(input, "content");
+
+<marko-web-browser-component
+  name="P1EventsTrackDownloadSubmission"
+  props={
+    entity: eventEntity(content.id, content.type),
+    eventName: input.eventName,
+  }
+/>

--- a/packages/marko-web-theme-monorail/components/content/download/index.marko
+++ b/packages/marko-web-theme-monorail/components/content/download/index.marko
@@ -18,6 +18,7 @@ $ const { surveyId, surveyType } = getAsObject(content, "gating");
         <theme-content-download-wufoo ...input.wufoo survey-id=surveyId target=fileSrc />
       </else-if>
       <else-if(surveyType === "idx")>
+        <marko-web-p1-events-track-download-submission content=content event-name="identity-x-download-submitted" />
         <theme-content-download-identity-x link=input.link content=content form-id=surveyId />
       </else-if>
       <else>


### PR DESCRIPTION
Add a new p1 event tracker and add that tracker to the idX contnet download component

when you click download within this new component you will track the followin event to p1 events if enabled. 

<img width="610" alt="Screen Shot 2023-06-02 at 3 40 27 PM" src="https://github.com/parameter1/base-cms/assets/3845869/47a81531-6414-4956-bd71-70f569d3fc76">
