### PR TITLE
Add sorting by activeCustomFieldsIds on profile page

### DIFF
--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -415,7 +415,8 @@ export default {
       const { activeCustomFieldIds: ids } = this;
       const { customBooleanFieldAnswers } = this.user;
       const answers = isArray(customBooleanFieldAnswers) ? customBooleanFieldAnswers : [];
-      return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true);
+      return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true)
+      .sort(this.sortByActiveCustomFieldId);
     },
 
     /**
@@ -425,7 +426,8 @@ export default {
       const { activeCustomFieldIds: ids } = this;
       const { customSelectFieldAnswers } = this.user;
       const answers = isArray(customSelectFieldAnswers) ? customSelectFieldAnswers : [];
-      return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true);
+      return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true)
+      .sort(this.sortByActiveCustomFieldIds);
     },
 
     showAddressBlock() {
@@ -562,6 +564,12 @@ export default {
 
     customSelectIsRequired(fieldAnswer) {
       return this.requiredFields.includes(fieldAnswer.field.id) || fieldAnswer.field.required;
+    },
+
+    sortByActiveCustomFieldIds(a, b) {
+      const { activeCustomFieldIds: ids } = this;
+      const sortingArr = ids.length > 0 ? ids : [];
+      return sortingArr.indexOf(a.field.id) - sortingArr.indexOf(a.field.id);
     },
 
     async handleReload() {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -569,7 +569,7 @@ export default {
     sortByActiveCustomFieldIds(a, b) {
       const { activeCustomFieldIds: ids } = this;
       const sortingArr = ids.length > 0 ? ids : [];
-      return sortingArr.indexOf(a.field.id) - sortingArr.indexOf(a.field.id);
+      return sortingArr.indexOf(a.field.id) - sortingArr.indexOf(b.field.id);
     },
 
     async handleReload() {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -416,7 +416,7 @@ export default {
       const { customBooleanFieldAnswers } = this.user;
       const answers = isArray(customBooleanFieldAnswers) ? customBooleanFieldAnswers : [];
       return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true)
-      .sort(this.sortByActiveCustomFieldId);
+        .sort(this.sortByActiveCustomFieldId);
     },
 
     /**
@@ -427,7 +427,7 @@ export default {
       const { customSelectFieldAnswers } = this.user;
       const answers = isArray(customSelectFieldAnswers) ? customSelectFieldAnswers : [];
       return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true)
-      .sort(this.sortByActiveCustomFieldIds);
+        .sort(this.sortByActiveCustomFieldIds);
     },
 
     showAddressBlock() {


### PR DESCRIPTION
This will add the sorting based on the order set in the array within the given sites config when the activeCustomFieldsIds value is present.