### PR TITLE
Preserve expected behavior when no query provided

### DIFF
--- a/packages/marko-web-theme-monorail/templates/search.marko
+++ b/packages/marko-web-theme-monorail/templates/search.marko
@@ -83,11 +83,12 @@ $ const sponsorLogo = site.get('search.sponsorLogos.page');
                   </if>
                 </div>
               </div>
-
+            <!-- Enforce it this way to not mess with the config, changing at the config level will auto apply sort -->
+            $ const sortField = (search.input.sortField === "SCORE" && search.input.searchQuery === '') ? "PUBLISHED" : search.input.sortField;
             <marko-web-search-query|{ nodes, totalCount }|
               limit=search.getLimit()
               skip=search.getSkip()
-              sort-field=search.input.sortField
+              sort-field=sortField
               sort-order=search.input.sortOrder
               content-types=search.input.contentTypes
               search-query=search.input.searchQuery


### PR DESCRIPTION
This change is the result of the discoveries made here: https://github.com/parameter1/watt-global-media-websites/pull/115

Essentially when the default field is overridden to score, when you load the page without a query string it will sort by score even though no scores have been established, this corrects that so that if it's found that there is not a query string and the sort field is set to Score it sets it back to published.