### PR TITLE
Update how default browser config values are assigned

### DIFF
--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -38,10 +38,14 @@ const defaultConfig = {
 export default (Browser, configOverrides = {}) => {
   const config = { ...defaultConfig, ...configOverrides };
   const { EventBus } = Browser;
-  const { enableOmedaIdentityX } = config;
-  const idxArgs = config.idxArgs || {};
-  const inquiryArgs = config.inquiryArgs || {};
-  if (config.withP1Events) {
+  const {
+    enableOmedaIdentityX,
+    idxArgs,
+    inquiryArgs,
+    withP1Events,
+  } = config;
+
+  if (withP1Events) {
     P1Events(Browser);
   }
 

--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -7,6 +7,7 @@ import NativeX from '@parameter1/base-cms-marko-web-native-x/browser';
 import IdentityX from '@parameter1/base-cms-marko-web-identity-x/browser';
 import OmedaIdentityX from '@parameter1/base-cms-marko-web-omeda-identity-x/browser';
 import P1Events from '@parameter1/base-cms-marko-web-p1-events/browser';
+import { getAsObject } from '@parameter1/base-cms-object-path';
 import IdentityXNewsletterForms from './idx-newsletter-form/index';
 import ContentMeterTrack from './content-meter-track.vue';
 
@@ -40,10 +41,11 @@ export default (Browser, configOverrides = {}) => {
   const { EventBus } = Browser;
   const {
     enableOmedaIdentityX,
-    idxArgs,
-    inquiryArgs,
     withP1Events,
   } = config;
+
+  const idxArgs = getAsObject(config, 'idxArgs');
+  const inquiryArgs = getAsObject(config, 'inquiryArgs');
 
   if (withP1Events) {
     P1Events(Browser);

--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -30,7 +30,6 @@ const setP1EventsIdentity = ({ p1events, brandKey, encryptedId }) => {
 
 const defaultConfig = {
   enableOmedaIdentityX: true,
-  withGTM: true,
   withP1Events: true,
   idxArgs: {},
   inquiryArgs: {},

--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -28,18 +28,20 @@ const setP1EventsIdentity = ({ p1events, brandKey, encryptedId }) => {
   p1events('setIdentity', `omeda.${brandKey}.customer*${encryptedId}~encrypted`);
 };
 
-export default (Browser, config = {
+const defaultConfig = {
   enableOmedaIdentityX: true,
   withGTM: true,
   withP1Events: true,
   idxArgs: {},
   inquiryArgs: {},
-}) => {
+};
+
+export default (Browser, configOverrides = {}) => {
+  const config = { ...defaultConfig, ...configOverrides };
   const { EventBus } = Browser;
   const { enableOmedaIdentityX } = config;
   const idxArgs = config.idxArgs || {};
   const inquiryArgs = config.inquiryArgs || {};
-
   if (config.withP1Events) {
     P1Events(Browser);
   }


### PR DESCRIPTION
This update will ensure that all browser config values have a their default values applied.

I also removed the withGTM prop as it was no longer referenced and config was also not passed through anywhere.  