### PR TITLE
Add primaryCategory to sitemap url resolver

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1096,6 +1096,7 @@ module.exports = {
         type: 1,
         'mutations.Website.slug': 1,
         'mutations.Website.primarySection': 1,
+        'mutations.Website.primaryCategory': 1,
         updated: 1,
         images: 1,
       };


### PR DESCRIPTION
This was preventing URLs to resolve in the same fashion they do within fields returned within `Content.siteContext` (`path`, `url`, `canonicalUrl`) and causing the sitemap URLs for Products and Companies (as defined within https://github.com/parameter1/base-cms/blob/master/services/graphql-server/src/graphql/definitions/platform/content/types/company.js#L19 and https://github.com/parameter1/base-cms/blob/master/services/graphql-server/src/graphql/definitions/platform/content/types/product.js#L9 are the only types that are allowed to utilize this field) to resolve incorrectly.

BEFORE (Product resolution):
![Screenshot from 2023-07-13 14-13-11](https://github.com/parameter1/base-cms/assets/46794001/2c22fb60-b196-4824-8a77-1fb31368474a)

AFTER (Product resolution):
![Screenshot from 2023-07-13 14-13-26](https://github.com/parameter1/base-cms/assets/46794001/b0bfe924-fcbc-49cf-8ce3-31b080f66260)

Showing Article resolution is unimpacted:
![Screenshot from 2023-07-13 14-21-14](https://github.com/parameter1/base-cms/assets/46794001/37e73529-5d3d-484a-8ebe-2316d6824954)

Query used within `indm_multi` tenant using the IEN site context via `x-site-id` header.
`query {
  contentSitemapUrls(input: {since: "1689000000000", contentTypes:[Product]}) {
    loc
  }
}`