### PR TITLE
Preserve `sortField` and `sortOrder` between search pages

### DIFF
--- a/packages/marko-web-search/components/links/next-page.marko
+++ b/packages/marko-web-search/components/links/next-page.marko
@@ -4,10 +4,12 @@ $ const { $markoWebSearch: search, i18n } = out.global;
 
 $ const nextPage = search.getNextPage(input.totalCount);
 
+$ const { sortField, sortOrder } = search.input;
+
 <if(nextPage)>
   <marko-web-search-link
     path=input.path
-    query-values={ page: nextPage }
+    query-values={ page: nextPage, sortField, sortOrder }
     class=input.class
     target=input.target
     rel=input.rel

--- a/packages/marko-web-search/components/links/previous-page.marko
+++ b/packages/marko-web-search/components/links/previous-page.marko
@@ -4,10 +4,12 @@ $ const { $markoWebSearch: search, i18n } = out.global;
 
 $ const previousPage = search.getPrevPage();
 
+$ const { sortField, sortOrder } = search.input;
+
 <if(previousPage)>
   <marko-web-search-link
     path=input.path
-    query-values={ page: previousPage }
+    query-values={ page: previousPage, sortField, sortOrder }
     class=input.class
     target=input.target
     rel=input.rel


### PR DESCRIPTION
![Screenshot from 2023-06-07 09-45-47](https://github.com/parameter1/base-cms/assets/46794001/e121cf04-7607-41f7-a94a-27590f1a5c38)
![Screenshot from 2023-06-07 09-45-51](https://github.com/parameter1/base-cms/assets/46794001/2d4e21e0-e720-4c0d-9129-459c527cd43b)
![Screenshot from 2023-06-07 09-46-24](https://github.com/parameter1/base-cms/assets/46794001/951c758c-e2cf-47eb-aa43-364bea39df53)
![Screenshot from 2023-06-07 09-46-27](https://github.com/parameter1/base-cms/assets/46794001/68d13b4b-e566-4ab8-bd63-f486c32e61f7)
