### PR TITLE
Adjust Almost Done! copy referencing login expiration

### DIFF
--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -231,7 +231,7 @@ export default {
       if (this.lang === 'es') {
         return `<h4>Falta muy poco!</h4>
         <p>
-          Enviamos un correo a <em>${this.email}</em> con su enlace de inicio de sesión único.
+          Enviamos un correo a <em>${this.email}</em> con su enlace de inicio de sesión único(caducó en una hora).
           Para terminar de  ${this.actionText || 'logging in'}, abra el mensaje de correo electrónico y haga clic en el enlace que contiene.
         </p>
         <p>
@@ -242,7 +242,7 @@ export default {
       }
       return `<h4>Almost Done!</h4>
       <p>
-        We just sent an email to <em>${this.email}</em> with your one-time login link.
+        We just sent an email to <em>${this.email}</em> with your one-time login link(expired in one hour).
         To finish ${this.actionText || 'logging in'}, open the email message and click the link within.
       </p>
       <p>

--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -231,7 +231,7 @@ export default {
       if (this.lang === 'es') {
         return `<h4>Falta muy poco!</h4>
         <p>
-          Enviamos un correo a <em>${this.email}</em> con su enlace de inicio de sesión único(caducó en una hora).
+          Enviamos un correo a <em>${this.email}</em> con su enlace de inicio de sesión único (caducó en una hora).
           Para terminar de  ${this.actionText || 'logging in'}, abra el mensaje de correo electrónico y haga clic en el enlace que contiene.
         </p>
         <p>
@@ -242,7 +242,7 @@ export default {
       }
       return `<h4>Almost Done!</h4>
       <p>
-        We just sent an email to <em>${this.email}</em> with your one-time login link(expired in one hour).
+        We just sent an email to <em>${this.email}</em> with your one-time login link (expired in one hour).
         To finish ${this.actionText || 'logging in'}, open the email message and click the link within.
       </p>
       <p>


### PR DESCRIPTION
This will just add `(expired in one hour)` to end of sentence one.  
<img width="1091" alt="Screen Shot 2023-09-20 at 11 41 16 AM" src="https://github.com/parameter1/base-cms/assets/3845869/3c5afe0a-775d-4470-aae1-8ef9c7e86176">
<img width="1104" alt="Screen Shot 2023-09-20 at 11 42 06 AM" src="https://github.com/parameter1/base-cms/assets/3845869/f9357ea6-aba1-4f23-999b-8f4b2459cabc">


@ForDiscussion: Investigate ability to also conditional change the second sentence or add a third based on if the user will be retuned to a page displaying the profile or not.  This will require, at minimum, the use of additional prop being sent into the login component.  Like clientRequiredFields & serverRequiredFields &... [line 187](https://github.com/parameter1/base-cms/blob/master/packages/marko-web-identity-x/browser/authenticate.vue#L187).  

Again all of this is up for discussion.
