### PR TITLE
Add customSelectIsRequired(fieldAnswer) check

### DIFF
--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -560,8 +560,8 @@ export default {
       if (ids.length) answers.push(...ids.map((id) => ({ id })));
     },
 
-    customSelectIsRequired(field) {
-      return this.requiredFields.includes(field.id) || field.required;
+    customSelectIsRequired(fieldAnswer) {
+      return this.requiredFields.includes(fieldAnswer.field.id) || fieldAnswer.field.required;
     },
 
     async handleReload() {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -118,7 +118,7 @@
             class="col-12"
             :class="{ 'col-md-6': (customSelectFieldAnswers.length > 1) }"
             :label="fieldAnswer.field.label"
-            :required="fieldAnswer.field.required"
+            :required="customSelectIsRequired(fieldAnswer)"
             :multiple="fieldAnswer.field.multiple"
             :selected="fieldAnswer.answers"
             :options="fieldAnswer.field.options"
@@ -558,6 +558,10 @@ export default {
       const ids = Array.isArray($event) ? [...$event] : [...($event ? [$event] : [])];
       answers.splice(0);
       if (ids.length) answers.push(...ids.map((id) => ({ id })));
+    },
+
+    customSelectIsRequired(field) {
+      return this.requiredFields.includes(field.id) || field.require;
     },
 
     async handleReload() {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -561,7 +561,7 @@ export default {
     },
 
     customSelectIsRequired(field) {
-      return this.requiredFields.includes(field.id) || field.require;
+      return this.requiredFields.includes(field.id) || field.required;
     },
 
     async handleReload() {


### PR DESCRIPTION
This will return true now if either it is returned as a required answer or if it is required to be in the list of required fields.

```js
requiredClientFields: [
    'givenName',
    'familyName',
    'organization',
    'organizationTitle', // @todo make this a custom field somehow
    'regionCode', // Only require client-side for non-us/ca
    'countryCode',
    'postalCode', // Only require client-side for non-us/ca
    '6441672d72aad16b3b150eff',
    '64416bd1361977719ab5ded5',
  ],
  ```
**Results in :**

<img width="1012" alt="Screen Shot 2023-06-15 at 2 32 46 PM" src="https://github.com/parameter1/base-cms/assets/3845869/34e33177-c954-4afc-b5a0-34c677668e1c">

  ```js
  requiredClientFields: [
    'givenName',
    'familyName',
    'organization',
    'organizationTitle', // @todo make this a custom field somehow
    'regionCode', // Only require client-side for non-us/ca
    'countryCode',
    'postalCode', // Only require client-side for non-us/ca
    '64416bd1361977719ab5ded5',
  ],
  ```
  
  **Results in :**
<img width="1016" alt="Screen Shot 2023-06-15 at 2 32 58 PM" src="https://github.com/parameter1/base-cms/assets/3845869/08dba245-7b8d-469b-9567-d87a48036c17">
