### PR TITLE
Add P1 event tracking support for native-x stories

### DIFF
--- a/packages/marko-web-native-x/utils/convert-story-to-content.js
+++ b/packages/marko-web-native-x/utils/convert-story-to-content.js
@@ -30,7 +30,6 @@ module.exports = (story = {}, { sectionName = 'Sponsored' } = {}) => {
       __typename: 'WebsiteSection',
     },
     company: {
-      id: advertiser.id,
       name: advertiser.name,
       primaryImage: {
         id: advertiserImage.id,

--- a/packages/marko-web-native-x/utils/convert-story-to-content.js
+++ b/packages/marko-web-native-x/utils/convert-story-to-content.js
@@ -30,6 +30,7 @@ module.exports = (story = {}, { sectionName = 'Sponsored' } = {}) => {
       __typename: 'WebsiteSection',
     },
     company: {
+      id: advertiser.id,
       name: advertiser.name,
       primaryImage: {
         id: advertiserImage.id,

--- a/packages/marko-web-p1-events/components/marko.json
+++ b/packages/marko-web-p1-events/components/marko.json
@@ -15,6 +15,10 @@
     "template": "./track-content.marko",
     "@node": "object"
   },
+  "<marko-web-p1-events-track-native-story>": {
+    "template": "./track-content.marko",
+    "@story": "object"
+  },
   "<marko-web-p1-events-track-content-body-links>": {
     "template": "./track-content-body-links.marko",
     "<content>": {

--- a/packages/marko-web-p1-events/components/track-content.marko
+++ b/packages/marko-web-p1-events/components/track-content.marko
@@ -13,17 +13,17 @@ $ const config = site.getAsObject("p1events");
     name: node.name,
     props: { type, published: node.published },
     refs: {
-      primarySection: primarySection
+      primarySection: primarySection && primarySection.id
         ? { id: primarySection.id, ns: ns("website-section"), name: primarySection.fullName, props: { alias: primarySection.alias } }
         : null,
-      company: company
+      company: company && company.id
         ? { id: company.id, ns: ns("content-company"), name: company.name }
         : null,
       authors: getAsArray(node, "authors.edges").map((edge) => {
         const { node: author } = edge;
         return { id: author.id, ns: ns("content-contact"), name: author.name };
       }),
-      createdBy: createdBy
+      createdBy: createdBy && createdBy.id
         ? { id: createdBy.id, ns: ns("user"), name: createdBy.username, props: { firstName: createdBy.firstName, lastName: createdBy.lastName } }
         : null,
     },

--- a/packages/marko-web-p1-events/components/track-native-story.marko
+++ b/packages/marko-web-p1-events/components/track-native-story.marko
@@ -1,0 +1,32 @@
+import { get } from "@parameter1/base-cms-object-path";
+
+$ const { site } = out.global;
+$ const { story } = input;
+$ const config = site.getAsObject("p1events");
+$ const ns = (type) => {
+  const [,tenantKey] = site.get('nativeX.uri').match(/\/\/(\w+)\.native-x/i);
+  return `native-x.${tenantKey}.${type}`;
+};
+
+<if(config.enabled)>
+  $ const { advertiser } = story;
+  $ const entity = {
+    id: story.id,
+    ns: ns(`story`),
+    name: story.title,
+    props: { type: 'story', published: get(story, 'publishedAt') },
+    refs: {
+      advertiser: advertiser && advertiser.id
+        ? { id: advertiser.id, ns: ns("advertiser"), name: advertiser.name }
+        : null,
+    },
+  };
+  $ const data = {
+    action: 'View',
+    category: 'Content',
+    entity,
+  };
+  <script>
+    p1events('track', ${JSON.stringify(data)});
+  </script>
+</if>

--- a/packages/marko-web-p1-events/components/track-native-story.marko
+++ b/packages/marko-web-p1-events/components/track-native-story.marko
@@ -15,11 +15,9 @@ $ const ns = (type) => {
     ns: ns(`story`),
     name: story.title,
     props: { type: 'story', published: get(story, 'publishedAt') },
-    refs: {
-      advertiser: advertiser && advertiser.id
-        ? { id: advertiser.id, ns: ns("advertiser"), name: advertiser.name }
-        : null,
-    },
+    ...(advertiser && advertiser.id && {
+      refs: { advertiser: { id: advertiser.id, ns: ns("advertiser"), name: advertiser.name } },
+    }),
   };
   $ const data = {
     action: 'View',


### PR DESCRIPTION
Add new `<marko-web-p1-events-track-native-story>` component to p1 events pacakge

The entity being passed would look like: 
```js
{
  id: '6467d2d80ec6330001adc4ae',
  ns: 'native-x.${tenantKey}.story',
  name: 'Screw conveyor drives from SEW-EURODRIVE',
  props: { type: 'story', published: 1688187600000 },
  refs: {
    advertiser: {
      id: '6452c63d3738d30001f880f6',
      ns: 'native-x.${tenantKey}.advertiser',
      name: 'SEW-EURODRIVE, Inc.'
    }
  }
}
```

`<marko-web-p1-events-track-native-story story=story />` will have to be added within the <@head> calls of the native story page templates.  