### PR TITLE
Configure `theme-section-feed-content-node` to display appropriate date configuration

### DIFF
--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -106,6 +106,24 @@ $ const blockName = "section-feed-content-node";
       <else-if(withDates && input.date)>
         <${input.date} />
       </else-if>
+      <else-if(withDates && multiDateFormats && (content.startDate || content.endDate))>
+        <marko-web-element block-name=blockName name="multidates" modifiers=modifiers >
+          <for|dateObj| of=multiDateFormats>
+            $ const dateFormat =  dateObj.dateFormat || dateFormat;
+            $ const timezone = dateObj.timezone  || "America/Chicago";
+            <div class=`${blockName}__content-event-dates`>
+              <marko-web-content-start-date tag="span" block-name=blockName obj=content format=dateFormat timezone=timezone />
+              <marko-web-content-end-date tag="span" block-name=blockName obj=content format=dateFormat timezone=timezone />
+            </div>
+          </for>
+        </marko-web-element>
+      </else-if>
+      <else-if(withDates && (content.startDate || content.endDate))>
+        <div class=`${blockName}__content-event-dates`>
+          <marko-web-content-start-date tag="span" block-name=blockName obj=content format=dateFormat />
+          <marko-web-content-end-date tag="span" block-name=blockName obj=content format=dateFormat />
+        </div>
+      </else-if>
       <else-if(withDates && multiDateFormats)>
         <marko-web-element block-name=blockName name="multidates" modifiers=modifiers >
           <for|dateObj| of=multiDateFormats>
@@ -119,12 +137,6 @@ $ const blockName = "section-feed-content-node";
             />
           </for>
         </marko-web-element>
-      </else-if>
-      <else-if(withDates && (content.startDate || content.endDate))>
-        <div class=`${blockName}__content-event-dates`>
-          <marko-web-content-start-date tag="span" block-name=blockName obj=content format=dateFormat />
-          <marko-web-content-end-date tag="span" block-name=blockName obj=content format=dateFormat />
-        </div>
       </else-if>
       <else-if(withDates)>
         <marko-web-content-published


### PR DESCRIPTION
PRODUCTION:
![Screenshot from 2023-06-26 12-03-36](https://github.com/parameter1/base-cms/assets/46794001/73f17bf7-cef5-4393-97c0-91ac52d215dd)


DEV:
![Screenshot from 2023-06-26 12-01-19](https://github.com/parameter1/base-cms/assets/46794001/3352e746-118b-49f2-bf89-cff1bb4f386f)


This corrects the ordering of the date conditionals to go in the order of:

1. Multi-date with start or end date (Webinar/Event)
2. With start or end date (Webinar/Event)
3. Multi-date with published
4. Published