### PR TITLE
Account for initiallyExpanded in newsletter toggle buttton

### DIFF
--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/toggle-button.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/toggle-button.vue
@@ -31,6 +31,10 @@ export default {
       type: Array,
       default: () => ['lg'],
     },
+    initiallyExpanded: {
+      type: Boolean,
+      default: false,
+    },
     buttonClass: {
       type: String,
       default: 'site-navbar__idx-newsletter-toggler',
@@ -45,6 +49,10 @@ export default {
     icon() {
       return `icon-${this.iconName}`;
     },
+  },
+
+  mounted() {
+    this.expanded = this.initiallyExpanded;
   },
 
   methods: {

--- a/packages/marko-web-theme-monorail/browser/newsletter-toggle-button.vue
+++ b/packages/marko-web-theme-monorail/browser/newsletter-toggle-button.vue
@@ -17,10 +17,20 @@ export default {
     IconMail,
   },
   inject: ['EventBus'],
+  props: {
+    initiallyExpanded: {
+      type: Boolean,
+      default: false,
+    },
+  },
 
   data: () => ({
     expanded: false,
   }),
+
+  mounted() {
+    this.expanded = this.initiallyExpanded;
+  },
 
   methods: {
     toggle() {

--- a/packages/marko-web-theme-monorail/components/site-header.marko
+++ b/packages/marko-web-theme-monorail/components/site-header.marko
@@ -14,6 +14,7 @@ $ const showIdxNewsletterSignup = enableIdxNewsletterSignup;
 $ const idxNesletterSignupIcon = (input.hasUser) ? 'person' : 'mail';
 $ const showNewsletterSignup = !newsletterConfig.disabled && !enableIdxNewsletterSignup;
 $ const showSearchIcon = defaultValue(input.showSearchIcon, false);
+$ const { initiallyExpanded } = getAsObject(out.global, "newsletterState");
 $ const menuBtnPosition = defaultValue(input.menuBtnPosition, 'left');
 
 $ const navigation = {
@@ -60,10 +61,10 @@ $ const navigation = {
     <marko-web-element block-name="site-navbar" name="icon-wrapper">
       <!-- Newsletter Menue Toggler -->
       <if(showIdxNewsletterSignup)>
-        <marko-web-browser-component name="IdentityXNewsletterToggleButton" props={ iconName: idxNesletterSignupIcon } ssr=true />
+        <marko-web-browser-component name="IdentityXNewsletterToggleButton" props={ iconName: idxNesletterSignupIcon, initiallyExpanded } ssr=true />
       </if>
       <else-if(showNewsletterSignup)>
-        <marko-web-browser-component name="ThemeNewsletterToggleButton" ssr=true />
+        <marko-web-browser-component name="ThemeNewsletterToggleButton" props={ initiallyExpanded } ssr=true />
       </else-if>
 
       <!-- Site Navbar Search Icon -->


### PR DESCRIPTION
Add prop to handle initiallyExpanded inorder to account for when the newsletter menu is forced open on page load.

Also add setting of initiallyExpanded prop n site header component based on newslewtterState