### PR TITLE
Update source & prop sent to idx login

### DIFF
--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -49,11 +49,13 @@ module.exports = asyncRoute(async (req, res) => {
   });
   tokenCookie.setTo(res, authToken.value);
   contextCookie.setTo(res, { loginSource });
+  contextCookie.setTo(res, { loginSourceType });
   if (loginSourceType) additionalEventData.loginSourceType = loginSourceType;
   res.json({
     ok: true,
     user,
     loginSource,
+    loginSourceType,
     additionalEventData,
   });
 });

--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -16,6 +16,7 @@ const loginAppUser = gql`
         ...ActiveUserFragment
       }
       loginSource
+      loginSourceType
     }
   }
 
@@ -30,7 +31,12 @@ module.exports = asyncRoute(async (req, res) => {
   const input = { token };
   const variables = { input };
   const { data = {} } = await identityX.client.mutate({ mutation: loginAppUser, variables });
-  const { token: authToken, user, loginSource } = data.loginAppUser;
+  const {
+    token: authToken,
+    user,
+    loginSource,
+    loginSourceType,
+  } = data.loginAppUser;
 
   // call authentication hooks
   await callHooksFor(identityX, 'onAuthenticationSuccess', {
@@ -43,6 +49,7 @@ module.exports = asyncRoute(async (req, res) => {
   });
   tokenCookie.setTo(res, authToken.value);
   contextCookie.setTo(res, { loginSource });
+  if (loginSourceType) additionalEventData.loginSourceType = loginSourceType;
   res.json({
     ok: true,
     user,

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -232,16 +232,22 @@ class IdentityX {
     additionalEventData,
   }) {
     const authUrl = `${this.req.protocol}://${this.req.get('host')}${this.config.getEndpointFor('authenticate')}`;
+    const input = {
+      email: appUser.email,
+      authUrl,
+      appContextId: this.config.get('appContextId'),
+      source,
+      // conditionally spread contentGateType when source is contentGate
+      ...((source === 'contentGate' && additionalEventData.contentGateType) && {
+        sourceType: additionalEventData.contentGateType,
+      }),
+      redirectTo,
+    };
+
     await this.client.mutate({
       mutation: sendLoginLinkMutation,
       variables: {
-        input: {
-          email: appUser.email,
-          authUrl,
-          appContextId: this.config.get('appContextId'),
-          source,
-          redirectTo,
-        },
+        input,
       },
     });
     await callHooksFor(this, 'onLoginLinkSent', {

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -255,6 +255,10 @@ class IdentityX {
       additionalEventData,
       req: this.req,
       source,
+      // conditionally spread contentGateType when source is contentGate
+      ...((source === 'contentGate' && additionalEventData.contentGateType) && {
+        sourceType: additionalEventData.contentGateType,
+      }),
       user: appUser,
     });
   }

--- a/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
@@ -7,6 +7,7 @@ $ const {
 } = contentMeterState;
 $ const additionalEventData = {
   promoCode: site.get("contentMeter.promoCode", undefined),
+  contentGateType: 'metered',
   views,
   viewLimit,
   displayGate,
@@ -64,7 +65,7 @@ $ const classes = [
         <div class="content-meter__login-form">
           <marko-web-identity-x-form-login
             login-email-placeholder="your@email.com"
-            source="content_meter_login"
+            source="contentGate"
             additional-event-data=additionalEventData
           />
         </div>


### PR DESCRIPTION
Update IdentityX package to send loginSourceType throughout the login process.  This will now pass the loginSource and loginSourceType though from login link sent to profile submitted. I tested against CCJ within RR and was able to confirm the source and type are now followin through

<img width="1030" alt="Screen Shot 2023-06-06 at 11 56 13 AM" src="https://github.com/parameter1/base-cms/assets/3845869/3d64cba7-dac9-4803-858f-cfa6781079b3">


source||actionSource = contentGate
contentGateType = ‘metered’

```
behaviorAttributes: {
    actionSource: {
      id: 55,
      valueIds: {
        default: 389824,
        newsletterSignup: 389826,
        comments: 389829,
        contentGate: 389823,
      },
    },
    contentGateType: {
      id: 54,
      valueIds: {
        default: 389825,
        metered: 389827,
        printPreview: 389830,
      },
    },
  },
```