### PR TITLE
Add `Promise` support to body injection and handle newsletter menu body injection

### DIFF
--- a/packages/marko-web-theme-monorail/browser/ssr.js
+++ b/packages/marko-web-theme-monorail/browser/ssr.js
@@ -2,12 +2,14 @@ import ThemeMenuToggleButton from './menu-toggle-button.vue';
 import ThemeNewsletterToggleButton from './newsletter-toggle-button.vue';
 import IdentityXNewsletterToggleButton from './idx-newsletter-form/toggle-button.vue';
 import IdentityXNewsletterFormPushdown from './idx-newsletter-form/pushdown.vue';
+import IdentityXNewsletterFormInline from './idx-newsletter-form/inline.vue';
 import ThemeSiteNewsletterMenu from './site-newsletter-menu.vue';
 
 export default {
   ThemeMenuToggleButton,
   IdentityXNewsletterToggleButton,
   IdentityXNewsletterFormPushdown,
+  IdentityXNewsletterFormInline,
   ThemeNewsletterToggleButton,
   ThemeSiteNewsletterMenu,
 };

--- a/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
+++ b/packages/marko-web-theme-monorail/components/content/body-with-injection.marko
@@ -64,46 +64,53 @@ $ const gamAdInjection = (GAM) ? [
   }
 ] : [];
 
-<theme-ssr-html-inject
-  to-render=MarkoWebContentBody
-  selector=`#${selector}`
->
-  <@component-input
-    block-name=blockName
-    modifiers=modifiers
-    obj=content
-    attrs={ id: selector }
-    embed-options=input.embedOptions
-    lazyload-first-image=input.lazyloadFirstImage
-  />
-  <if(!preventHTMLInjection)>
-    <if(htmlInjections.length)>
-      <for|htmlInjection| of=input.htmlInjections>
-        $ const { at, html } = htmlInjection;
-        <if (at && html)>
-          <@inject
-            at=at
-            html=html
-          />
+
+$ const injectionPromises = [];
+$ if (!preventHTMLInjection && htmlInjections.length) {
+  htmlInjections.forEach((injection) => injectionPromises.push(Promise.resolve(injection)));
+}
+<marko-web-resolve|{ resolved: resolvedInjections }| promise=Promise.all(injectionPromises)>
+  <theme-ssr-html-inject
+    to-render=MarkoWebContentBody
+    selector=`#${selector}`
+  >
+    <@component-input
+      block-name=blockName
+      modifiers=modifiers
+      obj=content
+      attrs={ id: selector }
+      embed-options=input.embedOptions
+      lazyload-first-image=input.lazyloadFirstImage
+    />
+    <if(!preventHTMLInjection)>
+      <if(resolvedInjections.length)>
+        <for|htmlInjection| of=resolvedInjections>
+          $ const { at, html } = htmlInjection;
+          <if (at && html)>
+            <@inject
+              at=at
+              html=html
+            />
+          </if>
+        </for>
+      </if>
+      <for|adInjection| of=gamAdInjection>
+        $ const { counts, name, modifiers } = adInjection;
+        <if(adInjection.counts.length)>
+          <for|count| of=adInjection.counts>
+            <@inject
+              at=count
+              html=GAMDefineDisplayAd.renderToString({
+                name,
+                aliases,
+                modifiers,
+                $global
+              })
+              dataPropToPreventDupes=adInjection.dataPropToPreventDupes
+            />
+          </for>
         </if>
       </for>
     </if>
-    <for|adInjection| of=gamAdInjection>
-      $ const { counts, name, modifiers } = adInjection;
-      <if(adInjection.counts.length)>
-        <for|count| of=adInjection.counts>
-          <@inject
-            at=count
-            html=GAMDefineDisplayAd.renderToString({
-              name,
-              aliases,
-              modifiers,
-              $global
-            })
-            dataPropToPreventDupes=adInjection.dataPropToPreventDupes
-          />
-        </for>
-      </if>
-    </for>
-  </if>
-</theme-ssr-html-inject>
+  </theme-ssr-html-inject>
+</marko-web-resolve>

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
@@ -1,5 +1,7 @@
 import buildProps from "@parameter1/base-cms-marko-web-theme-monorail/utils/site-idx-newsletter-menu-props";
 
