### PR TITLE
Update nativeX package config setup & use of core utils and fetch

### DIFF
--- a/packages/marko-newsletters-native-x/apollo/create-client.js
+++ b/packages/marko-newsletters-native-x/apollo/create-client.js
@@ -1,0 +1,41 @@
+const fetch = require('node-fetch');
+
+const getOperationName = (string) => {
+  const matches = /query\s+([a-z0-9]+)[(]?.+{/gi.exec(string);
+  if (matches && matches[1]) return matches[1];
+  return undefined;
+};
+
+module.exports = (uri) => Object.create({
+  query: async ({ query, variables, headers }) => {
+    const body = JSON.stringify({
+      operationName: getOperationName(query),
+      variables,
+      query,
+    });
+
+    const res = await fetch(uri, {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'content-type': 'application/json',
+      },
+      body,
+    });
+    const json = await res.json();
+    if (!res.ok || (json && json.errors)) {
+      if (!json || !json.errors) {
+        const err = new Error(`An unknown, fatal GraphQL error was encountered (${res.status})`);
+        err.statusCode = res.status;
+        throw err;
+      }
+      const [networkError] = json.errors;
+      const err = new Error(networkError.message);
+      const { extensions } = networkError;
+      if (extensions) err.code = extensions.code;
+      if (extensions && extensions.exception) err.statusCode = extensions.exception.statusCode;
+      throw err;
+    }
+    return json;
+  },
+});

--- a/packages/marko-newsletters-native-x/config.js
+++ b/packages/marko-newsletters-native-x/config.js
@@ -1,0 +1,81 @@
+const { asArray } = require('@parameter1/base-cms-utils');
+const { set, get, getAsObject } = require('@parameter1/base-cms-object-path');
+const createClient = require('./apollo/create-client');
+
+class NativeXConfiguration {
+  /**
+   *
+   * @param {string} uri
+   * @param {object} params
+   * @param {boolean} [params.enabled=true]
+   * @param {string} [params.defaultAlias=default]
+   */
+  constructor(uri, { enabled = true, defaultAlias = 'default' } = {}) {
+    if (!uri) throw new Error('Unable to configure NativeX: no URI was provided.');
+    this.uri = uri;
+    this.enabled = enabled;
+    this.defaultAlias = defaultAlias;
+
+    this.client = createClient(this.getGraphQLUri());
+    this.placements = {};
+  }
+
+  /**
+   *
+   * @param {object} params
+   * @param {string} params.alias The placement alias, e.g. `default` or `some-section-name`.
+   * @param {string} params.name The placement name, e.g. `primary` or `list1`, etc.
+   * @param {string} params.id The placement id, e.g. `5d4b04769f69b200013ab109`.
+   */
+  setPlacement({ alias, name, id } = {}) {
+    if (!name || !alias || !id) throw new Error('Unable to create NativeX placement: the name, alias, and ID are required');
+    const placement = { id };
+    set(this.placements, `${alias}.${name}`, placement);
+    return this;
+  }
+
+  /**
+   *
+   * @param {object} params
+   * @param {string} params.name  The placement name, e.g. `primary` or `list1`, etc.
+   * @param {string[]} params.aliases The placement aliases to traverse when loading the placement.
+   */
+  getPlacement({ name, aliases } = {}) {
+    // Retrieve the default and "alias-traversed" placements.
+    const defaultPlacement = getAsObject(this.placements, `${this.defaultAlias}.${name}`);
+    const foundPlacement = asArray(aliases).map((alias) => get(this.placements, `${alias}.${name}`)).filter((v) => v)[0];
+
+    // Ensure placement is duplicated so property re-assignment doesn't "stick."
+    return {
+      ...getAsObject(foundPlacement || defaultPlacement),
+      enabled: this.enabled,
+      uri: this.uri,
+    };
+  }
+
+  /**
+   *
+   * @param {string} alias
+   * @param {object[]} definitions
+   */
+  setAliasPlacements(alias, definitions) {
+    asArray(definitions).forEach((definition) => {
+      this.setPlacement({ ...definition, alias });
+    });
+    return this;
+  }
+
+  getUri() {
+    return this.uri;
+  }
+
+  getGraphQLUri() {
+    return `${this.uri}/graph`;
+  }
+
+  isEnabled() {
+    return this.enabled;
+  }
+}
+
+module.exports = NativeXConfiguration;


### PR DESCRIPTION
Add nativeX configuration for native x pacakge.  will utilize similar calls to web package.  Like getUri() isEnabled() and set get placements calls

**A dep upgrade will have to be run against all of these branches before they can be reviewed & merged.**

**Related Code/PRs:**
 - [AB(configured & in use I believe)](https://github.com/parameter1/ab-media-newsletters/pull/87)
 - [ACBM(revisit and remove any reference to nativeX)]()
 - [Allured(configured & in use I believe)](https://github.com/parameter1/allured-business-media-newsletters/pull/70)
 - [Ascend(configured & In use I believe)](https://github.com/parameter1/ascend-media-newsletters/pull/148)
 - [Bobit/Publicsafety(configured, but calls are commented out)](https://github.com/parameter1/bobit-business-media-newsletters/pull/9)
 - [Cox/Divers(configured, but calls are commented out)](https://github.com/parameter1/cox-matthews-associates-newsletters/pull/39)
  - [INDM(Not configured or setup...should it be by default? This just removes package)](https://github.com/parameter1/industrial-media-newsletters/pull/127)
  - [PMMI(configured but implemented differently within templates)](https://github.com/parameter1/pmmi-media-group-newsletters/pull/109)
  - [RR(configured & using in a mix of ways including randomization position name calls within templates)](https://github.com/parameter1/randall-reilly-newsletters/pull/51)
  - [Rogue(configured & setup to use, but dont think this repo is used)](https://github.com/parameter1/rogue-monkey-media-newsletters/pull/12)
  - [SMG(configured & in use i believe)](https://github.com/parameter1/science-medicine-group-newsletters/pull/27)
  - [WATT(configured & inuse)](https://github.com/parameter1/watt-global-media-newsletters/pull/44)
