### PR TITLE
Correctly apply browser/index.js config overrides and fallback logic 

### DIFF
--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -28,19 +28,25 @@ const setP1EventsIdentity = ({ p1events, brandKey, encryptedId }) => {
   p1events('setIdentity', `omeda.${brandKey}.customer*${encryptedId}~encrypted`);
 };
 
-export default (Browser, config = {
+const defaultConfig = {
   enableOmedaIdentityX: true,
-  withGTM: true,
   withP1Events: true,
   idxArgs: {},
   inquiryArgs: {},
-}) => {
+};
+
+export default (Browser, configOverrides = {}) => {
+  const config = { ...defaultConfig, ...configOverrides };
   const { EventBus } = Browser;
-  const { enableOmedaIdentityX } = config;
+  const {
+    enableOmedaIdentityX,
+    withP1Events,
+  } = config;
+
   const idxArgs = config.idxArgs || {};
   const inquiryArgs = config.inquiryArgs || {};
 
-  if (config.withP1Events) {
+  if (withP1Events) {
     P1Events(Browser);
   }
 


### PR DESCRIPTION
Reapply the changes reverted by https://github.com/parameter1/base-cms/pull/735 with the the correct way to ensure idxArgs & inquiryArgs are at least empty objects