### PR TITLE
Add hidden ld-json content body div when gated

### DIFF
--- a/packages/marko-web-theme-monorail/components/identity-x/content-page-gate.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/content-page-gate.marko
@@ -82,4 +82,8 @@ $ const additionalEventData = {
       />
     </marko-web-element>
   </else-if>
+  <if(!canAccess || (isLoggedIn && requiresUserInput))>
+    <!-- If either condition is true assume content body is gated & display for seo purposes -->
+    <marko-web-content-body block-name=blockName attrs={ style: "display: none;" } obj=content modifiers=["ld-json"] />
+  </if>
 </marko-web-block>


### PR DESCRIPTION
When using the monorail theme-content-gate component this will add the hidden div to display