### PR TITLE
Remove email field from Company structured data

### DIFF
--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -73,9 +73,6 @@ fragment ContentPageMetadataFragment on Content {
     mobile
     publicEmail
   }
-  ... on ContentCompany {
-    email
-  }
   images(input:{ pagination: { limit: 0 }, sort: { order: values } }) {
     edges {
       node {

--- a/packages/marko-web/components/page/metadata/content.marko
+++ b/packages/marko-web/components/page/metadata/content.marko
@@ -71,7 +71,7 @@ fragment ContentPageMetadataFragment on Content {
     website
     title
     mobile
-    publicEmail
+    email: publicEmail
   }
   images(input:{ pagination: { limit: 0 }, sort: { order: values } }) {
     edges {


### PR DESCRIPTION
This was originally added via: https://github.com/parameter1/base-cms/pull/113

**NOTE:** If we would like to add an aliased version of the `publicEmail` field called `email` (likely to prevent any backwards breaking behavior that could come with removing `email`) then that can certainly be done, initially just wanted to remove the actual trouble spot before making any additional alterations.