### PR TITLE
Adjust download form display of region & postal code depending on country codes

### DIFF
--- a/packages/marko-web-identity-x/browser/custom-column.vue
+++ b/packages/marko-web-identity-x/browser/custom-column.vue
@@ -85,7 +85,7 @@
     />
     <template v-else-if="fieldKey === 'regionCode'">
       <region-code
-        v-if="showContryCodeFields"
+        v-if="showCountryCodeFields"
         v-model="user.regionCode"
         :country-code="user.countryCode"
         :class-name="className"
@@ -95,7 +95,7 @@
     </template>
     <template v-else-if="fieldKey === 'postalCode'">
       <postal-code
-        v-if="showContryCodeFields"
+        v-if="showCountryCodeFields"
         v-model="user.postalCode"
         :class-name="className"
         :required="required"
@@ -230,7 +230,7 @@ export default {
     /**
      *
      */
-    showContryCodeFields() {
+    showCountryCodeFields() {
       return regionCountryCodes.includes(this.user.countryCode);
     },
 

--- a/packages/marko-web-identity-x/browser/custom-column.vue
+++ b/packages/marko-web-identity-x/browser/custom-column.vue
@@ -4,12 +4,14 @@
     <given-name
       v-if="fieldKey === 'givenName'"
       v-model="user.givenName"
+      :class-name="className"
       :required="required"
       :label="label"
     />
     <family-name
       v-else-if="fieldKey === 'familyName'"
       v-model="user.familyName"
+      :class-name="className"
       :required="required"
       :label="label"
     />
@@ -35,59 +37,71 @@
     <organization
       v-else-if="fieldKey === 'organization'"
       v-model="user.organization"
+      :class-name="className"
       :required="required"
       :label="label"
     />
     <organization-title
       v-else-if="fieldKey === 'organizationTitle'"
       v-model="user.organizationTitle"
+      :class-name="className"
       :required="required"
       :label="label"
     />
     <phone-number
       v-else-if="fieldKey === 'phoneNumber'"
       v-model="user.phoneNumber"
+      :class-name="className"
       :required="required"
       :label="label"
     />
     <country-code
       v-else-if="fieldKey === 'countryCode'"
       v-model="user.countryCode"
+      :class-name="className"
       :required="required"
       :label="label"
     />
     <street
       v-else-if="fieldKey === 'street'"
       v-model="user.street"
+      :class-name="className"
       :required="required"
       :label="label"
     />
     <address-extra
       v-else-if="fieldKey === 'addressExtra'"
       v-model="user.addressExtra"
+      :class-name="className"
       :required="required"
       :label="label"
     />
     <city
       v-else-if="fieldKey === 'city'"
       v-model="user.city"
+      :class-name="className"
       :required="required"
       :label="label"
     />
-    <region-code
-      v-else-if="fieldKey === 'regionCode'"
-      v-model="user.regionCode"
-      :country-code="user.countryCode"
-      class-name="col"
-      :required="required"
-      :label="label"
-    />
-    <postal-code
-      v-else-if="fieldKey === 'postalCode'"
-      v-model="user.postalCode"
-      :required="required"
-      :label="label"
-    />
+    <template v-else-if="fieldKey === 'regionCode'">
+      <region-code
+        v-if="showContryCodeFields"
+        v-model="user.regionCode"
+        :country-code="user.countryCode"
+        :class-name="className"
+        :required="required"
+        :label="label"
+      />
+    </template>
+    <template v-else-if="fieldKey === 'postalCode'">
+      <postal-code
+        v-if="showContryCodeFields"
+        v-model="user.postalCode"
+        :class-name="className"
+        :required="required"
+        :label="label"
+      />
+    </template>
     <custom-select
       v-else-if="type === 'custom-select' && customField"
       :id="fieldId"
@@ -119,6 +133,7 @@
 </template>
 
 <script>
+import regionCountryCodes from './utils/region-country-codes';
 import AddressExtra from './form/fields/address-extra.vue';
 import City from './form/fields/city.vue';
 import CountryCode from './form/fields/country.vue';
@@ -200,11 +215,22 @@ export default {
       type: Boolean,
       default: false,
     },
+    className: {
+      type: String,
+      default: '',
+    },
   },
   /**
    *
    */
   computed: {
+    /**
+     *
+     */
+    showContryCodeFields() {
+      return regionCountryCodes.includes(this.user.countryCode);
+    },
+
     /**
      *
      */

--- a/packages/marko-web-identity-x/browser/custom-column.vue
+++ b/packages/marko-web-identity-x/browser/custom-column.vue
@@ -224,6 +224,9 @@ export default {
    *
    */
   computed: {
+    countryCode() {
+      return this.user.countryCode;
+    },
     /**
      *
      */
@@ -264,6 +267,19 @@ export default {
       return classes;
     },
   },
+  /**
+   *
+   */
+  watch: {
+    /**
+     * Clear region and postal codes on country code change.
+     */
+    countryCode() {
+      this.user.regionCode = null;
+      this.user.postalCode = null;
+    },
+  },
+
   /**
    *
    */

--- a/packages/marko-web-identity-x/browser/form/fields/address-extra.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/address-extra.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group class-name="col-md-4">
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -45,6 +45,10 @@ export default {
     value: {
       type: String,
       default: '',
+    },
+    className: {
+      type: String,
+      default: 'col-md-4',
     },
   },
   data: () => ({

--- a/packages/marko-web-identity-x/browser/form/fields/country.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/country.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -49,6 +49,10 @@ export default {
       default: 'Country',
     },
     value: {
+      type: String,
+      default: '',
+    },
+    className: {
       type: String,
       default: '',
     },

--- a/packages/marko-web-identity-x/browser/form/fields/family-name.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/family-name.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -43,6 +43,10 @@ export default {
       default: '',
     },
     value: {
+      type: String,
+      default: '',
+    },
+    className: {
       type: String,
       default: '',
     },

--- a/packages/marko-web-identity-x/browser/form/fields/given-name.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/given-name.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -43,6 +43,10 @@ export default {
       default: '',
     },
     value: {
+      type: String,
+      default: '',
+    },
+    className: {
       type: String,
       default: '',
     },

--- a/packages/marko-web-identity-x/browser/form/fields/organization-title.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/organization-title.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -43,6 +43,10 @@ export default {
       default: '',
     },
     value: {
+      type: String,
+      default: '',
+    },
+    className: {
       type: String,
       default: '',
     },

--- a/packages/marko-web-identity-x/browser/form/fields/organization.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/organization.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -43,6 +43,10 @@ export default {
       default: '',
     },
     value: {
+      type: String,
+      default: '',
+    },
+    className: {
       type: String,
       default: '',
     },

--- a/packages/marko-web-identity-x/browser/form/fields/phone-number.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/phone-number.vue
@@ -1,5 +1,5 @@
 <template>
-  <form-group>
+  <form-group :class-name="className">
     <form-label :for="id" :required="required">
       {{ label }}
     </form-label>
@@ -43,6 +43,10 @@ export default {
       default: '',
     },
     value: {
+      type: String,
+      default: '',
+    },
+    className: {
       type: String,
       default: '',
     },

--- a/services/example-website/config/identity-x/download.js
+++ b/services/example-website/config/identity-x/download.js
@@ -39,8 +39,67 @@ module.exports = {
     // Row 3
     [
       {
-        label: 'Custom 1',
-        id: '618ab74dcd3e2f0147386c42',
+        label: 'Phone Number',
+        key: 'phoneNumber',
+        type: 'built-in',
+        required: true,
+        width: 0.5,
+      },
+      {
+        label: 'Country',
+        key: 'countryCode',
+        type: 'built-in',
+        required: true,
+        width: 0.5,
+      },
+
+    ],
+    // Row 4
+    [
+      {
+        label: 'Street',
+        key: 'street',
+        className: 'col-6',
+        type: 'built-in',
+        required: true,
+        width: 0.33,
+      },
+      {
+        label: 'Extra',
+        key: 'addressExtra',
+        type: 'built-in',
+        required: false,
+        width: 0.33,
+      },
+      {
+        label: 'City',
+        key: 'city',
+        type: 'built-in',
+        required: false,
+        width: 0.33,
+      },
+    ],
+    // Row 4
+    [
+      {
+        label: 'State/Province',
+        key: 'regionCode',
+        type: 'built-in',
+        required: true,
+        width: 0.5,
+      },
+      {
+        label: 'ZIP Code',
+        key: 'postalCode',
+        type: 'built-in',
+        required: true,
+        width: 0.5,
+      },
+    ],
+    [
+      {
+        label: 'Custom 2',
+        id: '626fe8854e597205b368a50f',
         type: 'custom-select',
         required: true,
         width: 0.66,
@@ -51,37 +110,6 @@ module.exports = {
         type: 'custom-select',
         required: true,
         width: 0.33,
-      },
-    ],
-    // Row 4
-    [
-      {
-        label: 'Phone Number',
-        key: 'phoneNumber',
-        type: 'built-in',
-        required: true,
-        width: 0.25,
-      },
-      {
-        label: 'Country',
-        key: 'countryCode',
-        type: 'built-in',
-        required: true,
-        width: 0.25,
-      },
-      {
-        label: 'State/Province',
-        key: 'regionCode',
-        type: 'built-in',
-        required: false,
-        width: 0.25,
-      },
-      {
-        label: 'ZIP Code',
-        key: 'postalCode',
-        type: 'built-in',
-        required: false,
-        width: 0.25,
       },
     ],
   ],

--- a/services/example-website/config/identity-x/download.js
+++ b/services/example-website/config/identity-x/download.js
@@ -62,15 +62,18 @@ module.exports = {
         className: 'col-6',
         type: 'built-in',
         required: true,
-        width: 0.33,
+        width: 0.50,
       },
       {
-        label: 'Extra',
+        label: 'Extra (Apt, Suite, etc.)',
         key: 'addressExtra',
         type: 'built-in',
         required: false,
-        width: 0.33,
+        width: 0.50,
       },
+    ],
+    // Row 4
+    [
       {
         label: 'City',
         key: 'city',
@@ -78,22 +81,19 @@ module.exports = {
         required: false,
         width: 0.33,
       },
-    ],
-    // Row 4
-    [
       {
         label: 'State/Province',
         key: 'regionCode',
         type: 'built-in',
         required: true,
-        width: 0.5,
+        width: 0.33,
       },
       {
         label: 'ZIP Code',
         key: 'postalCode',
         type: 'built-in',
         required: true,
-        width: 0.5,
+        width: 0.33,
       },
     ],
     [


### PR DESCRIPTION
Only allow for the visibility of the regionCode & postalCode inputs when the country code is set to US, Canada or Mexico.  

<img width="745" alt="Screen Shot 2023-08-02 at 11 31 16 AM" src="https://github.com/parameter1/base-cms/assets/3845869/0c6d1ab8-b952-48e7-a8fc-184f024d02ba">
<img width="743" alt="Screen Shot 2023-08-02 at 11 31 09 AM" src="https://github.com/parameter1/base-cms/assets/3845869/7f6ffc88-158b-4f77-8120-36d14a581404">
