### PR TITLE
Add getGTMUserData() & gtmUserFields prop to identityX config.

### DIFF
--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -54,7 +54,7 @@ fragment ActiveUserFragment on AppUser {
   }) {
     id
     hasAnswered
-    answers { id externalIdentifier writeInValue }
+    answers { id label externalIdentifier writeInValue }
     field {
       id
       label

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -29,6 +29,7 @@ class IdentityXConfiguration {
     hiddenFields = ['city', 'street', 'addressExtra', 'phoneNumber'],
     defaultCountryCode,
     booleanQuestionsLabel,
+    gtmUserFields = {}, // { primary_role: 'ObjectId' }
     onHookError,
     ...rest
   } = {}) {
@@ -45,6 +46,7 @@ class IdentityXConfiguration {
       hiddenFields,
       defaultCountryCode,
       booleanQuestionsLabel,
+      gtmUserFields,
       onHookError: (e) => {
         if (process.env.NODE_ENV === 'development') {
           log('ERROR IN IDENTITY-X HOOK', e);
@@ -106,6 +108,19 @@ class IdentityXConfiguration {
 
   getRequiredServerFields() {
     return this.getAsArray('requiredServerFields');
+  }
+
+  getGTMUserFieldsData(user) {
+    if (!user) return {};
+    const questions = this.getAsObject('gtmUserFields');
+    const userData = { user_id: user.id };
+    Object.entries(questions).forEach(([key, value]) => {
+      const select = user.customSelectFieldAnswers.find(({id: qId}) => qId === value)
+      if (select && select.answers.length) userData[key] = select.answers.map(({ label }) => label).join("| ");
+      const boolean = user.customBooleanFieldAnswers.find(({id: qId}) => qId === value)
+      if (boolean && boolean.hasAnswered) userData[key] =  boolean.answer;
+    });
+    return userData;
   }
 
   getRequiredClientFields() {

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -110,7 +110,7 @@ class IdentityXConfiguration {
     return this.getAsArray('requiredServerFields');
   }
 
-  getGTMUserFieldsData(user) {
+  getGTMUserData(user) {
     if (!user) return {};
     const questions = this.getAsObject('gtmUserFields');
     const userData = { user_id: user.id };

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -116,7 +116,7 @@ class IdentityXConfiguration {
     const userData = { user_id: user.id };
     Object.entries(questions).forEach(([key, value]) => {
       const select = user.customSelectFieldAnswers.find(({id: qId}) => qId === value)
-      if (select && select.answers.length) userData[key] = select.answers.map(({ label }) => label).join("| ");
+      if (select && select.answers.length) userData[key] = select.answers.map(({ label }) => label).join("|");
       const boolean = user.customBooleanFieldAnswers.find(({id: qId}) => qId === value)
       if (boolean && boolean.hasAnswered) userData[key] =  boolean.answer;
     });

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -29,7 +29,7 @@ class IdentityXConfiguration {
     hiddenFields = ['city', 'street', 'addressExtra', 'phoneNumber'],
     defaultCountryCode,
     booleanQuestionsLabel,
-    gtmUserFields = {}, // { primary_role: 'ObjectId' }
+    gtmUserFields = {},
     onHookError,
     ...rest
   } = {}) {
@@ -115,9 +115,9 @@ class IdentityXConfiguration {
     const questions = this.getAsObject('gtmUserFields');
     const userData = { user_id: user.id };
     Object.entries(questions).forEach(([key, value]) => {
-      const select = user.customSelectFieldAnswers.find(({ id }) => id === value)
-      if (select && select.answers.length) userData[key] = select.answers.map(({ label }) => label).join("|");
-      const boolean = user.customBooleanFieldAnswers.find(({ id }) => id === value)
+      const select = user.customSelectFieldAnswers.find(({ id }) => id === value);
+      if (select && select.answers.length) userData[key] = select.answers.map(({ label }) => label).join('|');
+      const boolean = user.customBooleanFieldAnswers.find(({ id }) => id === value);
       if (boolean && boolean.hasAnswered) userData[key] =  boolean.answer;
     });
     return userData;

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -118,7 +118,7 @@ class IdentityXConfiguration {
       const select = user.customSelectFieldAnswers.find(({ id }) => id === value);
       if (select && select.answers.length) userData[key] = select.answers.map(({ label }) => label).join('|');
       const boolean = user.customBooleanFieldAnswers.find(({ id }) => id === value);
-      if (boolean && boolean.hasAnswered) userData[key] =  boolean.answer;
+      if (boolean && boolean.hasAnswered) userData[key] = boolean.answer;
     });
     return userData;
   }

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -115,9 +115,9 @@ class IdentityXConfiguration {
     const questions = this.getAsObject('gtmUserFields');
     const userData = { user_id: user.id };
     Object.entries(questions).forEach(([key, value]) => {
-      const select = user.customSelectFieldAnswers.find(({id: qId}) => qId === value)
+      const select = user.customSelectFieldAnswers.find(({ id }) => id === value)
       if (select && select.answers.length) userData[key] = select.answers.map(({ label }) => label).join("|");
-      const boolean = user.customBooleanFieldAnswers.find(({id: qId}) => qId === value)
+      const boolean = user.customBooleanFieldAnswers.find(({ id }) => id === value)
       if (boolean && boolean.hasAnswered) userData[key] =  boolean.answer;
     });
     return userData;


### PR DESCRIPTION
You can no configure gtm key value data pairs. At the site configuation level you can set:
```
gtmUserFields: {
    primary_role: '62b3193c39347cb0d3864305',
    job_title: '62b32c2f39347c47cd86433c',
    daily_enl: '62b330936ca6068d0407dd18',
  },
  ```
  
  This will then use this gtmUserFields object and the new function to generate a data object.  This is then sent to gtm and has the users answers mapped  by the related objectId. something looking like 

<img width="820" alt="Screen Shot 2023-09-27 at 11 15 40 AM" src="https://github.com/parameter1/base-cms/assets/3845869/6f95a8ab-766f-4a80-8a96-b767b19fddff">
