### PR TITLE
Limit modified boolean questions to active custom fields

### DIFF
--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -579,7 +579,6 @@ export default {
       try {
         const res = await post('/profile', {
           ...this.user,
-          activeCustomFieldIds: this.activeCustomFieldIds,
           additionalEventData: {
             ...this.additionalEventData,
             actionSource: this.loginSource,

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -579,6 +579,7 @@ export default {
       try {
         const res = await post('/profile', {
           ...this.user,
+          activeCustomFieldIds: this.activeCustomFieldIds,
           additionalEventData: {
             ...this.additionalEventData,
             actionSource: this.loginSource,

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -1,5 +1,6 @@
 const gql = require('graphql-tag');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
+const { getAsArray } = require('@parameter1/base-cms-object-path');
 const userFragment = require('../api/fragments/active-user');
 const callHooksFor = require('../utils/call-hooks-for');
 
@@ -55,7 +56,6 @@ module.exports = asyncRoute(async (req, res) => {
     regionalConsentAnswers,
     customBooleanFieldAnswers,
     customSelectFieldAnswers,
-    activeCustomFieldIds = [],
     additionalEventData = {},
   } = body;
   const input = {
@@ -72,6 +72,8 @@ module.exports = asyncRoute(async (req, res) => {
     phoneNumber,
     receiveEmail,
   };
+
+  const activeCustomFieldIds = getAsArray(identityX, 'config.options.activeCustomFieldIds');
 
   const answers = regionalConsentAnswers
     .map((answer) => ({ policyId: answer.id, given: answer.given }));

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -55,6 +55,7 @@ module.exports = asyncRoute(async (req, res) => {
     regionalConsentAnswers,
     customBooleanFieldAnswers,
     customSelectFieldAnswers,
+    activeCustomFieldIds = [],
     additionalEventData = {},
   } = body;
   const input = {
@@ -86,7 +87,11 @@ module.exports = asyncRoute(async (req, res) => {
       // can either be true, false or null. convert null to false.
       // the form submit is effectively answers the question.
       value: Boolean(fieldAnswer.answer),
-    }));
+    })).filter(
+      activeCustomFieldIds.length > 0
+        ? ({ fieldId }) => activeCustomFieldIds.includes(fieldId)
+        : () => true,
+    );
     await identityX.client.mutate({
       mutation: customBooleanFieldsMutation,
       variables: { input: { answers: customBooleanFieldsInput } },
@@ -102,7 +107,11 @@ module.exports = asyncRoute(async (req, res) => {
         ...arr,
         ...(writeInValue ? [{ optionId: id, value: writeInValue }] : []),
       ]), []),
-    }));
+    })).filter(
+      activeCustomFieldIds.length > 0
+        ? ({ fieldId }) => activeCustomFieldIds.includes(fieldId)
+        : () => true,
+    );
     await identityX.client.mutate({
       mutation: customSelectFieldsMutation,
       variables: { input: { answers: customSelectFieldsInput } },


### PR DESCRIPTION
This passed the configured activeCustomFieldIds from the vue component displaying them to the route that handles submittion of configured questions to only set/update the configured custom questions.

Tested this on Divers with DE & DH:

<img width="1197" alt="Screen Shot 2023-07-31 at 2 32 35 PM" src="https://github.com/parameter1/base-cms/assets/3845869/4d8af0af-408c-442f-ae65-2769c694dde9">
<img width="1346" alt="Screen Shot 2023-07-31 at 2 32 43 PM" src="https://github.com/parameter1/base-cms/assets/3845869/8ec0f79c-408e-436e-a168-19fc1175c21c">
<img width="2351" alt="Screen Shot 2023-07-31 at 2 32 50 PM" src="https://github.com/parameter1/base-cms/assets/3845869/65d6e9e6-5a49-48d4-9a78-06232a1fc9e5">

New way has no product value set for the other two brands vs old way it would have submitted a false value for those given products.  
