### PR TITLE
Include `publicEmail` on `UpdateContentCompanyPayloadMutationInput`

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/company.js
@@ -87,6 +87,7 @@ input UpdateContentCompanyPayloadMutationInput {
   website: String
   type: String
   email: String
+  publicEmail: String
   body: String
   teaser: String
   numberOfEmployees: String


### PR DESCRIPTION
Required to allow for updating the `publicEmail` field via the company update form.