### PR TITLE
Add verifiedCount to ActiveUser fragment

### DIFF
--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -6,6 +6,7 @@ fragment ActiveUserFragment on AppUser {
   id
   email
   verified
+  isFirstTimeVerifying
   givenName
   familyName
   displayName

--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -6,7 +6,7 @@ fragment ActiveUserFragment on AppUser {
   id
   email
   verified
-  isFirstTimeVerifying
+  verifiedCount
   givenName
   familyName
   displayName

--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -241,6 +241,7 @@ export default {
         this.emit('authenticated', {
           id: this.activeUser.id,
           email: this.activeUser.email,
+          isFirstTimeVerifying: this.activeUser.isFirstTimeVerifying,
           mustReVerifyProfile: this.mustReVerifyProfile,
           isProfileComplete: this.isProfileComplete,
           requiresCustomFieldAnswers: this.requiresCustomFieldAnswers,

--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -241,7 +241,7 @@ export default {
         this.emit('authenticated', {
           id: this.activeUser.id,
           email: this.activeUser.email,
-          isFirstTimeVerifying: this.activeUser.isFirstTimeVerifying,
+          verifiedCount: this.activeUser.verifiedCount,
           mustReVerifyProfile: this.mustReVerifyProfile,
           isProfileComplete: this.isProfileComplete,
           requiresCustomFieldAnswers: this.requiresCustomFieldAnswers,


### PR DESCRIPTION
This flag is only set to true the first time a user has the verified flag set.  meaning this should only be true the first time a person clicks on the loginLink sent to their inbox.

Related PRs: 
 - https://github.com/parameter1/identity-x/pull/39
 - https://github.com/parameter1/randall-reilly-websites/pull/556