### PR TITLE
Fix display of table(desktop) menu displays when viewed horizontally

### DIFF
--- a/packages/marko-web-theme-monorail/scss/components/_site-menu.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-menu.scss
@@ -50,6 +50,7 @@ body.site-menu--open {
   @each $breakpoint, $width in sort-map-by-values($theme-site-header-breakpoints, desc) {
     @media (max-width: $width) {
       top: calculate-navbar-height-for($breakpoint);
+      max-height: calc(100vh - calculate-navbar-height-for($breakpoint));
     }
   }
 


### PR DESCRIPTION
Allow for a max desktop menu height of 100 view height - header height to allow for the menu to scoll on devices like the iphone 12 when viewed horizontally.

Note: display has to be over 700px wide to display desktop. 

<img width="872" alt="Screen Shot 2023-07-05 at 12 17 54 PM" src="https://github.com/parameter1/base-cms/assets/3845869/fd91fc11-a062-4992-b025-fe12fefe5108">
<img width="1139" alt="Screen Shot 2023-07-05 at 12 18 13 PM" src="https://github.com/parameter1/base-cms/assets/3845869/8e6b759b-db01-4386-8e95-48a440d05529">
<img width="160" alt="Screen Shot 2023-07-05 at 12 18 25 PM" src="https://github.com/parameter1/base-cms/assets/3845869/b94fe2af-4f5d-40c4-a7f1-3b4428669a8c">
<img width="1198" alt="Screen Shot 2023-07-05 at 12 18 40 PM" src="https://github.com/parameter1/base-cms/assets/3845869/08ab2dac-c24e-4b7c-8628-94ed913867c2">
