### PR TITLE
Replace look up for from & from.toLowerCase with  case insensitive regex match

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/website/redirect.js
+++ b/services/graphql-server/src/graphql/resolvers/website/redirect.js
@@ -49,9 +49,8 @@ module.exports = {
       const siteOp = siteOps[siteQueryOperator];
       const query = {
         $or: [
-          { siteId: { [siteOp]: siteId }, from },
-          { siteId: { [siteOp]: siteId }, from: from.toLowerCase() },
-          { siteId: { [siteOp]: siteId }, from: { $regex: new RegExp(`${from.toLowerCase()}\\?${queryParams}`, 'i') } },
+          { siteId: { [siteOp]: siteId }, from: { $regex: new RegExp(`${from}`, 'i') } },
+          { siteId: { [siteOp]: siteId }, from: { $regex: new RegExp(`${from}\\?${queryParams}`, 'i') } },
         ],
       };
       const redirect = await basedb.findOne('website.Redirects', query);

--- a/services/graphql-server/src/graphql/resolvers/website/redirect.js
+++ b/services/graphql-server/src/graphql/resolvers/website/redirect.js
@@ -51,8 +51,7 @@ module.exports = {
         $or: [
           { siteId: { [siteOp]: siteId }, from },
           { siteId: { [siteOp]: siteId }, from: from.toLowerCase() },
-          { siteId: { [siteOp]: siteId }, from: `${from}?${queryParams}` },
-          { siteId: { [siteOp]: siteId }, from: `${from.toLowerCase()}?${queryParams}` },
+          { siteId: { [siteOp]: siteId }, from: { $regex: new RegExp(`${from.toLowerCase()}\\?${queryParams}`, 'i') } },
         ],
       };
       const redirect = await basedb.findOne('website.Redirects', query);


### PR DESCRIPTION
Instead of looking up by just from and from.toLowerCase() replace this with a new RegExp for a case insensitive version of the look for from.

Exmple: http://www-smg-am.dev.parameter1.com:9954/Forum/tt.aspx?forumid=7
old $or: 
```
[
  {
    siteId: { '$eq': 63038e5dd15c7c4b2e8b458a },
    from: '/Forum/tt.aspx'
  },
  {
    siteId: { '$eq': 63038e5dd15c7c4b2e8b458a },
    from: '/forum/tt.aspx'
  },
  {
    siteId: { '$eq': 63038e5dd15c7c4b2e8b458a },
    from: '/Forum/tt.aspx?forumid=7'
  },
  {
    siteId: { '$eq': 63038e5dd15c7c4b2e8b458a },
    from: '/forum/tt.aspx?forumid=7'
  }
]
```
new $or:
```
[
  {
    siteId: { '$eq': 63038e5dd15c7c4b2e8b458a },
    from: { '$regex': /\/Forum\/tt.aspx/i }
  },
  {
    siteId: { '$eq': 63038e5dd15c7c4b2e8b458a },
    from: { '$regex': /\/Forum\/tt.aspx\?forumid=7/i }
  }
]
```
