### PR TITLE
Add ability to pass a before/after injectedHtml

### DIFF
--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -106,4 +106,14 @@ $ const gamAdInjection = (GAM) ? [
       </if>
     </for>
   </if>
+  <if(input.beforeInjectedHtml)>
+    <@before-injected-html|{ hasInjectedContent }|>
+      <${input.beforeInjectedHtml.renderBody} has-injected-content=hasInjectedContent />
+    </@before-injected-html>
+  </if>
+  <if(input.afterInjectedHtml)>
+    <@after-injected-html|{ hasInjectedContent }|>
+      <${input.afterInjectedHtml.renderBody} has-injected-content=hasInjectedContent />
+    </@after-injected-html>
+  </if>
 </theme-ssr-html-inject>

--- a/packages/marko-web-theme-monorail/components/marko.json
+++ b/packages/marko-web-theme-monorail/components/marko.json
@@ -45,6 +45,8 @@
     "@inject <inject>[]": {},
     "@selector": "string",
     "@to-render": "expression",
-    "@ad-inject-config": "array"
+    "@ad-inject-config": "array",
+    "<before-injected-html>": {},
+    "<after-injected-html>": {}
   }
 }

--- a/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
+++ b/packages/marko-web-theme-monorail/components/ssr-html-inject.marko
@@ -97,6 +97,12 @@ $ $children.each(function injectAds(index) {
 });
 
 $ const injectedHtml = $('body').html();
+<if(input.beforeInjectedHtml)>
+  <${input.beforeInjectedHtml.renderBody} has-injected-content=hasInjectedContent />
+</if>
 <if(true)>
   $!{injectedHtml}
+</if>
+<if(input.afterInjectedHtml)>
+  <${input.afterInjectedHtml.renderBody} has-injected-content=hasInjectedContent />
 </if>


### PR DESCRIPTION
Add the ability to to pass in a beforeInjectedHtml &or afterInjectedHtml in to the ssr html inject component with access the the hasInjectedContnet prop withing the component.

Also add the pass through of this in the body-with-injection component.

example content body call:
```markojs
$ const htmlInjections = [
  {
    at: 1200,
    html: "<h1>HTML INJECTION</h1>"
  },
  {
    at: 2400,
    html: "<h1>HTML INJECTION</h1>"
  },
  {
    at: 3600,
    html: "<h1>HTML INJECTION</h1>"
  },
  {
    at: 4800,
    html: "<h1>HTML INJECTION</h1>"
  },
  {
    at: 6000,
    html: "<h1>HTML INJECTION</h1>"
  },
  {
    at: 7200,
    html: "<h1>HTML INJECTION</h1>"
  },
];
<theme-body-with-injection
  content=content
  aliases=[]
  block-name=blockName
  html-injections=htmlInjections
  preventHTMLInjection=false
>
  <@before-injected-html|{ hasInjectedContent }|>
    <if(hasInjectedContent && !hasInjectedContent[1200])>
      <div>
        <strong>
          This will show before the body if the htmlInjections[1200] didn't inject
        </strong>
      </div>
    </if>
  </@before-injected-html>
  <@after-injected-html|{ hasInjectedContent }|>
    <if(hasInjectedContent && !hasInjectedContent[1200])>
      <div>
        <strong>
          This will show after the body if the htmlInjections[1200] didn't inject
        </strong>
      </div>
    </if>
    <if(hasInjectedContent && !hasInjectedContent[2400])>
      <div>
        <strong>
          This will show after the body if the htmlInjections[2400] didn't inject
        </strong>
      </div>
    </if>
    <if(hasInjectedContent && !hasInjectedContent[3600])>
      <div>
        <strong>
          This will show after the body if the htmlInjections[3600] didn't inject
        </strong>
      </div>
    </if>
    <if(hasInjectedContent && !hasInjectedContent[4800])>
      <div>
        <strong>
          This will show after the body if the htmlInjections[4800] didn't inject
        </strong>
      </div>
    </if>
    <if(hasInjectedContent && !hasInjectedContent[6000])>
      <div>
        <strong>
          This will show after the body if the htmlInjections[6000] didn't inject
        </strong>
      </div>
    </if>
    <if(hasInjectedContent && !hasInjectedContent[7200])>
      <div>
        <strong>
          This will show after the body if the htmlInjections[7200] didn't inject
        </strong>
      </div>
    </if>
  </@after-injected-html>
</theme-body-with-injection>
```
![htmlinject](https://github.com/parameter1/base-cms/assets/3845869/1fae5cf5-11b0-4ace-b1b4-62e60277ea3e)




