### PR TITLE
Display approved comments only

### DIFF
--- a/packages/marko-web-identity-x/browser/comments/post.vue
+++ b/packages/marko-web-identity-x/browser/comments/post.vue
@@ -3,7 +3,6 @@
     <div :class="element('header')">
       <div :class="element('display-name')">
         <span>Posted by {{ displayName }}</span>
-        <span v-if="!approved">(pending moderation)</span>
       </div>
       <div>
         <span :class="element('created-at')">

--- a/packages/marko-web-identity-x/browser/comments/stream.vue
+++ b/packages/marko-web-identity-x/browser/comments/stream.vue
@@ -62,7 +62,7 @@
     <div v-else-if="error" :class="element('error')">
       Unable to load comments: {{ error.message }}
     </div>
-    <div v-else-if="approveComments.length === 0" :class="element('no-posts')">
+    <div v-else-if="approvedComments.length === 0" :class="element('no-posts')">
       {{ noCommentsMessage }}
     </div>
     <div v-else :class="element('posts')">

--- a/packages/marko-web-identity-x/browser/comments/stream.vue
+++ b/packages/marko-web-identity-x/browser/comments/stream.vue
@@ -49,8 +49,11 @@
         />
       </div>
 
-      <h5 v-if="latestCommentsHeader && comments.length" :class="element('latest-comments')">
-        {{ latestCommentsHeader }} ({{ totalCount }})
+      <h5
+        v-if="latestCommentsHeader && approvedComments.length"
+        :class="element('latest-comments')"
+      >
+        {{ latestCommentsHeader }} ({{ approvedComments.length }})
       </h5>
     </div>
     <div v-if="isLoading" :class="element('loading')">
@@ -59,12 +62,12 @@
     <div v-else-if="error" :class="element('error')">
       Unable to load comments: {{ error.message }}
     </div>
-    <div v-else-if="comments.length === 0" :class="element('no-posts')">
+    <div v-else-if="approveComments.length === 0" :class="element('no-posts')">
       {{ noCommentsMessage }}
     </div>
     <div v-else :class="element('posts')">
       <div
-        v-for="comment in comments"
+        v-for="comment in approvedComments"
         :key="comment.id"
         :class="element('post')"
       >
@@ -230,6 +233,12 @@ export default {
      */
     hasActiveUser() {
       return this.activeUser && this.activeUser.email;
+    },
+    /**
+     *
+     */
+    approvedComments() {
+      return this.comments.filter((comment) => comment.approved);
     },
   },
 


### PR DESCRIPTION
Development (only to show what this COULD do for a cited example, comments have not be "denied" (i.e. marked as `approved: false`):
![Screenshot from 2023-08-23 10-30-57](https://github.com/parameter1/base-cms/assets/46794001/db837b6e-bcc7-461a-9cc6-e2c8b246b45b)

Production:
![Screenshot from 2023-08-23 10-31-05](https://github.com/parameter1/base-cms/assets/46794001/882168ca-cbb3-4583-9ee9-c4618a5d3b7b)
