### PR TITLE
Enable configuration of `defaultSortField` within `MarkoWebSearchConfig` and further `MarkoWebSearchQueryParamConfig`

### DIFF
--- a/packages/marko-web-search/components/sort-by/index.marko
+++ b/packages/marko-web-search/components/sort-by/index.marko
@@ -1,6 +1,5 @@
 import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
 import { dasherize } from "@parameter1/base-cms-inflector";
-import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { isFunction } from '@parameter1/base-cms-utils';
 
 $ const { $markoWebSearch: search, i18n } = out.global;
@@ -16,7 +15,7 @@ $ const options = isFunction(i18n) ? [
 
 <marko-web-block name=blockName modifiers=input.modifiers>
   $ const { searchQuery, sortField } = search.input;
-  $ const selectedId = input.sortField || sortField;
+  $ const selectedId = sortField;
   <if(searchQuery)>
     <marko-web-browser-component
       name="MarkoWebSearchSortSelect"

--- a/packages/marko-web-search/config/index.js
+++ b/packages/marko-web-search/config/index.js
@@ -30,6 +30,7 @@ class MarkoWebSearchConfig {
       resultsPerPage,
       contentTypes,
       assignedToWebsiteSectionIds,
+      defaultSortField,
     } = validate(Joi.object({
       resultsPerPage: Joi.object({
         min: Joi.number().integer().default(1),
@@ -48,6 +49,8 @@ class MarkoWebSearchConfig {
       assignedToWebsiteSectionIds: Joi.array().items(
         Joi.number().integer().min(1).required(),
       ).default([]),
+
+      defaultSortField: Joi.string().allow('PUBLISHED', 'SCORE').default('PUBLISHED'),
     }).default(), params);
 
     this.contentTypeObjects = contentTypes.sort().map((type) => (type.label ? ({
@@ -68,6 +71,7 @@ class MarkoWebSearchConfig {
     this.queryParams = new MarkoWebSearchQueryParamConfig({
       resultsPerPage,
       contentTypeIds: this.contentTypeObjects.map(({ id }) => id),
+      defaultSortField,
     });
   }
 }

--- a/packages/marko-web-search/config/query-params.js
+++ b/packages/marko-web-search/config/query-params.js
@@ -26,6 +26,7 @@ class MarkoWebSearchQueryParamConfig {
   constructor({
     resultsPerPage = {},
     contentTypeIds = [],
+    defaultSortField = 'PUBLISHED',
   } = {}) {
     this.params = new Map();
 
@@ -71,7 +72,7 @@ class MarkoWebSearchQueryParamConfig {
       })
       .add('sortField', {
         type: String,
-        defaultValue: 'PUBLISHED',
+        defaultValue: defaultSortField,
         validator: (v) => sortFieldSet.has(v),
       })
       .add('sortOrder', {

--- a/packages/marko-web-theme-monorail/routes/search.js
+++ b/packages/marko-web-theme-monorail/routes/search.js
@@ -7,11 +7,13 @@ module.exports = (app, siteConfig) => {
   const {
     contentTypes = ['Article', 'Blog', 'Company', 'Podcast', 'Product', 'Video', 'Whitepaper'],
     assignedToWebsiteSectionIds,
+    defaultSortField,
   } = getAsObject(siteConfig, 'search');
   const config = new MarkoWebSearchConfig({
     resultsPerPage: { default: 18 },
     contentTypes,
     assignedToWebsiteSectionIds,
+    defaultSortField,
   });
   app.get('/search', (req, res, next) => {
     if (!get(req, 'query.searchQuery') && get(req, 'query.sortField')) {

--- a/packages/marko-web-theme-monorail/templates/search.marko
+++ b/packages/marko-web-theme-monorail/templates/search.marko
@@ -17,10 +17,6 @@ $ const description = i18nIsFunction ? `${i18n("Search")} ${config.siteName()}` 
 
 $ const currentPage = search.getCurrentPage();
 
-$ const overrideSortField = get(site, 'config.setSearchSortFieldToScore');
-$ const searchQueryPresent = (search.query.searchQuery && search.query.searchQuery !== '');
-$ const setDefaultSortField = (searchQueryPresent && !search.query.sortField && overrideSortField);
-$ const sortField = setDefaultSortField ? 'SCORE' : search.input.sortField;
 $ const sponsorLogo = site.get('search.sponsorLogos.page');
 
 <marko-web-default-page-layout type=type title=title description=description>
@@ -73,7 +69,7 @@ $ const sponsorLogo = site.get('search.sponsorLogos.page');
                 </marko-web-search-form>
                 </div>
                 <div class="col-xl-3">
-                  <marko-web-search-sort-by sort-field=sortField />
+                  <marko-web-search-sort-by />
                   <if(sponsorLogo)>
                     <div class="search-sponsor">
                       <span class="search-sponsor__label">Sponsored by</span>
@@ -91,7 +87,7 @@ $ const sponsorLogo = site.get('search.sponsorLogos.page');
             <marko-web-search-query|{ nodes, totalCount }|
               limit=search.getLimit()
               skip=search.getSkip()
-              sort-field=sortField
+              sort-field=search.input.sortField
               sort-order=search.input.sortOrder
               content-types=search.input.contentTypes
               search-query=search.input.searchQuery


### PR DESCRIPTION
**IMPORTANT** This is technically a backwards breaking change as such here is a migration guide:

1. Remove `setSearchSortFieldToScore` from the site's `config/site.js` file (if currently set)
2. Remove `sort-field` input from `marko-web-search-sort-by ` (if currently being passed into it, notable example is Allured as they aren't on Monorail and were the originators of overriding this to `SCORE` see https://github.com/parameter1/base-cms/pull/227)
3. If the default search sort field still needs to be overridden to `SCORE` set `defaultSortField` in the site's `config/search.js` file and ensure it is being passed into the respective routing for the site's search page. For Monorail sites this likely is managed within the Monorail package however for other sites this may be at a shared package level and/or individual site level.

This _**hopefully**_ corrects the longstanding issue I had introduced via https://github.com/parameter1/base-cms/pull/227 in that the actual search configuration, which ultimately drives the site search pages, was not "aware" of when the default value was overridden to something other than it's _internal_ default of `PUBLISHED` (the only other available option has and remains `SCORE`).

Screenshots showing flow of if a site uses the default configuration (Default sort field of Published):

Upon query entered:
![Screenshot from 2023-06-09 09-22-37](https://github.com/parameter1/base-cms/assets/46794001/55888aad-4543-486f-9546-958473affb65)

Flip to Relevancy (`SCORE`):
![Screenshot from 2023-06-09 09-22-45](https://github.com/parameter1/base-cms/assets/46794001/b896d4ca-3d47-4568-bdc8-b40398de6efe)

Proceed to Page 2:
![Screenshot from 2023-06-09 09-22-52](https://github.com/parameter1/base-cms/assets/46794001/194c780c-17e6-4fe2-bb23-f61c8217f2a7)

Flip back to Published:
![Screenshot from 2023-06-09 09-22-58](https://github.com/parameter1/base-cms/assets/46794001/3708b420-062f-4eab-bfec-87f825576984)

Proceed to Page 3:
![Screenshot from 2023-06-09 09-23-04](https://github.com/parameter1/base-cms/assets/46794001/9713e67d-ec23-4f38-8906-1fe42ec117c9)

Screenshots showing flow of if a site uses an overridden configuration (Default sort field of Relevancy (`SCORE`)):

Upon query entered:
![Screenshot from 2023-06-09 09-43-41](https://github.com/parameter1/base-cms/assets/46794001/01c179cd-c968-4d96-94eb-8f1b90f3399f)

Flip to Published:
![Screenshot from 2023-06-09 09-43-45](https://github.com/parameter1/base-cms/assets/46794001/26740054-e7a0-4ed5-b53f-44baa0b76d49)

Proceed to Page 2:
![Screenshot from 2023-06-09 09-43-58](https://github.com/parameter1/base-cms/assets/46794001/ff89f38d-a5f7-496d-a69d-d6d33741f84b)

Flip back to Relevancy (`SCORE`)
![Screenshot from 2023-06-09 09-44-24](https://github.com/parameter1/base-cms/assets/46794001/ea95bb40-45aa-4306-843b-1602122e9a7a)

Proceed to Page 3:
![Screenshot from 2023-06-09 09-44-40](https://github.com/parameter1/base-cms/assets/46794001/4feb34b3-94c1-4369-9533-56aebbe54508)
