### PR TITLE
Prevent recaptcha badge css from being purged

### DIFF
--- a/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
@@ -24,9 +24,11 @@
   }
 }
 
+/*! purgecss start ignore */
 .grecaptcha-badge {
   visibility: hidden;
 }
+/*! purgecss end ignore */
 
 .site-newsletter-menu {
   max-height: 0;


### PR DESCRIPTION
This will restore the badge being hidden.

Will allow for a dep upgrade to replace this: https://github.com/parameter1/randall-reilly-websites/pull/553

![image](https://github.com/parameter1/base-cms/assets/3845869/f710cbe6-8602-433b-9ee5-c5663e107663)
