### PR TITLE
Add simple progressive reg components and routes

### DIFF
--- a/packages/marko-web-identity-x/browser/form/consent.vue
+++ b/packages/marko-web-identity-x/browser/form/consent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="visible">
     <div v-if="emailConsentRequest" class="row mt-3">
       <div class="col-12">
         <receive-email
@@ -66,6 +66,21 @@ export default {
       type: String,
       default: null,
     },
+    hideWhenAnswered: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  /**
+   *
+   */
+  data() {
+    return {
+      currentUser: {
+        ...this.user,
+      },
+    };
   },
 
   /**
@@ -82,6 +97,20 @@ export default {
         const countryCodes = policy.countries.map((country) => country.id);
         return countryCodes.includes(countryCode);
       });
+    },
+    /**
+     *
+     */
+    visible() {
+      const { hideWhenAnswered } = this;
+      if (!hideWhenAnswered) return true;
+      if (!this.currentUser.receiveEmail) return true;
+      if (this.regionalPolicyFields.length) {
+        if (this.regionalPolicyFields.reduce(
+          (policy) => this.getRegionalPolicyAnswerValue(policy.id),
+        ).length) return true;
+      }
+      return false;
     },
   },
 

--- a/packages/marko-web-identity-x/browser/index.js
+++ b/packages/marko-web-identity-x/browser/index.js
@@ -9,6 +9,7 @@ const Download = () => import(/* webpackChunkName: "identity-x-download" */ './d
 const Logout = () => import(/* webpackChunkName: "identity-x-logout" */ './logout.vue');
 const Login = () => import(/* webpackChunkName: "identity-x-login" */ './login.vue');
 const Profile = () => import(/* webpackChunkName: "identity-x-profile" */ './profile.vue');
+const Progressive = () => import(/* webpackChunkName: "identity-x-progressive" */ './progressive.vue');
 const CommentStream = () => import(/* webpackChunkName: "identity-x-comment-stream" */ './comments/stream.vue');
 
 const $graphql = createGraphqlClient({ uri: '/__graphql' });
@@ -25,6 +26,7 @@ export default (Browser, {
   CustomLoginComponent,
   CustomLogoutComponent,
   CustomProfileComponent,
+  CustomProgressiveComponent,
 } = {}) => {
   const AccessComponent = CustomAccessComponent || Access;
   const AuthenticateComponent = CustomAuthenticateComponent || Authenticate;
@@ -35,6 +37,7 @@ export default (Browser, {
   const LoginComponent = CustomLoginComponent || Login;
   const LogoutComponent = CustomLogoutComponent || Logout;
   const ProfileComponent = CustomProfileComponent || Profile;
+  const ProgressiveComponent = CustomProgressiveComponent || Progressive;
 
   window.IdentityX = new IdentityX();
 
@@ -48,6 +51,7 @@ export default (Browser, {
   Browser.register('IdentityXLogin', LoginComponent, { provide: { EventBus } });
   Browser.register('IdentityXLogout', LogoutComponent, { provide: { EventBus } });
   Browser.register('IdentityXProfile', ProfileComponent, { provide: { EventBus } });
+  Browser.register('IdentityXProgressive', ProgressiveComponent, { provide: { EventBus } });
 
   // Ensure the client-side IdX context is refreshed when the authentication event occurs
   EventBus.$on('identity-x-authenticated', () => window.IdentityX.refreshContext());
@@ -66,6 +70,7 @@ export default (Browser, {
     'identity-x-login-mounted',
     'identity-x-logout-mounted',
     'identity-x-profile-mounted',
+    'identity-x-progressive-mounted',
     // Actions/submissions
     'identity-x-access-submitted',
     'identity-x-authenticated',
@@ -79,6 +84,7 @@ export default (Browser, {
     'identity-x-login-link-sent',
     'identity-x-logout',
     'identity-x-profile-updated',
+    'identity-x-progressive-updated',
     // Errors
     'identity-x-access-errored',
     'identity-x-authenticate-errored',
@@ -90,6 +96,7 @@ export default (Browser, {
     'identity-x-login-errored',
     'identity-x-logout-errored',
     'identity-x-profile-errored',
+    'identity-x-progressive-errored',
   ].forEach((event) => {
     EventBus.$on(event, (args) => {
       if (!window.IdentityX) return;

--- a/packages/marko-web-identity-x/browser/progressive.vue
+++ b/packages/marko-web-identity-x/browser/progressive.vue
@@ -5,25 +5,6 @@
     </p>
     <form v-if="!didSubmit" @submit.prevent="handleSubmit">
       <fieldset :disabled="isLoading">
-        <div v-if="enableChangeEmail" class="row">
-          <div class="col-12">
-            <label>Email address</label>
-            <div class="form-group">
-              <div class="input-group">
-                <input disabled :value="user.email" class="form-control">
-                <div class="input-group-append">
-                  <a
-                    :href="endpoints.changeEmail"
-                    class="btn btn-outline-secondary d-flex justify-content-center flex-column"
-                    title="Change your login email address"
-                  >
-                    Change email
-                  </a>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
         <div class="row">
           <div
             v-if="givenNameSettings.visible"

--- a/packages/marko-web-identity-x/browser/progressive.vue
+++ b/packages/marko-web-identity-x/browser/progressive.vue
@@ -151,20 +151,11 @@
     <div v-else>
       <div class="success-message">
         <div class="success-message__title">
-          Your profile has been saved.
+          Your profile has been update.
         </div>
-        <div v-if="returnTo" class="success-message__message">
+        <div class="success-message__message">
           <p>
-            You will be automatically redirected in {{ returnToDelay / 1000 }} seconds.
-          </p>
-          <p>
-            To continue now,
-            <a :href="returnTo">click here</a>.
-          </p>
-        </div>
-        <div v-else class="success-message__message">
-          <p>
-            To continue modifying your profile,
+            To finsih filling out your profile,
             <button class="" type="button" @click="handleReload()">
               click here
             </button>.

--- a/packages/marko-web-identity-x/browser/progressive.vue
+++ b/packages/marko-web-identity-x/browser/progressive.vue
@@ -128,7 +128,7 @@
           </div>
         </div>
 
-        <form-consent
+        <!-- <form-consent
           :user="user"
           :consent-policy="consentPolicy"
           :consent-policy-enabled="consentPolicyEnabled"
@@ -136,7 +136,7 @@
           :email-consent-request-enabled="emailConsentRequestEnabled"
           :regional-consent-policies="regionalConsentPolicies"
           :country-code="countryCode"
-        />
+        /> -->
 
         <div class="d-flex align-items-center">
           <button type="submit" class="btn btn-primary">
@@ -320,18 +320,6 @@ export default {
     booleanQuestionsLabel: {
       type: String,
       default: null,
-    },
-    returnTo: {
-      type: String,
-      default: null,
-    },
-    returnToDelay: {
-      type: Number,
-      default: 3000,
-    },
-    enableChangeEmail: {
-      type: Boolean,
-      default: false,
     },
   },
 
@@ -613,13 +601,6 @@ export default {
         if (this.reloadPageOnSubmit) {
           this.isReloadingPage = true;
           window.location.reload(true);
-        }
-
-        if (this.returnTo) {
-          this.isRedirectingPage = true;
-          setTimeout(() => {
-            window.location.href = this.returnTo;
-          }, this.returnToDelay);
         }
       } catch (e) {
         this.error = e;

--- a/packages/marko-web-identity-x/browser/progressive.vue
+++ b/packages/marko-web-identity-x/browser/progressive.vue
@@ -363,14 +363,14 @@ export default {
       const ids = this.progressiveFields.map(({ id }) => id);
       console.warn('currentProgressiceIds: ', ids);
       const unAnsweredIds = ids.filter((id) => {
-        if (this.user[id]) return false;
-        if (this.user.customBooleanFieldAnswers && this.user.customBooleanFieldAnswers
+        if (this.activeUser[id]) return false;
+        if (this.activeUser.customBooleanFieldAnswers && this.activeUser.customBooleanFieldAnswers
           .filter(({ id: answerId, hasAnswered }) => {
             console.warn('filter: ', id, answerId, hasAnswered);
             if (id === answerId && !hasAnswered) return true;
             return false;
           }).length) return true;
-        if (this.user.customSelectFieldAnswers && this.user.customSelectFieldAnswers
+        if (this.activeUser.customSelectFieldAnswers && this.activeUser.customSelectFieldAnswers
           .filter(({ id: answerId, hasAnswered }) => {
             if (id === answerId && !hasAnswered) return true;
             return false;

--- a/packages/marko-web-identity-x/browser/progressive.vue
+++ b/packages/marko-web-identity-x/browser/progressive.vue
@@ -256,7 +256,7 @@ export default {
     },
     callToAction: {
       type: String,
-      default: 'To complete your profile, please fill out the required fields.',
+      default: 'Please tell us a little more about yourself',
     },
     requiredServerFields: {
       type: Array,

--- a/packages/marko-web-identity-x/browser/progressive.vue
+++ b/packages/marko-web-identity-x/browser/progressive.vue
@@ -81,7 +81,6 @@
         </div>
 
         <address-block
-          v-if="showAddressBlock"
           :user="user"
           :street="streetSettings"
           :address-extra="addressExtraSettings"
@@ -361,12 +360,12 @@ export default {
      */
     currentProgressiveQuestions() {
       const ids = this.progressiveFields.map(({ id }) => id);
-      console.warn('currentProgressiceIds: ', ids);
+      const addressDependent = ['postalCode'];
       const unAnsweredIds = ids.filter((id) => {
         if (this.activeUser[id]) return false;
+        if (addressDependent.includes(id)) return this.showAddressBlock;
         if (this.activeUser.customBooleanFieldAnswers && this.activeUser.customBooleanFieldAnswers
           .filter(({ id: answerId, hasAnswered }) => {
-            console.warn('filter: ', id, answerId, hasAnswered);
             if (id === answerId && !hasAnswered) return true;
             return false;
           }).length) return true;
@@ -377,7 +376,6 @@ export default {
           }).length) return true;
         return true;
       });
-      // console.warn('hittingCurrentPro: ', ids, this.user);
       return [unAnsweredIds[0]];
     },
 

--- a/packages/marko-web-identity-x/browser/progressive.vue
+++ b/packages/marko-web-identity-x/browser/progressive.vue
@@ -413,7 +413,7 @@ export default {
           return true;
         }
         // only return non answered customBooleanFields
-        const { customBooleanFieldAnswers, customSelectFieldAnswers} = this.activeUser;
+        const { customBooleanFieldAnswers, customSelectFieldAnswers } = this.activeUser;
         const filteredBoolean = customBooleanFieldAnswers && customBooleanFieldAnswers
           .filter(({ id: answerId }) => id === answerId);
         if (filteredBoolean.length !== 0) {

--- a/packages/marko-web-identity-x/browser/progressive.vue
+++ b/packages/marko-web-identity-x/browser/progressive.vue
@@ -1,0 +1,661 @@
+<template>
+  <div v-if="hasActiveUser" id="progressive-form-wrapper">
+    <p v-if="!didSubmit">
+      {{ callToAction }}
+    </p>
+    <form v-if="!didSubmit" @submit.prevent="handleSubmit">
+      <fieldset :disabled="isLoading">
+        <div v-if="enableChangeEmail" class="row">
+          <div class="col-12">
+            <label>Email address</label>
+            <div class="form-group">
+              <div class="input-group">
+                <input disabled :value="user.email" class="form-control">
+                <div class="input-group-append">
+                  <a
+                    :href="endpoints.changeEmail"
+                    class="btn btn-outline-secondary d-flex justify-content-center flex-column"
+                    title="Change your login email address"
+                  >
+                    Change email
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div
+            v-if="givenNameSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': familyNameSettings.visible }"
+          >
+            <given-name
+              v-model="user.givenName"
+              :required="givenNameSettings.required"
+              :label="defaultFieldLabels.givenName"
+            />
+          </div>
+          <div
+            v-if="familyNameSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': givenNameSettings.visible }"
+          >
+            <family-name
+              v-model="user.familyName"
+              :required="familyNameSettings.required"
+              :label="defaultFieldLabels.familyName"
+            />
+          </div>
+        </div>
+
+        <div class="row">
+          <div
+            v-if="organizationSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': organizationTitleSettings.visible }"
+          >
+            <organization
+              v-model="user.organization"
+              :required="organizationSettings.required"
+              :label="defaultFieldLabels.organization"
+            />
+          </div>
+          <div
+            v-if="organizationTitleSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': organizationSettings.visible }"
+          >
+            <organization-title
+              v-model="user.organizationTitle"
+              :required="organizationTitleSettings.required"
+              :label="defaultFieldLabels.organizationTitle"
+            />
+          </div>
+        </div>
+
+        <div class="row">
+          <div
+            v-if="phoneNumberSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': countryCodeSettings.visible }"
+          >
+            <phone-number
+              v-model="user.phoneNumber"
+              :required="phoneNumberSettings.required"
+              :label="defaultFieldLabels.phoneNumber"
+            />
+          </div>
+          <div
+            v-if="countryCodeSettings.visible"
+            class="col-12"
+            :class="{ 'col-md-6': phoneNumberSettings.visible }"
+          >
+            <country
+              v-model="user.countryCode"
+              :required="countryCodeSettings.required"
+              :label="defaultFieldLabels.country"
+            />
+          </div>
+        </div>
+
+        <address-block
+          v-if="showAddressBlock"
+          :user="user"
+          :street="streetSettings"
+          :address-extra="addressExtraSettings"
+          :city="citySettings"
+          :region-code="regionCodeSettings"
+          :postal-code="postalCodeSettings"
+          :default-field-labels="defaultFieldLabels"
+        />
+
+        <div v-if="customSelectFieldAnswers.length" class="row">
+          <custom-select
+            v-for="fieldAnswer in customSelectFieldAnswers"
+            :id="fieldAnswer.field.id"
+            :key="fieldAnswer.id"
+            class="col-12"
+            :class="{ 'col-md-6': (customSelectFieldAnswers.length > 1) }"
+            :label="fieldAnswer.field.label"
+            :required="customSelectIsRequired(fieldAnswer)"
+            :multiple="fieldAnswer.field.multiple"
+            :selected="fieldAnswer.answers"
+            :options="fieldAnswer.field.options"
+            @change="onCustomSelectChange(fieldAnswer.answers, $event)"
+          />
+        </div>
+
+        <div v-if="customBooleanFieldAnswers.length" class="row mt-3">
+          <div
+            v-if="booleanQuestionsLabel"
+            class="col-12 boolean-questions-label"
+            v-html="booleanQuestionsLabel"
+          />
+          <div
+            v-for="fieldAnswer in customBooleanFieldAnswers"
+            :key="fieldAnswer.id"
+            class="col-12"
+          >
+            <custom-boolean
+              :id="fieldAnswer.id"
+              :message="fieldAnswer.field.label"
+              :required="fieldAnswer.field.required"
+              :value="fieldAnswer.answer"
+              @input="onCustomBooleanChange(fieldAnswer.id)"
+            />
+          </div>
+        </div>
+
+        <form-consent
+          :user="user"
+          :consent-policy="consentPolicy"
+          :consent-policy-enabled="consentPolicyEnabled"
+          :email-consent-request="emailConsentRequest"
+          :email-consent-request-enabled="emailConsentRequestEnabled"
+          :regional-consent-policies="regionalConsentPolicies"
+          :country-code="countryCode"
+        />
+
+        <div class="d-flex align-items-center">
+          <button type="submit" class="btn btn-primary">
+            {{ buttonLabel }}
+          </button>
+        </div>
+      </fieldset>
+      <p v-if="error" class="mt-3 text-danger">
+        An error occurred: {{ error }}
+      </p>
+    </form>
+    <div v-else>
+      <div class="success-message">
+        <div class="success-message__title">
+          Your profile has been saved.
+        </div>
+        <div v-if="returnTo" class="success-message__message">
+          <p>
+            You will be automatically redirected in {{ returnToDelay / 1000 }} seconds.
+          </p>
+          <p>
+            To continue now,
+            <a :href="returnTo">click here</a>.
+          </p>
+        </div>
+        <div v-else class="success-message__message">
+          <p>
+            To continue modifying your profile,
+            <button class="" type="button" @click="handleReload()">
+              click here
+            </button>.
+          </p>
+          <p>
+            To return to the home page, <a href="/">click here</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div v-else>
+    <p>You must be logged in to modify your user profile.</p>
+    <login
+      :additional-event-data="additionalEventData"
+      :source="loginSource"
+      :endpoints="endpoints"
+      :app-context-id="appContextId"
+      :consent-policy="consentPolicy"
+      :consent-policy-enabled="consentPolicyEnabled"
+      :email-consent-request="emailConsentRequest"
+      :email-consent-request-enabled="emailConsentRequestEnabled"
+      :regional-consent-policies="regionalConsentPolicies"
+      :required-create-fields="requiredCreateFields"
+      :default-field-labels="defaultFieldLabels"
+    />
+  </div>
+</template>
+
+<script>
+import post from './utils/post';
+import cookiesEnabled from './utils/cookies-enabled';
+import regionCountryCodes from './utils/region-country-codes';
+
+import AddressBlock from './form/address-block.vue';
+import FormConsent from './form/consent.vue';
+import CustomBoolean from './form/fields/custom-boolean.vue';
+import CustomSelect from './form/fields/custom-select.vue';
+import GivenName from './form/fields/given-name.vue';
+import FamilyName from './form/fields/family-name.vue';
+import Organization from './form/fields/organization.vue';
+import OrganizationTitle from './form/fields/organization-title.vue';
+import Country from './form/fields/country.vue';
+import PhoneNumber from './form/fields/phone-number.vue';
+import Login from './login.vue';
+
+import FeatureError from './errors/feature';
+import FormError from './errors/form';
+import AutoSignupEventEmitter from './mixins/global-auto-signup-event-emitter';
+import EventEmitter from './mixins/global-event-emitter';
+
+const { isArray } = Array;
+
+export default {
+  components: {
+    AddressBlock,
+    CustomBoolean,
+    CustomSelect,
+    GivenName,
+    FamilyName,
+    FormConsent,
+    Organization,
+    OrganizationTitle,
+    Country,
+    PhoneNumber,
+    Login,
+  },
+
+  /**
+   *
+   */
+  mixins: [EventEmitter, AutoSignupEventEmitter],
+
+  /**
+   *
+   */
+  props: {
+    loginSource: {
+      type: String,
+      default: 'default',
+    },
+    endpoints: {
+      type: Object,
+      required: true,
+    },
+    activeUser: {
+      type: Object,
+      default: () => ({}),
+    },
+    callToAction: {
+      type: String,
+      default: 'To complete your profile, please fill out the required fields.',
+    },
+    requiredServerFields: {
+      type: Array,
+      default: () => [],
+    },
+    requiredClientFields: {
+      type: Array,
+      default: () => [],
+    },
+    activeCustomFieldIds: {
+      type: Array,
+      default: () => [],
+    },
+    progressiveFields: {
+      type: Array,
+      default: () => [],
+    },
+    requiredCreateFields: {
+      type: Array,
+      default: () => [],
+    },
+    defaultFieldLabels: {
+      type: Object,
+      default: () => {},
+    },
+    hiddenFields: {
+      type: Array,
+      default: () => [],
+    },
+    reloadPageOnSubmit: {
+      type: Boolean,
+      default: false,
+    },
+    consentPolicy: {
+      type: String,
+      default: null,
+    },
+    consentPolicyEnabled: {
+      type: Boolean,
+      default: false,
+    },
+    emailConsentRequest: {
+      type: String,
+      default: null,
+    },
+    emailConsentRequestEnabled: {
+      type: Boolean,
+      default: false,
+    },
+    appContextId: {
+      type: String,
+      default: null,
+    },
+    buttonLabel: {
+      type: String,
+      default: 'Submit',
+    },
+    regionalConsentPolicies: {
+      type: Array,
+      default: () => [],
+    },
+    requiredLoginFields: {
+      type: Array,
+      default: () => [],
+    },
+    defaultCountryCode: {
+      type: String,
+      default: null,
+    },
+    booleanQuestionsLabel: {
+      type: String,
+      default: null,
+    },
+    returnTo: {
+      type: String,
+      default: null,
+    },
+    returnToDelay: {
+      type: Number,
+      default: 3000,
+    },
+    enableChangeEmail: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  /**
+   *
+   */
+  data() {
+    return {
+      error: null,
+      isLoading: false,
+      isReloadingPage: false,
+      isRedirectingPage: false,
+      didSubmit: false,
+      user: {
+        ...this.activeUser,
+        ...(
+          !this.hiddenFields.includes('countryCode')
+          && this.defaultCountryCode
+          && !this.activeUser.countryCode
+          && { countryCode: this.defaultCountryCode }
+        ),
+      },
+    };
+  },
+
+  /**
+   *
+   */
+  computed: {
+    /**
+     *
+     */
+    hasActiveUser() {
+      return this.user && this.user.email;
+    },
+
+    /**
+     *
+     */
+    currentProgressiveQuestions() {
+      const ids = this.progressiveFields.map(({ id }) => id);
+      console.warn('currentProgressiceIds: ', ids);
+      const unAnsweredIds = ids.filter((id) => {
+        if (this.user[id]) return false;
+        if (this.user.customBooleanFieldAnswers && this.user.customBooleanFieldAnswers
+          .filter(({ id: answerId, hasAnswered }) => {
+            console.warn('filter: ', id, answerId, hasAnswered);
+            if (id === answerId && !hasAnswered) return true;
+            return false;
+          }).length) return true;
+        if (this.user.customSelectFieldAnswers && this.user.customSelectFieldAnswers
+          .filter(({ id: answerId, hasAnswered }) => {
+            if (id === answerId && !hasAnswered) return true;
+            return false;
+          }).length) return true;
+        return true;
+      });
+      // console.warn('hittingCurrentPro: ', ids, this.user);
+      return [unAnsweredIds[0]];
+    },
+
+    /**
+     *
+     */
+    requiredFields() {
+      return [...this.currentProgressiveQuestions];
+    },
+
+    /**
+     *
+     */
+    countryCode() {
+      const { user } = this;
+      if (!user) return null;
+      return user.countryCode;
+    },
+
+    /**
+     *
+     */
+    customBooleanFieldAnswers() {
+      const { requiredFields: ids } = this;
+      const { customBooleanFieldAnswers } = this.user;
+      const answers = isArray(customBooleanFieldAnswers) ? customBooleanFieldAnswers : [];
+      return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true)
+        .sort(this.sortByActiveCustomFieldId);
+    },
+
+    /**
+     *
+     */
+    customSelectFieldAnswers() {
+      const { requiredFields: ids } = this;
+      console.log('customblah: ', ids)
+      const { customSelectFieldAnswers } = this.user;
+      const answers = isArray(customSelectFieldAnswers) ? customSelectFieldAnswers : [];
+      return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true)
+        .sort(this.sortByActiveCustomFieldIds);
+    },
+
+    showAddressBlock() {
+      // Don't show at all until country is selected.
+      if (!this.countryCode) return false;
+
+      // Only show if a subfield is visible
+      if (this.citySettings.visible) return true;
+      if (this.streetSettings.visible) return true;
+      if (this.regionCodeSettings.visible) return true;
+      if (this.postalCodeSettings.visible) return true;
+      return false;
+    },
+
+    /**
+     * Field settings
+     */
+    givenNameSettings() {
+      return {
+        required: this.requiredFields.includes('givenName'),
+        visible: !this.hiddenFields.includes('givenName') && this.currentProgressiveQuestions.includes('givenName'),
+      };
+    },
+    familyNameSettings() {
+      return {
+        required: this.requiredFields.includes('familyName'),
+        visible: !this.hiddenFields.includes('familyName') && this.currentProgressiveQuestions.includes('familyName'),
+      };
+    },
+    organizationSettings() {
+      return {
+        required: this.requiredFields.includes('organization'),
+        visible: !this.hiddenFields.includes('organization') && this.currentProgressiveQuestions.includes('organization'),
+      };
+    },
+    organizationTitleSettings() {
+      return {
+        required: this.requiredFields.includes('organizationTitle'),
+        visible: !this.hiddenFields.includes('organizationTitle') && this.currentProgressiveQuestions.includes('organizationTitle'),
+      };
+    },
+    countryCodeSettings() {
+      return {
+        required: this.requiredFields.includes('countryCode'),
+        visible: !this.hiddenFields.includes('countryCode') && this.currentProgressiveQuestions.includes('countryCode'),
+      };
+    },
+    streetSettings() {
+      return {
+        required: this.requiredFields.includes('street'),
+        visible: !this.hiddenFields.includes('street') && this.currentProgressiveQuestions.includes('street'),
+      };
+    },
+    addressExtraSettings() {
+      return {
+        required: this.requiredFields.includes('addressExtra'),
+        visible: !this.hiddenFields.includes('addressExtra') && this.currentProgressiveQuestions.includes('addressExtra'),
+      };
+    },
+    phoneNumberSettings() {
+      return {
+        required: this.requiredFields.includes('phoneNumber'),
+        visible: !this.hiddenFields.includes('phoneNumber') && this.currentProgressiveQuestions.includes('phoneNumber'),
+      };
+    },
+    citySettings() {
+      return {
+        required: this.requiredFields.includes('city'),
+        visible: !this.hiddenFields.includes('city') && this.currentProgressiveQuestions.includes('city'),
+      };
+    },
+    regionCodeSettings() {
+      const canRequire = regionCountryCodes.includes(this.countryCode);
+      return {
+        required: canRequire && this.requiredFields.includes('regionCode'),
+        visible: canRequire && !this.hiddenFields.includes('regionCode') && this.currentProgressiveQuestions.includes('regionCode'),
+      };
+    },
+    postalCodeSettings() {
+      const canRequire = regionCountryCodes.includes(this.countryCode);
+      return {
+        required: canRequire && this.requiredFields.includes('postalCode'),
+        visible: canRequire && !this.hiddenFields.includes('postalCode') && this.currentProgressiveQuestions.includes('postalCode'),
+      };
+    },
+  },
+
+  /**
+   *
+   */
+  watch: {
+    /**
+     * Clear region and postal codes on country code change.
+     */
+    countryCode() {
+      this.user.regionCode = null;
+      this.user.postalCode = null;
+    },
+  },
+
+  /**
+   *
+   */
+  mounted() {
+    if (cookiesEnabled()) {
+      this.emit('progressive-mounted');
+    } else {
+      const error = new FeatureError('Your browser does not support cookies. Please enable cookies to use this feature.');
+      this.error = error.message;
+      this.emit('progressive-errored', { message: error.message });
+    }
+  },
+
+  /**
+   *
+   */
+  methods: {
+    /**
+     *
+     */
+    onCustomBooleanChange(id) {
+      const objIndex = this.customBooleanFieldAnswers.findIndex(((obj) => obj.id === id));
+      const answer = !this.customBooleanFieldAnswers[objIndex].answer;
+      this.customBooleanFieldAnswers[objIndex].answer = answer;
+
+      this.user.customBooleanFieldAnswers = this.customBooleanFieldAnswers;
+    },
+
+    onCustomSelectChange(answers, $event) {
+      const ids = Array.isArray($event) ? [...$event] : [...($event ? [$event] : [])];
+      answers.splice(0);
+      if (ids.length) answers.push(...ids.map((id) => ({ id })));
+    },
+
+    customSelectIsRequired(fieldAnswer) {
+      return this.requiredFields.includes(fieldAnswer.field.id) || fieldAnswer.field.required;
+    },
+
+    sortByActiveCustomFieldIds(a, b) {
+      const { activeCustomFieldIds: ids } = this;
+      const sortingArr = ids.length > 0 ? ids : [];
+      return sortingArr.indexOf(a.field.id) - sortingArr.indexOf(b.field.id);
+    },
+
+    async handleReload() {
+      this.isReloadingPage = true;
+      window.location.reload(true);
+    },
+
+    /**
+     *
+     */
+    async handleSubmit() {
+      this.error = null;
+      this.isLoading = true;
+      this.didSubmit = false;
+      try {
+        const res = await post('/progressive', {
+          ...this.user,
+          additionalEventData: {
+            ...this.additionalEventData,
+            actionSource: this.loginSource,
+          },
+        });
+        const data = await res.json();
+        if (!res.ok) throw new FormError(data.message, res.status);
+
+        this.user = data.user;
+        this.didSubmit = true;
+        // force scroll to top of page when form and success message toggle
+        window.scrollTo(0, 0);
+
+        this.emitAutoSignup(data);
+        this.emit('progressive-updated', {
+          additionalEventData: {
+            ...(this.additionalEventData || {}),
+            ...(data.additionalEventData || {}),
+          },
+        });
+
+        if (this.reloadPageOnSubmit) {
+          this.isReloadingPage = true;
+          window.location.reload(true);
+        }
+
+        if (this.returnTo) {
+          this.isRedirectingPage = true;
+          setTimeout(() => {
+            window.location.href = this.returnTo;
+          }, this.returnToDelay);
+        }
+      } catch (e) {
+        this.error = e;
+        this.emit('progressive-errored', { message: e.message });
+      } finally {
+        this.isLoading = false;
+      }
+    },
+  },
+};
+</script>

--- a/packages/marko-web-identity-x/browser/progressive.vue
+++ b/packages/marko-web-identity-x/browser/progressive.vue
@@ -407,26 +407,24 @@ export default {
       const unAnsweredIds = ids.filter((id) => {
         // filter already preansered userFields
         if (this.activeUser[id]) return false;
-
         // Region & Postal are dependent on country being United Stages, Canada or Mexico
         if (addressDependent.includes(id)) {
           if (!this.countryCode || !regionCountryCodes.includes(this.countryCode)) return false;
           return true;
         }
-
         // only return non answered customBooleanFields
-        if (this.activeUser.customBooleanFieldAnswers && this.activeUser.customBooleanFieldAnswers
-          .filter(({ id: answerId, hasAnswered }) => {
-            if (id === answerId && !hasAnswered) return true;
-            return false;
-          }).length) return true;
-
+        const { customBooleanFieldAnswers, customSelectFieldAnswers} = this.activeUser;
+        const filteredBoolean = customBooleanFieldAnswers && customBooleanFieldAnswers
+          .filter(({ id: answerId }) => id === answerId);
+        if (filteredBoolean.length !== 0) {
+          return filteredBoolean.some(({ hasAnswered }) => !hasAnswered);
+        }
+        const filteredSelect = customSelectFieldAnswers && customSelectFieldAnswers
+          .filter(({ id: answerId }) => id === answerId);
+        if (filteredSelect.length !== 0) {
+          return filteredSelect.some(({ hasAnswered }) => !hasAnswered);
+        }
         // only return non answered customSelectFields
-        if (this.activeUser.customSelectFieldAnswers && this.activeUser.customSelectFieldAnswers
-          .filter(({ id: answerId, hasAnswered }) => {
-            if (id === answerId && !hasAnswered) return true;
-            return false;
-          }).length) return true;
         return true;
       });
       // for now ensure only one is returned.

--- a/packages/marko-web-identity-x/components/access.marko
+++ b/packages/marko-web-identity-x/components/access.marko
@@ -11,6 +11,7 @@ $ const accessObj = {
   requiresAccessLevel: false,
   requiredAccessLevels: [],
   requiresUserInput: false,
+  requiresPUI: false,
   messages: {},
 };
 

--- a/packages/marko-web-identity-x/components/form-progressive.marko
+++ b/packages/marko-web-identity-x/components/form-progressive.marko
@@ -1,0 +1,41 @@
+import { get } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { req } = out.global;
+$ const { identityX, query } = req;
+$ const additionalEventData = defaultValue(input.additionalEventData, {});
+
+$ console.log(identityX.config.getProgresiveQuestions())
+
+<if(Boolean(identityX))>
+  <marko-web-identity-x-context|{ user, isEnabled, application }|>
+    $ const props = {
+      additionalEventData: additionalEventData,
+      loginSource: input.loginSource,
+      activeUser: user,
+      requiredServerFields: identityX.config.getRequiredServerFields(),
+      requiredClientFields: identityX.config.getRequiredClientFields(),
+      requiredCreateFields: identityX.config.getRequiredCreateFields(),
+      activeCustomFieldIds: identityX.config.getActiveCustomFieldIds(),
+      progressiveFields: identityX.config.getProgresiveQuestions(),
+      defaultFieldLabels: identityX.config.get("defaultFieldLabels"),
+      hiddenFields: identityX.config.getHiddenFields(),
+      defaultCountryCode: identityX.config.get('defaultCountryCode'),
+      booleanQuestionsLabel: identityX.config.get('booleanQuestionsLabel'),
+      callToAction: input.callToAction,
+      reloadPageOnSubmit: input.reloadPageOnSubmit,
+      buttonLabel: input.buttonLabel,
+      endpoints: identityX.config.getEndpoints(),
+      consentPolicy: get(application, "organization.consentPolicy"),
+      emailConsentRequest: get(application, "organization.emailConsentRequest"),
+      appContextId: identityX.config.get("appContextId"),
+      regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
+      returnTo: query.returnTo,
+      returnToDelay: input.returnToDelay,
+      enableChangeEmail: identityX.config.get("enableChangeEmail"),
+    };
+    <if(isEnabled)>
+      <marko-web-browser-component name="IdentityXProgressive" props=props />
+    </if>
+  </marko-web-identity-x-context>
+</if>

--- a/packages/marko-web-identity-x/components/marko.json
+++ b/packages/marko-web-identity-x/components/marko.json
@@ -66,6 +66,18 @@
     "@return-to-delay": "number",
     "@button-label": "string"
   },
+  "<marko-web-identity-x-form-progressive>": {
+    "template": "./form-progressive.marko",
+    "@additional-event-data": "object",
+    "@login-source": {
+      "type": "string",
+      "default-value": "default"
+    },
+    "@call-to-action": "string",
+    "@reload-page-on-submit": "boolean",
+    "@return-to-delay": "number",
+    "@button-label": "string"
+  },
   "<marko-web-identity-x-comment-stream>": {
     "template": "./comment-stream.marko",
     "@additional-event-data": "object",

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -25,6 +25,7 @@ class IdentityXConfiguration {
     requiredClientFields = [],
     requiredCreateFields = [],
     activeCustomFieldIds = [],
+    progressiveDelay = 24, // hours
     progressiveQuestions = [],
     defaultFieldLabels = {},
     hiddenFields = ['city', 'street', 'addressExtra', 'phoneNumber', 'mobileNumber'],
@@ -43,6 +44,7 @@ class IdentityXConfiguration {
       requiredClientFields,
       requiredCreateFields,
       activeCustomFieldIds,
+      progressiveDelay,
       progressiveQuestions,
       defaultFieldLabels,
       hiddenFields,
@@ -140,6 +142,10 @@ class IdentityXConfiguration {
 
   getActiveCustomFieldIds() {
     return this.getAsArray('activeCustomFieldIds');
+  }
+
+  getProgresiveDelay() {
+    return this.get('progressiveDelay');
   }
 
   getProgresiveQuestions() {

--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -25,6 +25,7 @@ class IdentityXConfiguration {
     requiredClientFields = [],
     requiredCreateFields = [],
     activeCustomFieldIds = [],
+    progressiveQuestions = [],
     defaultFieldLabels = {},
     hiddenFields = ['city', 'street', 'addressExtra', 'phoneNumber', 'mobileNumber'],
     defaultCountryCode,
@@ -42,6 +43,7 @@ class IdentityXConfiguration {
       requiredClientFields,
       requiredCreateFields,
       activeCustomFieldIds,
+      progressiveQuestions,
       defaultFieldLabels,
       hiddenFields,
       defaultCountryCode,
@@ -64,6 +66,7 @@ class IdentityXConfiguration {
       'logout',
       'register',
       'profile',
+      'progressive',
     ];
     this.hooks = validHooks.reduce((o, name) => ({ ...o, [name]: [] }), {});
   }
@@ -137,6 +140,10 @@ class IdentityXConfiguration {
 
   getActiveCustomFieldIds() {
     return this.getAsArray('activeCustomFieldIds');
+  }
+
+  getProgresiveQuestions() {
+    return this.getAsArray('progressiveQuestions');
   }
 
   get(path, def) {

--- a/packages/marko-web-identity-x/routes/index.js
+++ b/packages/marko-web-identity-x/routes/index.js
@@ -15,6 +15,7 @@ const login = require('./login');
 const loginFields = require('./login-fields');
 const logout = require('./logout');
 const profile = require('./profile');
+const progressive = require('./progressive');
 const regions = require('./regions');
 
 const router = Router();
@@ -35,6 +36,7 @@ router.post('/login-fields', loginFields);
 router.post('/login', login);
 router.post('/logout', logout);
 router.post('/profile', profile);
+router.post('/progressive', progressive);
 router.use(jsonErrorHandler());
 
 module.exports = router;

--- a/packages/marko-web-identity-x/routes/progressive.js
+++ b/packages/marko-web-identity-x/routes/progressive.js
@@ -122,6 +122,13 @@ module.exports = asyncRoute(async (req, res) => {
 
   const { data } = await identityX.client.mutate({ mutation, variables: { input } });
   const { updateOwnAppUser: user } = data;
+
+  const now = new Date().getTime();
+  await identityX.setAppUserCustomAttributes({
+    userId: user.id,
+    attributes: { profileLastUpdated: now },
+  });
+
   await callHooksFor(identityX, 'onUserProfileUpdate', {
     additionalEventData,
     ...(additionalEventData || {}),

--- a/packages/marko-web-identity-x/routes/progressive.js
+++ b/packages/marko-web-identity-x/routes/progressive.js
@@ -1,0 +1,132 @@
+const gql = require('graphql-tag');
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const { getAsArray } = require('@parameter1/base-cms-object-path');
+const userFragment = require('../api/fragments/active-user');
+const callHooksFor = require('../utils/call-hooks-for');
+
+const mutation = gql`
+  mutation UpdateUserProfile($input: UpdateOwnAppUserMutationInput!) {
+    updateOwnAppUser(input: $input) {
+      ...ActiveUserFragment
+    }
+  }
+
+  ${userFragment}
+`;
+
+const consentAnswers = gql`
+  mutation SetAppUserRegionalConsent($input: SetAppUserRegionalConsentMutationInput!) {
+    setAppUserRegionalConsent(input: $input) {
+      id
+    }
+  }
+`;
+
+const customBooleanFieldsMutation = gql`
+  mutation SetAppUserCustomBooleanFields($input: UpdateOwnAppUserCustomBooleanAnswersMutationInput!) {
+    updateOwnAppUserCustomBooleanAnswers(input: $input) {
+      id
+    }
+  }
+`;
+
+const customSelectFieldsMutation = gql`
+  mutation SetAppUserCustomSelectFields($input: UpdateOwnAppUserCustomSelectAnswersMutationInput!) {
+    updateOwnAppUserCustomSelectAnswers(input: $input) {
+      id
+    }
+  }
+`;
+
+module.exports = asyncRoute(async (req, res) => {
+  const { identityX, body } = req;
+  const {
+    givenName,
+    familyName,
+    organization,
+    organizationTitle,
+    countryCode,
+    regionCode,
+    postalCode,
+    city,
+    street,
+    addressExtra,
+    phoneNumber,
+    receiveEmail,
+    regionalConsentAnswers,
+    customBooleanFieldAnswers,
+    customSelectFieldAnswers,
+    additionalEventData = {},
+  } = body;
+  const input = {
+    givenName,
+    familyName,
+    organization,
+    organizationTitle,
+    countryCode,
+    regionCode,
+    postalCode,
+    city,
+    street,
+    addressExtra,
+    phoneNumber,
+    receiveEmail,
+  };
+
+  const activeCustomFieldIds = getAsArray(identityX, 'config.options.activeCustomFieldIds');
+
+  const answers = regionalConsentAnswers
+    .map((answer) => ({ policyId: answer.id, given: answer.given }));
+
+  if (answers.length) {
+    await identityX.client.mutate({ mutation: consentAnswers, variables: { input: { answers } } });
+  }
+
+  if (customBooleanFieldAnswers.length) {
+    // only update custom questions when there some :)
+    const customBooleanFieldsInput = customBooleanFieldAnswers.map((fieldAnswer) => ({
+      fieldId: fieldAnswer.field.id,
+      // can either be true, false or null. convert null to false.
+      // the form submit is effectively answers the question.
+      value: Boolean(fieldAnswer.answer),
+    })).filter(
+      activeCustomFieldIds.length > 0
+        ? ({ fieldId }) => activeCustomFieldIds.includes(fieldId)
+        : () => true,
+    );
+    await identityX.client.mutate({
+      mutation: customBooleanFieldsMutation,
+      variables: { input: { answers: customBooleanFieldsInput } },
+    });
+  }
+
+  if (customSelectFieldAnswers.length) {
+    // only update custom questions when there some :)
+    const customSelectFieldsInput = customSelectFieldAnswers.map((fieldAnswer) => ({
+      fieldId: fieldAnswer.field.id,
+      optionIds: fieldAnswer.answers.map(({ id }) => id),
+      writeInValues: fieldAnswer.answers.reduce((arr, { id, writeInValue }) => ([
+        ...arr,
+        ...(writeInValue ? [{ optionId: id, value: writeInValue }] : []),
+      ]), []),
+    })).filter(
+      activeCustomFieldIds.length > 0
+        ? ({ fieldId }) => activeCustomFieldIds.includes(fieldId)
+        : () => true,
+    );
+    await identityX.client.mutate({
+      mutation: customSelectFieldsMutation,
+      variables: { input: { answers: customSelectFieldsInput } },
+    });
+  }
+
+  const { data } = await identityX.client.mutate({ mutation, variables: { input } });
+  const { updateOwnAppUser: user } = data;
+  await callHooksFor(identityX, 'onUserProfileUpdate', {
+    additionalEventData,
+    ...(additionalEventData || {}),
+    req,
+    user,
+  });
+  res.json({ ok: true, user, additionalEventData });
+});

--- a/packages/marko-web-theme-monorail/components/identity-x/content-page-gate.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/content-page-gate.marko
@@ -95,6 +95,7 @@ $ const additionalEventData = {
     <marko-web-element name="form-wrapper" block-name=blockName>
       <marko-web-identity-x-form-progressive
         call-to-action=' '
+        reload-page-on-submit=true
         additional-event-data=additionalEventData
         login-source="progressive"
       />

--- a/packages/marko-web-theme-monorail/components/identity-x/content-page-gate.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/content-page-gate.marko
@@ -10,6 +10,7 @@ $ const {
   hasRequiredAccessLevel,
   requiresAccessLevel,
   requiresUserInput,
+  requiresPUI,
   profileCallToAction,
   profileButtonLabel,
   buttonLabels,
@@ -20,6 +21,7 @@ $ const messages = getAsObject(input, "messages");
 $ const title = defaultValue(input.title, "Log in to view the full article");
 $ const profileConfirmation = defaultValue(input.profileConfirmation, "Email Confirmed!")
 $ const userInputTitle = defaultValue(input.userInputTitle, "Complete your profile to view the full article");
+$ const puiTitle = defaultValue(input.userInputTitle, "Tell us a little more to view the full article");
 $ const contentGateType = defaultValue(input.contentGateType, "default");
 $ const additionalEventData = {
   promoCode: site.get("contentMetering.promoCode", undefined),
@@ -28,7 +30,6 @@ $ const additionalEventData = {
   ...(input.loginEventName === "content_meter_login" && { contentGateType: "metered" }),
   ...(input.profileEventName === "content_meter_profile" && { contentGateType: "metered" }),
 };
-
 <marko-web-block name=blockName>
   <if(!canAccess)>
     <marko-web-element tag="h5" name="title" block-name=blockName>
@@ -79,6 +80,23 @@ $ const additionalEventData = {
         reload-page-on-submit=true
         additional-event-data=additionalEventData
         login-source="contentGate"
+      />
+    </marko-web-element>
+  </else-if>
+  <else-if(isLoggedIn && requiresPUI)>
+    <if(profileConfirmation)>
+      <marko-web-element name="confirmation" block-name=blockName>
+        ${profileConfirmation}
+      </marko-web-element>
+    </if>
+    <marko-web-element tag="h5" name="title" block-name=blockName>
+      ${puiTitle}
+    </marko-web-element>
+    <marko-web-element name="form-wrapper" block-name=blockName>
+      <marko-web-identity-x-form-progressive
+        call-to-action=' '
+        additional-event-data=additionalEventData
+        login-source="progressive"
       />
     </marko-web-element>
   </else-if>

--- a/packages/marko-web-theme-monorail/components/identity-x/marko.json
+++ b/packages/marko-web-theme-monorail/components/identity-x/marko.json
@@ -9,6 +9,7 @@
     "@has-required-access-level": "boolean",
     "@requires-access-level": "boolean",
     "@requires-user-input": "boolean",
+    "@requiresPUI": "boolean",
     "@messages": "object",
     "@title": "string",
     "@user-input-title": "string",

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -38,28 +38,32 @@ module.exports = new IdentityXConfiguration({
     phoneNumber: 'Mobile Phone',
     organization: 'Company Name',
   },
-  progressiveDelay: 0.25, // hours
+  progressiveDelay: 0.1, // hours
   progressiveQuestions: [
-    {
-      id: 'postalCode',
-    },
-    {
-      id: 'street',
-    },
-    {
-      id: 'countryCode',
-    },
     {
       id: 'givenName',
     },
-    {
-      id: 'familyName',
-    },
+    // {
+    //   id: 'familyName',
+    // },
+    // {
+    //   id: 'postalCode',
+    // },
+    // {
+    //   id: 'street',
+    // },
+    // {
+    //   id: 'countryCode',
+    // },
+
     {
       id: '618a8a62934f8400ad4beb8f',
     },
     {
       id: '626fe91c79d99b27544a4c9f',
+    },
+    {
+      id: '628e9333f8dbf1d5cdda43d2',
     },
 
   ],

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -38,6 +38,7 @@ module.exports = new IdentityXConfiguration({
     phoneNumber: 'Mobile Phone',
     organization: 'Company Name',
   },
+  progressiveDelay: 0.25, // hours
   progressiveQuestions: [
     {
       id: 'postalCode',

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -4,8 +4,6 @@ const formDefault = require('./identity-x/default');
 
 const { log } = console;
 
-log('env: ', process.env)
-
 module.exports = new IdentityXConfiguration({
   appId: process.env.IDENTITYX_APP_ID,
   ...(process.env.IDENTITYX_CONTEXT === 'parameter1.io' ? {

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -38,6 +38,21 @@ module.exports = new IdentityXConfiguration({
     phoneNumber: 'Mobile Phone',
     organization: 'Company Name',
   },
+  progressiveQuestions: [
+    {
+      id: 'givenName',
+    },
+    {
+      id: 'familyName',
+    },
+    {
+      id: '618a8a62934f8400ad4beb8f',
+    },
+    {
+      id: '626fe91c79d99b27544a4c9f',
+    },
+
+  ],
   hiddenFields: [],
   onHookError: (e) => {
     log('IDENTITY-X HOOK ERROR!', e);

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -4,6 +4,8 @@ const formDefault = require('./identity-x/default');
 
 const { log } = console;
 
+log('env: ', process.env)
+
 module.exports = new IdentityXConfiguration({
   appId: process.env.IDENTITYX_APP_ID,
   ...(process.env.IDENTITYX_CONTEXT === 'parameter1.io' ? {
@@ -16,11 +18,10 @@ module.exports = new IdentityXConfiguration({
     ],
   } : {
     // Parameter1.dev
-    appContextId: '64483b96361977163db5e286',
+    appContextId: '5d1b86070ce467bff670a052',
     activeCustomFieldIds: [
-      '618ab74dcd3e2f0147386c42', // Favorite games
-      '626fe91c79d99b27544a4c9f', // Pina coladas
-      '628e98dc2da307ff2ef6a8b0', // Rain
+      '628e9333f8dbf1d5cdda43d2', //
+      '6272f0046f7301b6afa14956', //
     ],
   }),
   // custom form field definitions
@@ -57,13 +58,10 @@ module.exports = new IdentityXConfiguration({
     // },
 
     {
-      id: '618a8a62934f8400ad4beb8f',
-    },
-    {
-      id: '626fe91c79d99b27544a4c9f',
-    },
-    {
       id: '628e9333f8dbf1d5cdda43d2',
+    },
+    {
+      id: '6272f0046f7301b6afa14956',
     },
 
   ],

--- a/services/example-website/config/identity-x.js
+++ b/services/example-website/config/identity-x.js
@@ -40,6 +40,15 @@ module.exports = new IdentityXConfiguration({
   },
   progressiveQuestions: [
     {
+      id: 'postalCode',
+    },
+    {
+      id: 'street',
+    },
+    {
+      id: 'countryCode',
+    },
+    {
       id: 'givenName',
     },
     {

--- a/services/example-website/server/templates/content.marko
+++ b/services/example-website/server/templates/content.marko
@@ -1,5 +1,9 @@
+import { getAsArray, get } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import getContentPreview from "@parameter1/base-cms-marko-web-theme-monorail/utils/get-content-preview";
+
 $ const { id, type, pageNode } = data;
-$ const { recaptcha } = out.global;
+$ const { recaptcha, identityX } = out.global;
 
 <marko-web-content-page-layout id=id type=type>
   <@page>
@@ -22,17 +26,57 @@ $ const { recaptcha } = out.global;
       <div class="row mt-3">
         <div class="col-md-8">
           <div class="content-page-body">
-            <theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
             <marko-web-p1-events-track-content-scroll-depth
               content=content
               selector=".document-container .page .row .content-page-body"
             />
-              <content-body
-                content=content
-                block-name=blockName
-                display-read-next=false
-                display-comments=true
-              />
+            <theme-page-contents|{ blockName }| attrs={ "data-gallery-id": id }>
+              $ const requiresRegistration = get(content, "userRegistration.isCurrentlyRequired");
+              $ const progressiveRegEnabled = identityX ?  identityX.config.getProgresiveQuestions().length !== 0 : false;
+              $ const checkReg = requiresRegistration || progressiveRegEnabled;
+              <marko-web-identity-x-access|context| enabled=checkReg>
+                <!-- If ProgressiveReg is enabled & required: Fire it first & ignore required user fields!  -->
+                <if(progressiveRegEnabled)>
+                  $ const body = getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" });
+                  <marko-web-content-body block-name=blockName obj={ body } />
+                  <div class="content-page-preview-overlay" />
+                  <theme-content-page-gate
+                    profile-confirmation=false
+                    can-access=context.canAccess
+                    is-logged-in=context.isLoggedIn
+                    has-required-access-level=context.hasRequiredAccessLevel
+                    requires-access-level=context.requiresAccessLevel
+                    requires-user-input=false
+                    requiresPUI=context.requiresPUI
+                    messages=context.messages
+                    content-gate-type="default"
+                  />
+                </if>
+                <else-if(!context.canAccess || (context.requiresUserInput && requiresRegistration))>
+                  $ const body = getContentPreview({ body: content.body, selector: "p:nth-of-type(1)" });
+                  <marko-web-content-body block-name=blockName obj={ body } />
+                  <div class="content-page-preview-overlay" />
+                  <theme-content-page-gate
+                    profile-confirmation=false
+                    can-access=context.canAccess
+                    is-logged-in=context.isLoggedIn
+                    has-required-access-level=context.hasRequiredAccessLevel
+                    requires-access-level=context.requiresAccessLevel
+                    requires-user-input=context.requiresUserInput
+                    requiresPUI=context.requiresPUI
+                    messages=context.messages
+                    content-gate-type="default"
+                  />
+                </else-if>
+                <else>
+                  <content-body
+                    content=content
+                    block-name=blockName
+                    display-read-next=false
+                    display-comments=false
+                  />
+                </else>
+              </marko-web-identity-x-access>
             </theme-page-contents>
           </div>
         </div>

--- a/services/example-website/server/templates/user/index.js
+++ b/services/example-website/server/templates/user/index.js
@@ -3,6 +3,7 @@ const changeEmail = require('./change-email');
 const login = require('./login');
 const logout = require('./logout');
 const profile = require('./profile');
+const progressive = require('./progressive');
 
 module.exports = {
   authenticate,
@@ -10,4 +11,5 @@ module.exports = {
   login,
   logout,
   profile,
+  progressive,
 };

--- a/services/example-website/server/templates/user/progressive.marko
+++ b/services/example-website/server/templates/user/progressive.marko
@@ -31,7 +31,6 @@ $ const qIds = questions.map(({id}) => id);
             <if(canAsk)>
               <marko-web-identity-x-form-progressive
                 additional-event-data={
-                  foo: "bar",
                   action: "progressiveReg",
                 }
               />

--- a/services/example-website/server/templates/user/progressive.marko
+++ b/services/example-website/server/templates/user/progressive.marko
@@ -7,9 +7,8 @@ $ const title = "Progressive Profile";
 $ const description = `Tell ${config.siteName()} a little more about your self`;
 
 $ const now = new Date().getTime();
-<!-- day / hours * min * factor(4=15sec, 6=10sec) -->
-$ const days = 1 / (24 * 60);
-$ const delay = days * 24 * 60 * 60 * 1000;
+$ const hours = identityX.config.getProgresiveDelay();
+$ const delay = hours * 60 * 60 * 1000;
 
 $ const setDisplayNext = user => identityX.setAppUserCustomAttributes({
   userId: user.id,
@@ -25,11 +24,9 @@ $ const qIds = questions.map(({id}) => id);
       <@section>
         <h1 class="page-wrapper__title">${description}</h1>
         <marko-web-identity-x-context|{ user, hasUser }|>
-          $ console.log(user);
           <if(user)>
             $ const customAttributes = getAsObject(user, 'customAttributes');
             $ const { profileLastUpdated } = customAttributes;
-            $ console.log(customAttributes, profileLastUpdated, now, delay, profileLastUpdated - (now - delay))
             $ const canAsk = profileLastUpdated ? profileLastUpdated < (now - delay) : true;
             <if(canAsk)>
               <marko-web-identity-x-form-progressive
@@ -41,49 +38,14 @@ $ const qIds = questions.map(({id}) => id);
             </if>
             <else>
               $ const waitInMilliSeconds =  profileLastUpdated - (now - delay);
-              $ const waitInSec = waitInMilliSeconds / 1000;
-              $ const customAttributes = { ...user.customAttributes, waitInMilliSeconds, waitInSec };
+              $ const date = new Date(waitInMilliSeconds);
+              $ const waitInMin = `${date.getMinutes()}:${date.getSeconds()}`;
+              $ const customAttributes = { ...user.customAttributes, waitInMilliSeconds, waitInMin };
               <pre class="my-3 border p-3">${JSON.stringify({ id: user.id, customAttributes }, null, 2)}</pre>
             </else>
           </if>
         </marko-web-identity-x-context>
       </@section>
-      <!-- <@section>
-        <h1 class="page-wrapper__title">${description}</h1>
-        <marko-web-identity-x-context|{ user, hasUser }|>
-          $ console.log(user);
-          <if(user && user.customAttributes && (user.customAttributes.progressiveSeenAt < (now - delay)))>
-            <await(setDisplayNext(user))>
-              <@placeholder>
-                Updating user attributes only after ${delay} milliseconds...
-              </@placeholder>
-              <@then|updated|>
-                <pre class="my-3 border p-3">${JSON.stringify({ id: user.id, customAttributes: updated.customAttributes || {} }, null, 2)}</pre>
-              </@then>
-              <@catch|e|>
-                <div class="my-3 border p-3 text-danger border-danger">
-                  <h3>Error: ${e.name}</h3>
-                  <p>${e.message}</p>
-                </div>
-              </@catch>
-            </await>
-          </if>
-          <else-if(user)>
-            $ const waitInMilliSeconds =  user.customAttributes.progressiveSeenAt - (now-delay);
-            $ const sec = waitInMilliSeconds / 1000;
-            $ const customAttributes = { ...user.customAttributes, waitInMilliSeconds, sec };
-            <pre class="my-3 border p-3">${JSON.stringify({ id: user.id, customAttributes }, null, 2)}</pre>
-          </else-if>
-        </marko-web-identity-x-context>
-
-          <marko-web-identity-x-form-progressive
-            additional-event-data={
-              foo: "bar",
-              action: "progressiveReg",
-            }
-          />
-
-      </@section> -->
     </marko-web-page-wrapper>
   </@page>
 </marko-web-default-page-layout>

--- a/services/example-website/server/templates/user/progressive.marko
+++ b/services/example-website/server/templates/user/progressive.marko
@@ -1,0 +1,89 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+$ const { config, res } = out.global;
+$ const { identityX } = res.locals;
+
+$ const type = "profile";
+$ const title = "Progressive Profile";
+$ const description = `Tell ${config.siteName()} a little more about your self`;
+
+$ const now = new Date().getTime();
+<!-- day / hours * min * factor(4=15sec, 6=10sec) -->
+$ const days = 1 / (24 * 60);
+$ const delay = days * 24 * 60 * 60 * 1000;
+
+$ const setDisplayNext = user => identityX.setAppUserCustomAttributes({
+  userId: user.id,
+  attributes: { progressiveSeenAt:  now },
+});
+
+$ const questions = identityX.config.getProgresiveQuestions();
+$ const qIds = questions.map(({id}) => id);
+
+<marko-web-default-page-layout type=type title=title description=description>
+  <@page>
+    <marko-web-page-wrapper>
+      <@section>
+        <h1 class="page-wrapper__title">${description}</h1>
+        <marko-web-identity-x-context|{ user, hasUser }|>
+          $ console.log(user);
+          <if(user)>
+            $ const customAttributes = getAsObject(user, 'customAttributes');
+            $ const { profileLastUpdated } = customAttributes;
+            $ console.log(customAttributes, profileLastUpdated, now, delay, profileLastUpdated - (now - delay))
+            $ const canAsk = profileLastUpdated ? profileLastUpdated < (now - delay) : true;
+            <if(canAsk)>
+              <marko-web-identity-x-form-progressive
+                additional-event-data={
+                  foo: "bar",
+                  action: "progressiveReg",
+                }
+              />
+            </if>
+            <else>
+              $ const waitInMilliSeconds =  profileLastUpdated - (now - delay);
+              $ const waitInSec = waitInMilliSeconds / 1000;
+              $ const customAttributes = { ...user.customAttributes, waitInMilliSeconds, waitInSec };
+              <pre class="my-3 border p-3">${JSON.stringify({ id: user.id, customAttributes }, null, 2)}</pre>
+            </else>
+          </if>
+        </marko-web-identity-x-context>
+      </@section>
+      <!-- <@section>
+        <h1 class="page-wrapper__title">${description}</h1>
+        <marko-web-identity-x-context|{ user, hasUser }|>
+          $ console.log(user);
+          <if(user && user.customAttributes && (user.customAttributes.progressiveSeenAt < (now - delay)))>
+            <await(setDisplayNext(user))>
+              <@placeholder>
+                Updating user attributes only after ${delay} milliseconds...
+              </@placeholder>
+              <@then|updated|>
+                <pre class="my-3 border p-3">${JSON.stringify({ id: user.id, customAttributes: updated.customAttributes || {} }, null, 2)}</pre>
+              </@then>
+              <@catch|e|>
+                <div class="my-3 border p-3 text-danger border-danger">
+                  <h3>Error: ${e.name}</h3>
+                  <p>${e.message}</p>
+                </div>
+              </@catch>
+            </await>
+          </if>
+          <else-if(user)>
+            $ const waitInMilliSeconds =  user.customAttributes.progressiveSeenAt - (now-delay);
+            $ const sec = waitInMilliSeconds / 1000;
+            $ const customAttributes = { ...user.customAttributes, waitInMilliSeconds, sec };
+            <pre class="my-3 border p-3">${JSON.stringify({ id: user.id, customAttributes }, null, 2)}</pre>
+          </else-if>
+        </marko-web-identity-x-context>
+
+          <marko-web-identity-x-form-progressive
+            additional-event-data={
+              foo: "bar",
+              action: "progressiveReg",
+            }
+          />
+
+      </@section> -->
+    </marko-web-page-wrapper>
+  </@page>
+</marko-web-default-page-layout>


### PR DESCRIPTION
Initial port from profile components and routes as it will have to support the same variation of inputs.  It does have added logic to only display one question at the moment based on array of configured ids.

Example of what to add to the identityX config: 
```
 progressiveQuestions: [
    {
      id: 'givenName',
    },
    {
      id: 'familyName',
    },
    {
      id: '618a8a62934f8400ad4beb8f',
    },
    {
      id: '626fe91c79d99b27544a4c9f',
    },

  ],
  ```

It will only display on unanswered question in order at the moment.