### PR TITLE
Allow NAME sort for default + passed in sortField, `marko-web-search`

### DIFF
--- a/packages/marko-web-search/config/index.js
+++ b/packages/marko-web-search/config/index.js
@@ -50,7 +50,7 @@ class MarkoWebSearchConfig {
         Joi.number().integer().min(1).required(),
       ).default([]),
 
-      defaultSortField: Joi.string().allow('PUBLISHED', 'SCORE').default('PUBLISHED'),
+      defaultSortField: Joi.string().allow('NAME', 'PUBLISHED', 'SCORE').default('PUBLISHED'),
     }).default(), params);
 
     this.contentTypeObjects = contentTypes.sort().map((type) => (type.label ? ({

--- a/packages/marko-web-search/config/query-params.js
+++ b/packages/marko-web-search/config/query-params.js
@@ -19,7 +19,7 @@ const fromArrayInput = (arr) => {
 const toIntArrayInput = (arr) => toArrayInput(arr, (v) => parseInt(v, 10));
 const toStringArrayInput = (arr) => toArrayInput(arr, (v) => v.trim());
 
-const sortFieldSet = new Set(['PUBLISHED', 'SCORE']);
+const sortFieldSet = new Set(['NAME', 'PUBLISHED', 'SCORE']);
 const sortOrderSet = new Set(['DESC', 'ASC']);
 
 class MarkoWebSearchQueryParamConfig {


### PR DESCRIPTION
NOTE: This does not updated the list of fields within `marko-web-search-sort-by` so as not to introduce unexpected behavior to existing uses of the component (tied exclusively to site searchs).


This change is in order for directories using the underlying `MarkoWebSearchConfig` to do so using `NAME` as a valid sort field.