### PR TITLE
Add mulitDate format/timezone to section feed node

### DIFF
--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -111,7 +111,6 @@ $ const blockName = "section-feed-content-node";
           <for|dateObj| of=multiDateFormats>
             $ const dateFormat = dateObj.dateFormat || dateFormat;
             $ const timezone = dateObj.timezone  || "America/Chicago";
-            $ console.warn('inside: ', dateFormat.timezone, timezone);
             <marko-web-content-published
               block-name=blockName
               obj=content

--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -18,6 +18,8 @@ $ const withBody = defaultValue(input.withBody, false);
 $ const withAddress = defaultValue(input.withAddress, (content.type === "company"));
 $ const withDates = defaultValue(input.withDates, true);
 $ const dateFormat = defaultValue(input.dateFormat, "MMMM D, YYYY");
+$ const multiDateFormats = input.multiDateFormats;
+
 $ const isUpcoming = content.startDate > Date.now();
 $ if (isUpcoming) modifiers.push("upcoming");
 $ const withSection = defaultValue(input.withSection, true);
@@ -103,6 +105,21 @@ $ const blockName = "section-feed-content-node";
       </if>
       <else-if(withDates && input.date)>
         <${input.date} />
+      </else-if>
+      <else-if(withDates && multiDateFormats)>
+        <marko-web-element block-name=blockName name="multidates" modifiers=modifiers >
+          <for|dateObj| of=multiDateFormats>
+            $ const dateFormat = dateObj.dateFormat || dateFormat;
+            $ const timezone = dateObj.timezone  || "America/Chicago";
+            $ console.warn('inside: ', dateFormat.timezone, timezone);
+            <marko-web-content-published
+              block-name=blockName
+              obj=content
+              format=dateFormat
+              timezone=timezone
+            />
+          </for>
+        </marko-web-element>
       </else-if>
       <else-if(withDates && (content.startDate || content.endDate))>
         <div class=`${blockName}__content-event-dates`>

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
@@ -93,6 +93,11 @@
     }
   }
 
+  &__multidates {
+    display: flex;
+    flex-direction: row;
+  }
+
   &__content-company {
     font-weight: $theme-content-attribution-prefix-font-weight;
     &::before {


### PR DESCRIPTION
You can now pass in a multiDateFormats Array of { format, timezone }.

It will loop over and render the publishDate with multiple formats and timezones.

Example with multiple dates implemented https://github.com/parameter1/watt-global-media-websites/pull/137

![FS-webinars](https://github.com/parameter1/base-cms/assets/3845869/adb787cf-67ec-427f-8a6c-26a563ff0b3d)