+$ const { identityX } =  out.global.req;
+
 <if(Boolean(identityX))>
   <marko-web-identity-x-context|{ user, application }|>
     $ const props = buildProps({

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-inline.marko
@@ -1,65 +1,19 @@
-import { buildImgixUrl } from "@parameter1/base-cms-image";
-import { get } from "@parameter1/base-cms-object-path";
-import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
-
-$ const blockName = "newsletter-signup-banner";
-
-$ const { config, site, req } = out.global;
-$ const { identityX } = req;
-$ const additionalEventData = defaultValue(input.additionalEventData, {});
-$ const buttonLabels = defaultValue(input.buttonLabels, { continue: "Sign Up" })
-$ const loginEmailPlaceholder = defaultValue(input.loginEmailPlaceholder, "example@gmail.com");
-$ const source = defaultValue(input.source, "newsletterSignup");
-$ const configName = defaultValue(input.configName, "signupBanner");
-$ const newsletterSignupType = defaultValue(input.type, "default");
-$ const validTypes = ["inlineContent", "inlineSection", "footer"];
-$ const withImage = defaultValue(input.withImage, true);
-
-$ if (!validTypes.includes(newsletterSignupType)) {
-  console.log(`Unknown inline signup type. One of ${validTypes} expected!`);
-}
-
-$ const {
-  name,
-  description,
-  imagePath,
-  disabled,
-} = site.getAsObject(`newsletter.${configName}`);
-
-$ const lang = site.config.lang || "en";
-$ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 120, auto: "format,compress" }) : null;
-$ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
+import buildProps from "@parameter1/base-cms-marko-web-theme-monorail/utils/site-idx-newsletter-menu-props";
 
 <if(Boolean(identityX))>
-  <marko-web-identity-x-context|{ user, isEnabled, application }|>
-    <if(name && description)>
+  <marko-web-identity-x-context|{ user, application }|>
+    $ const props = buildProps({
+        out,
+        input: {
+          ...input,
+          user,
+          application,
+        }
+      });
+    <if(props.name && props.description)>
       <marko-web-browser-component
         name="IdentityXNewsletterFormInline"
-        props={
-          imageSrc: withImage && imageSrc,
-          imageSrcset: withImage && imageSrcset,
-          siteName: config.website("name"),
-          name,
-          description,
-          disabled,
-          lang,
-          additionalEventData: additionalEventData,
-          source,
-          type: newsletterSignupType,
-          activeUser: user,
-          endpoints: identityX.config.getEndpoints(),
-          buttonLabels,
-          redirect: input.redirect,
-          loginEmailPlaceholder,
-          loginEmailLabel: input.loginEmailLabel,
-          actionText: input.actionText,
-          consentPolicy: input.consentPolicy || get(application, "organization.consentPolicy"),
-          emailConsentRequest: get(application, "organization.emailConsentRequest"),
-          regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
-          appContextId: identityX.config.get("appContextId"),
-          requiredCreateFields: identityX.config.getRequiredCreateFields(),
-          defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
-        }
+        props=props
       />
     </if>
   </marko-web-identity-x-context>

--- a/packages/marko-web-theme-monorail/components/site-newsletter-menu.marko
+++ b/packages/marko-web-theme-monorail/components/site-newsletter-menu.marko
@@ -1,45 +1,11 @@
-import { buildImgixUrl } from "@parameter1/base-cms-image";
-import { getAsObject } from "@parameter1/base-cms-object-path";
+import buildProps from "@parameter1/base-cms-marko-web-theme-monorail/utils/site-newsletter-menu-props";
 
-$ const { site, config, recaptcha } = out.global;
-$ const {
-  name,
-  description,
-  imagePath,
-  defaultNewsletter,
-  newsletters,
-  demographic,
-  disabled,
-  step1CtaLabel,
-  step2CtaLabel,
-  privacyPolicy,
-} = site.getAsObject("newsletter.pushdown");
+$ const props = buildProps({ out });
 
-$ const lang = site.config.lang || "en";
-$ const { initiallyExpanded } = getAsObject(out.global, "newsletterState");
-$ const imageSrc = imagePath ? buildImgixUrl(`https://${config.website("imageHost")}/${imagePath}`, { w: 280, auto: "format,compress" }) : null;
-$ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
-
-<if(name && description)>
+<if(props.name && props.description)>
   <marko-web-browser-component
     name="ThemeSiteNewsletterMenu"
     ssr=true
-    props={
-      siteName: config.website("name"),
-      name,
-      description,
-      defaultNewsletter,
-      newsletters,
-      demographic,
-      disabled,
-      imageSrc,
-      imageSrcset,
-      initiallyExpanded,
-      step1CtaLabel,
-      step2CtaLabel,
-      recaptchaSiteKey: recaptcha.siteKey,
-      privacyPolicyLink: privacyPolicy,
-      lang
-    }
+    props=props
   />
 </if>

