### PR TITLE
Pass `requestingSiteId` to `redirectToFn`, `withContent` middleware

### DIFF
--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -23,10 +23,14 @@ module.exports = ({
 
   const additionalInput = buildContentInput({ req });
   const content = await loader(apollo, { id, additionalInput, queryFragment: loaderQueryFragment });
+  const requestingSiteId = req.app.locals.config.website('id');
 
   // set the route kind
   setRouteKind(res, { kind: 'content', type: content.type });
-  const redirectTo = isFn(redirectToFn) ? redirectToFn({ content }) : content.redirectTo;
+  const redirectTo = isFn(redirectToFn) ? redirectToFn({
+    content,
+    requestingSiteId,
+  }) : content.redirectTo;
   const path = isFn(pathFn) ? pathFn({ content }) : get(content, 'siteContext.path');
 
   if (redirectTo) {


### PR DESCRIPTION
This allows for the designated `redirecToFn` to utilize the requesting site ID within itself (i.e checking if the content returned is being returned on the primary site versus not)