### PR TITLE
Prevent page-content embedded body element css purging

### DIFF
--- a/packages/marko-web-theme-monorail/scss/components/_content-page.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_content-page.scss
@@ -56,7 +56,7 @@
     }
   }
 }
-
+/*! purgecss start ignore */
 .page-contents {
   $self: &;
 
@@ -300,7 +300,7 @@
     content: "Source: ";
   }
 }
-
+/*! purgecss end ignore */
 .social-sharing {
   padding-bottom: map-get($spacers, block);
   &__button {


### PR DESCRIPTION
This prevents css for thins like pull quotes, blockquotes & drop caps from being purged and this is only critical on content page routes

<img width="857" alt="Screen Shot 2023-06-07 at 9 23 45 AM" src="https://github.com/parameter1/base-cms/assets/3845869/a5584de4-adf8-4d2a-a2f5-2ff6e42e01f0">