--- a/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
@@ -149,6 +149,29 @@
   }
 }
 
+// overrides for inbody content injections
+.page-contents__content-body {
+  .site-newsletter-menu {
+    visibility: visible;
+    max-height: initial;
+    padding: map-get($spacers, block);
+    padding-bottom: 0;
+    margin-bottom: map-get($spacers, block);
+    background: linear-gradient($gray-100, $gray-300);
+    &__container {
+      padding-top: 0;
+    }
+    &__image {
+      max-width: 100%;
+      filter: drop-shadow(-10px -10px 10px rgba(0,0,0,.24));
+    }
+    &__close-container,
+    &__close-container {
+      display: none !important;
+    }
+  }
+}
+
 .complete-newsletter-signup {
   $self: &;
   max-width: 652px;

--- a/packages/marko-web-theme-monorail/utils/render-site-idx-newsletter-menu.js
+++ b/packages/marko-web-theme-monorail/utils/render-site-idx-newsletter-menu.js
@@ -1,0 +1,26 @@
+const { randomElementId } = require('@parameter1/base-cms-utils');
+const renderVueSSRComponent = require('@parameter1/base-cms-marko-web/utils/render-ssr-component-from-marko');
+const buildProps = require('./site-idx-newsletter-menu-props');
+
+module.exports = async ({
+  out,
+  input,
+  user,
+  application,
+}) => {
+  const props = buildProps({
+    out,
+    input,
+    user,
+    application,
+  });
+  if (!props.name || !props.description) return '';
+  return renderVueSSRComponent({
+    id: randomElementId({ prefix: 'vue' }),
+    input: {
+      name: 'IdentityXNewsletterFormInline',
+      props,
+    },
+    out,
+  });
+};

--- a/packages/marko-web-theme-monorail/utils/render-site-newsletter-menu.js
+++ b/packages/marko-web-theme-monorail/utils/render-site-newsletter-menu.js
@@ -1,0 +1,16 @@
+const { randomElementId } = require('@parameter1/base-cms-utils');
+const renderVueSSRComponent = require('@parameter1/base-cms-marko-web/utils/render-ssr-component-from-marko');
+const buildProps = require('./site-newsletter-menu-props');
+
+module.exports = async ({ out }) => {
+  const props = buildProps({ out });
+  if (!props.name || !props.description) return '';
+  return renderVueSSRComponent({
+    id: randomElementId({ prefix: 'vue' }),
+    input: {
+      name: 'ThemeSiteNewsletterMenu',
+      props,
+    },
+    out,
+  });
+};

--- a/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
+++ b/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
@@ -1,0 +1,58 @@
+const { buildImgixUrl } = require('@parameter1/base-cms-image');
+const { get } = require('@parameter1/base-cms-object-path');
+const defaultValue = require('@parameter1/base-cms-marko-core/utils/default-value');
+
+module.exports = ({ out, input }) => {
+  const { config, site, req } = out.global;
+  const { user, application } = input;
+  const { identityX } = req;
+  const additionalEventData = defaultValue(input.additionalEventData, {});
+  const buttonLabels = defaultValue(input.buttonLabels, { continue: 'Sign Up' });
+  const loginEmailPlaceholder = defaultValue(input.loginEmailPlaceholder, 'example@gmail.com');
+  const source = defaultValue(input.source, 'newsletterSignup');
+  const configName = defaultValue(input.configName, 'signupBanner');
+  const newsletterSignupType = defaultValue(input.type, 'default');
+  const validTypes = ['inlineContent', 'inlineSection', 'footer'];
+  const withImage = defaultValue(input.withImage, true);
+
+  if (!validTypes.includes(newsletterSignupType)) {
+    console.log(`Unknown inline signup type. One of ${validTypes} expected!`);
+  }
+
+  const {
+    name,
+    description,
+    imagePath,
+    disabled,
+  } = site.getAsObject(`newsletter.${configName}`);
+
+  const lang = site.config.lang || 'en';
+  const imageSrc = imagePath ? buildImgixUrl(`https://${config.website('imageHost')}/${imagePath}`, { w: 120, auto: 'format,compress' }) : null;
+  const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
+
+  return {
+    imageSrc: withImage && imageSrc,
+    imageSrcset: withImage && imageSrcset,
+    siteName: config.website('name'),
+    name,
+    description,
+    disabled,
+    lang,
+    additionalEventData,
+    source,
+    type: newsletterSignupType,
+    activeUser: user,
+    endpoints: identityX.config.getEndpoints(),
+    buttonLabels,
+    redirect: input.redirect,
+    loginEmailPlaceholder,
+    loginEmailLabel: input.loginEmailLabel,
+    actionText: input.actionText,
+    consentPolicy: input.consentPolicy || get(application, 'organization.consentPolicy'),
+    emailConsentRequest: get(application, 'organization.emailConsentRequest'),
+    regionalConsentPolicies: get(application, 'organization.regionalConsentPolicies'),
+    appContextId: identityX.config.get('appContextId'),
+    requiredCreateFields: identityX.config.getRequiredCreateFields(),
+    defaultFieldLabels: identityX.config.get('defaultFieldLabels'),
+  };
+};

--- a/packages/marko-web-theme-monorail/utils/site-newsletter-menu-props.js
+++ b/packages/marko-web-theme-monorail/utils/site-newsletter-menu-props.js
@@ -1,0 +1,41 @@
+const { buildImgixUrl } = require('@parameter1/base-cms-image');
+const { getAsObject } = require('@parameter1/base-cms-object-path');
+
+module.exports = ({ out }) => {
+  const { site, config, recaptcha } = out.global;
+  const {
+    name,
+    description,
+    imagePath,
+    defaultNewsletter,
+    newsletters,
+    demographic,
+    disabled,
+    step1CtaLabel,
+    step2CtaLabel,
+    privacyPolicy,
+  } = site.getAsObject('newsletter.pushdown');
+
+  const lang = site.config.lang || 'en';
+  const { initiallyExpanded } = getAsObject(out.global, 'newsletterState');
+  const imageSrc = imagePath ? buildImgixUrl(`https://${config.website('imageHost')}/${imagePath}`, { w: 280, auto: 'format,compress' }) : null;
+  const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
+
+  return {
+    siteName: config.website('name'),
+    name,
+    description,
+    defaultNewsletter,
+    newsletters,
+    demographic,
+    disabled,
+    imageSrc,
+    imageSrcset,
+    initiallyExpanded,
+    step1CtaLabel,
+    step2CtaLabel,
+    recaptchaSiteKey: recaptcha.siteKey,
+    privacyPolicyLink: privacyPolicy,
+    lang,
+  };
+};

--- a/packages/marko-web/components/browser-component.marko
+++ b/packages/marko-web/components/browser-component.marko
@@ -2,14 +2,9 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { randomElementId } from "@parameter1/base-cms-utils";
 import renderComponent from "../utils/render-ssr-component-from-marko";
 
-$ const id = randomElementId({ prefix: 'vue' });
+$ const id = randomElementId({ prefix: "vue" });
 $ const tag = defaultValue(input.tag, "div");
-$ const { name } = input;
 $ const ssr = defaultValue(input.ssr, false);
-$ const hydrate = ssr ? true : defaultValue(input.hydrate, false);
-$ const skipWhenExists = defaultValue(input.skipWhenExists, false);
-$ const props = JSON.stringify(input.props || {});
-$ const contents = `CMSBrowserComponents.load({ el: '#${id}', name: '${name}', props: ${props}, hydrate: ${hydrate}, skipWhenExists: ${skipWhenExists} });`;
 
 <if(ssr)>
   <marko-web-resolve|{ resolved: html }| promise=renderComponent({ id, input, out })>
@@ -20,5 +15,10 @@ $ const contents = `CMSBrowserComponents.load({ el: '#${id}', name: '${name}', p
   <${tag} ...input.attrs id=id class=input.class>
     <${input.renderBody} />
   </>
+  <marko-web-browser-component-script
+    id=id
+    hydrate=input.hydrate
+    name=input.name
+    props=input.props
+  />
 </else>
-<script class="component" data-name=name>$!{contents}</script>

--- a/packages/marko-web/components/browser-component.marko
+++ b/packages/marko-web/components/browser-component.marko
@@ -1,6 +1,6 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { randomElementId } from "@parameter1/base-cms-utils";
-import renderComponent from "../utils/render-ssr-component";
+import renderComponent from "../utils/render-ssr-component-from-marko";
 
 $ const id = randomElementId({ prefix: 'vue' });
 $ const tag = defaultValue(input.tag, "div");
@@ -12,10 +12,7 @@ $ const props = JSON.stringify(input.props || {});
 $ const contents = `CMSBrowserComponents.load({ el: '#${id}', name: '${name}', props: ${props}, hydrate: ${hydrate}, skipWhenExists: ${skipWhenExists} });`;
 
 <if(ssr)>
-  $ const { compiledVueComponents } = out.global;
-  $ const Component = compiledVueComponents[name];
-  $ if (!Component) throw new Error(`No compiled Vue template found for ${name}. Unable to render server-side.`);
-  <marko-web-resolve|{ resolved: html }| promise=renderComponent(Component, { id, props: input.props })>
+  <marko-web-resolve|{ resolved: html }| promise=renderComponent({ id, input, out })>
     $!{html}
   </marko-web-resolve>
 </if>

--- a/packages/marko-web/components/browser-component/script.marko
+++ b/packages/marko-web/components/browser-component/script.marko
@@ -1,0 +1,10 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { id, name } = input;
+
+$ const props = JSON.stringify(input.props || {})
+$ const hydrate = defaultValue(input.hydrate, false);
+$ const skipWhenExists = defaultValue(input.skipWhenExists, false);
+$ const contents = `CMSBrowserComponents.load({ el: '#${id}', name: '${name}', props: ${props}, hydrate: ${hydrate}, skipWhenExists: ${skipWhenExists} });`;
+
+<script class="component" data-name=name>$!{contents}</script>

--- a/packages/marko-web/components/marko.json
+++ b/packages/marko-web/components/marko.json
@@ -24,6 +24,9 @@
     "@attrs": "object",
     "@props": "object"
   },
+  "<marko-web-browser-component-script>": {
+    "template": "./browser-component/script.marko"
+  },
   "<marko-web-deferred-stylesheet>": {
     "template": "./deferred-stylesheet.marko",
     "@href": {

--- a/packages/marko-web/utils/render-ssr-component-from-marko.js
+++ b/packages/marko-web/utils/render-ssr-component-from-marko.js
@@ -1,9 +1,19 @@
 const renderComponent = require('./render-ssr-component');
+const BrowserComponentScript = require('../components/browser-component/script');
 
-module.exports = ({ id, input, out }) => {
-  const { name } = input;
+module.exports = async ({ id, input, out }) => {
+  const { name, props } = input;
   const { compiledVueComponents } = out.global;
   const Component = compiledVueComponents[name];
   if (!Component) throw new Error(`No compiled Vue template found for ${name}. Unable to render server-side.`);
-  return renderComponent(Component, { id, props: input.props });
+  const html = await renderComponent(Component, { id, props });
+  const script = BrowserComponentScript.renderToString({
+    id,
+    hydrate: true,
+    name,
+    props,
+    skipWhenExists: input.skipWhenExists,
+  });
+  console.log({ script });
+  return `${html}${script}`;
 };

--- a/packages/marko-web/utils/render-ssr-component-from-marko.js
+++ b/packages/marko-web/utils/render-ssr-component-from-marko.js
@@ -1,0 +1,9 @@
+const renderComponent = require('./render-ssr-component');
+
+module.exports = ({ id, input, out }) => {
+  const { name } = input;
+  const { compiledVueComponents } = out.global;
+  const Component = compiledVueComponents[name];
+  if (!Component) throw new Error(`No compiled Vue template found for ${name}. Unable to render server-side.`);
+  return renderComponent(Component, { id, props: input.props });
+};

--- a/packages/marko-web/utils/render-ssr-component-from-marko.js
+++ b/packages/marko-web/utils/render-ssr-component-from-marko.js
@@ -14,6 +14,5 @@ module.exports = async ({ id, input, out }) => {
     props,
     skipWhenExists: input.skipWhenExists,
   });
-  console.log({ script });
   return `${html}${script}`;
 };

--- a/services/example-website/config/newsletter.js
+++ b/services/example-website/config/newsletter.js
@@ -1,9 +1,47 @@
+const privacyPolicy = require('./privacy-policy');
+
 const defaults = {
   name: 'Don’t Miss Out',
-  description: 'Get the business tips, industry insights and trending news every user needs to know in the <span class="newsletter-name">Sandbox</span> newsletter.',
-  privacyPolicy: { href: '/page/terms-conditions', label: 'Terms & Conditions' },
+  description: 'Get the business tips, industry insights and trending news every owner-operator needs to know in the <span class="newsletter-name">Overdrive</span> newsletter.',
+  defaultNewsletter: {
+    deploymentTypeId: 33,
+    name: 'Overdrive Daily Newsletter',
+    eventCategory: 'Daily Newsletter Subscription',
+  },
+  privacyPolicy,
+  newsletters: [
+    {
+      deploymentTypeId: 35,
+      name: 'Custom Rigs Weekly Newsletter',
+      description: 'Great photos and stories of the coolest rigs out there',
+      eventCategory: 'Custom Rigs Subscription',
+    },
+    {
+      deploymentTypeId: 85,
+      name: 'Overdrive Monthly Gear Newsletter',
+      description: 'The best products for owner-operators',
+      eventCategory: 'Monthly Gear Subscription',
+    },
+    {
+      deploymentTypeId: 63,
+      name: 'Overdrive Weekly Newsletter',
+      description: 'The most important news of the week in trucking',
+      eventCategory: 'Weekly Newsletter Subscription',
+    },
+  ],
+  demographic: {
+    id: 241,
+    label: 'Your primary role?',
+    values: [
+      { id: 380, label: 'Owner/Operator leased to a for-hire carrier' },
+      { id: 381, label: 'Owner with own authority to haul freight (for-hire)' },
+      { id: 382, label: 'Owner not for hire, with vocational business' },
+      { id: 379, label: 'Company Driver' },
+      { id: 383, label: 'School' },
+      { id: 384, label: 'Other' },
+    ],
+  },
 };
-
 module.exports = {
   // uses inline omeda form
   signupBanner: {

--- a/services/example-website/server/templates/components/content-body.marko
+++ b/services/example-website/server/templates/components/content-body.marko
@@ -2,6 +2,7 @@ import { get, getAsArray, getAsObject } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
 import cm from "@parameter1/base-cms-marko-web-theme-monorail/utils/content-meter-helpers";
+import renderSiteNewsletterMenu from "@parameter1/base-cms-marko-web-theme-monorail/utils/render-site-newsletter-menu";
 
 $ const { content, blockName } = input;
 $ const { contentGatingHandler, contentMeterState, req } = out.global;
@@ -67,11 +68,15 @@ $ const useIdxDownload = defaultValue(get(content, "gating.surveyType") === "idx
   </else-if>
   <else>
     $ const bodyId = `content-body-${content.id}`;
+    $ const newsletterPromise = renderSiteNewsletterMenu({ out }).then((html) => ({ at: 800, html }));
     <if(shouldInjectAds)>
       <theme-body-with-injection
         content=content
         aliases=[]
         block-name=blockName
+        html-injections=[
+          newsletterPromise,
+        ]
         preventHTMLInjection=false
       />
     </if>

--- a/services/example-website/server/templates/components/content-body.marko
+++ b/services/example-website/server/templates/components/content-body.marko
@@ -3,6 +3,7 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
 import cm from "@parameter1/base-cms-marko-web-theme-monorail/utils/content-meter-helpers";
 import renderSiteNewsletterMenu from "@parameter1/base-cms-marko-web-theme-monorail/utils/render-site-newsletter-menu";
+import renderSiteIdxNewsletterMenu from "@parameter1/base-cms-marko-web-theme-monorail/utils/render-site-idx-newsletter-menu";
 
 $ const { content, blockName } = input;
 $ const { contentGatingHandler, contentMeterState, req } = out.global;
@@ -69,12 +70,21 @@ $ const useIdxDownload = defaultValue(get(content, "gating.surveyType") === "idx
   <else>
     $ const bodyId = `content-body-${content.id}`;
     $ const newsletterPromise = renderSiteNewsletterMenu({ out }).then((html) => ({ at: 800, html }));
+    $ const idxNewsletterPromise = renderSiteIdxNewsletterMenu({
+      out,
+      input: {
+        type: "inlineContent",
+        user: context.user,
+        application: context.application,
+      },
+    }).then((html) => ({ at: 200, html }));
     <if(shouldInjectAds)>
       <theme-body-with-injection
         content=content
         aliases=[]
         block-name=blockName
         html-injections=[
+          idxNewsletterPromise,
           newsletterPromise,
         ]
         preventHTMLInjection=false


### PR DESCRIPTION
Example with these being configure and injected at the top of an article page:
<img width="609" alt="Screen Shot 2023-08-17 at 10 08 56 AM" src="https://github.com/parameter1/base-cms/assets/3845869/34cb7593-b28f-4dff-ad08-5c4c55b8e906">
