### PR TITLE
Adjust newsletters pushdown css for additional questions

### DIFF
--- a/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_site-newsletter-menu.scss
@@ -69,13 +69,16 @@
     form {
       display: flex;
       flex-wrap: wrap;
-      label {
+      label[for="newsletter-pushdown-email"] {
         display: none;
       }
-      .form-group {
+      .form-group:only-of-type {
         flex: 1;
         flex-grow: 1;
-        max-width: 318px
+        max-width: 318px;
+         ~ .btn {
+          align-self: flex-start;
+         }
       }
       .btn {
         flex-shrink: 1;
@@ -83,7 +86,7 @@
         padding: 10px;
         font-weight: $font-weight-bolder;
         order: 2;
-        align-self: flex-start;
+        align-self: center;
       }
       .form-group ~ .text-muted {
         order: 4;
@@ -518,19 +521,24 @@
     form {
       display: flex;
       flex-wrap: wrap;
-      label {
+      label[for="newsletter-pushdown-email"] {
         display: none;
       }
       #newsletter-menu-email {
         flex: 1;
         flex-grow: 1;
       }
+      .form-group:only-of-type {
+        ~ .btn {
+          align-self: flex-start;
+         }
+      }
       .btn {
         flex-shrink: 1;
         margin-left: map-get($spacers, 3);
         padding: 10px;
         order: 2;
-        align-self: flex-start;
+        align-self: center;
       }
       .form-group ~ .text-muted {
         order: 4;


### PR DESCRIPTION
Add css to account for when email is not enough to rapid identity and there are additional inputs needed.

<img width="1244" alt="Screen Shot 2023-10-25 at 1 05 59 PM" src="https://github.com/parameter1/base-cms/assets/3845869/2ab7fb6c-59d7-47b3-b68f-0c84d5532548">



<img width="847" alt="Screenshot 2023-11-01 at 8 36 48 AM" src="https://github.com/parameter1/base-cms/assets/3845869/d0b86c82-1d2a-4022-885b-9b3852428115">
<img width="869" alt="Screenshot 2023-11-01 at 8 36 59 AM" src="https://github.com/parameter1/base-cms/assets/3845869/501c117f-7e1e-4ec0-82dc-43393891ac56">
