### PR TITLE
IdentityX identity tracking

### DIFF
--- a/packages/marko-web-identity-x/api/queries/load-user-by-external-id.js
+++ b/packages/marko-web-identity-x/api/queries/load-user-by-external-id.js
@@ -1,0 +1,14 @@
+const gql = require('graphql-tag');
+const userFragment = require('../fragments/active-user');
+
+module.exports = gql`
+  query LoadUserByExternalId(
+    $identifier: AppUserExternalIdentifierInput!,
+    $namespace: AppUserExternalNamespaceInput!
+  ) {
+    appUserByExternalId(input: { identifier: $identifier, namespace: $namespace }) {
+      ...ActiveUserFragment
+    }
+  }
+  ${userFragment}
+`;

--- a/packages/marko-web-identity-x/package.json
+++ b/packages/marko-web-identity-x/package.json
@@ -22,6 +22,7 @@
     "apollo-link-http": "^1.5.17",
     "body-parser": "^1.20.1",
     "cookie": "0.3.1",
+    "debug": "^4.3.4",
     "dayjs": "^1.11.7",
     "express": "^4.18.2",
     "graphql-tag": "^2.12.6",

--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -43,6 +43,7 @@ module.exports = asyncRoute(async (req, res) => {
   });
   tokenCookie.setTo(res, authToken.value);
   contextCookie.setTo(res, { loginSource });
+  identityX.setIdentityCookie(user.id);
   res.json({
     ok: true,
     user,

--- a/packages/marko-web-omeda-identity-x/api/queries/customer-by-encrypted-id.js
+++ b/packages/marko-web-omeda-identity-x/api/queries/customer-by-encrypted-id.js
@@ -1,0 +1,10 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+  query IdXIdentifyCustomer($id: String!) {
+    customerByEncryptedId(input: { id: $id, errorOnNotFound: false }) {
+      id
+      primaryEmailAddress { emailAddress }
+    }
+  }
+`;

--- a/packages/marko-web-omeda-identity-x/index.js
+++ b/packages/marko-web-omeda-identity-x/index.js
@@ -7,6 +7,7 @@ const setPromoSourceCookie = require('./middleware/set-promo-source');
 const stripOlyticsParam = require('./middleware/strip-olytics-param');
 const resyncCustomerData = require('./middleware/resync-customer-data');
 const setOlyticsCookie = require('./middleware/set-olytics-cookie');
+const setIdentityCookie = require('./middleware/set-identity-cookie');
 const rapidIdentify = require('./middleware/rapid-identify');
 const rapidIdentifyRouter = require('./routes/rapid-identify');
 const props = require('./validation/props');
@@ -158,6 +159,7 @@ module.exports = (app, params = {}) => {
   identityX(app, idxConfig, { templates: idxRouteTemplates });
 
   app.use(setOlyticsCookie({ brandKey }));
+  app.use(setIdentityCookie({ brandKey }));
 
   // install the Omeda data sync middleware
   app.use(resyncCustomerData({

--- a/packages/marko-web-omeda-identity-x/middleware/README.md
+++ b/packages/marko-web-omeda-identity-x/middleware/README.md
@@ -1,0 +1,12 @@
+Omeda+IdentityX Middleware
+===
+
+## Set Identity Cookie
+This [middleware](./set-identity-cookie.js) sets the IdentityX Identity cookie. This cookie represents the identity that all user behavior should be attributed to.
+
+Test cases:
+1. Fully anonymous user (no omeda or idx tokens). No cookie should be set.
+2. Logged in user w/o cookie: cookkie should be set
+3. Logged in user w/ cookie: Cookie shoudl not be set.
+4. Omeda identity cookie present, identityx user exists for ext id: cookie shoul dbe set.
+5. Omeda identity cookie present, no identityx user exists: cookie should be set.

--- a/packages/marko-web-omeda-identity-x/middleware/set-identity-cookie.js
+++ b/packages/marko-web-omeda-identity-x/middleware/set-identity-cookie.js
@@ -1,0 +1,80 @@
+const { asyncRoute } = require('@parameter1/base-cms-utils');
+const { get } = require('@parameter1/base-cms-object-path');
+const olyticsCookie = require('@parameter1/base-cms-marko-web-omeda/olytics/customer-cookie');
+const query = require('../api/queries/customer-by-encrypted-id');
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @returns {String|null}
+ */
+const findOlyticsId = (req, res) => {
+  // Read from request cookies
+  const reqId = olyticsCookie.parseFrom(req);
+  if (reqId) return reqId;
+  // request query param
+  const { oly_enc_id: qId } = req.query;
+  if (qId) return qId;
+  // response cookie
+  const cookies = (res.get('set-cookie') || []).reduce((o, c) => {
+    const [r] = `${c}`.split(';');
+    const [k, v] = `${r}`.split('=');
+    return { ...o, [k]: v };
+  }, {});
+  const resId = olyticsCookie.parseFrom({ cookies });
+  return resId;
+};
+
+/**
+ * @typedef OIDXRequest
+ * @prop {import('@parameter1/omeda-graphql-client')} $omedaGraphQLClient
+ * @prop {import('@parameter1/base-cms-marko-web-identity-x/service')} identityX
+ *
+ * @param {Object} o
+ * @param {String} o.brandKey
+ */
+module.exports = ({
+  brandKey,
+}) => asyncRoute(async (req, res, next) => {
+  /** @type {OIDXRequest} */
+  const { identityX: idx, $omedaGraphQLClient: omeda } = req;
+  const { user } = await idx.loadActiveContext();
+  const cookie = idx.getIdentity(res);
+
+  // Don't overwrite an existing cookie
+  if (cookie) return next();
+
+  // Set logged in user identity
+  if (user && user.id) {
+    idx.setIdentityCookie(user.id);
+    return next();
+  }
+
+  // get oly enc id. if we don't have one, bail
+  const omedaId = findOlyticsId(req, res);
+  if (!omedaId) return next();
+
+  // Look up idx user by encrypted id
+  const namespace = { provider: 'omeda', tenant: brandKey.toLowerCase(), type: 'customer' };
+  const identity = await idx.findUserByExternalId({ identifier: omedaId, namespace });
+  if (identity) {
+    idx.setIdentityCookie(identity.id);
+    return next();
+  }
+
+  const or = await omeda.query({ query, variables: { id: omedaId } });
+  const email = get(or, 'data.customerByEncryptedId.primaryEmailAddress.emailAddress');
+  if (email) {
+    // Upsert the user and add the external id to it.
+    const { id } = await idx.createAppUser({ email });
+    await idx.addExternalUserId({
+      userId: id,
+      identifier: { value: omedaId, type: 'encrypted' },
+      namespace,
+    });
+    idx.setIdentityCookie(id);
+    return next();
+  }
+  return next();
+});

--- a/packages/marko-web-omeda-identity-x/middleware/set-identity-cookie.js
+++ b/packages/marko-web-omeda-identity-x/middleware/set-identity-cookie.js
@@ -39,17 +39,10 @@ module.exports = ({
 }) => asyncRoute(async (req, res, next) => {
   /** @type {OIDXRequest} */
   const { identityX: idx, $omedaGraphQLClient: omeda } = req;
-  const { user } = await idx.loadActiveContext();
   const cookie = idx.getIdentity(res);
 
   // Don't overwrite an existing cookie
   if (cookie) return next();
-
-  // Set logged in user identity
-  if (user && user.id) {
-    idx.setIdentityCookie(user.id);
-    return next();
-  }
 
   // get oly enc id. if we don't have one, bail
   const omedaId = findOlyticsId(req, res);

--- a/packages/marko-web-theme-monorail/components/identity-x/identify.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/identify.marko
@@ -1,0 +1,18 @@
+$ const { req, res } = out.global;
+$ const { identityX } = req;
+$ const identity = identityX.getIdentity(res);
+
+<if(Boolean(identityX))>
+  <marko-web-identity-x-context|{ user, hasUser }|>
+    $ const payload = {
+      ...(identity && { identity }),
+      ...(hasUser && {
+        user: identityX.config.getGTMUserData(user),
+        user_id: user.id
+      }),
+    };
+    <if(hasUser || identity)>
+      <marko-web-gtm-push data=payload />
+    </if>
+  </marko-web-identity-x-context>
+</if>

--- a/packages/marko-web-theme-monorail/components/identity-x/marko.json
+++ b/packages/marko-web-theme-monorail/components/identity-x/marko.json
@@ -29,6 +29,9 @@
   "<identity-x-newsletter-form-inline>": {
     "template": "./newsletter-inline.marko"
   },
+  "<identity-x-identify>": {
+    "template": "./identify.marko"
+  },
   "<identity-x-newsletter-form-footer>": {
     "template": "./newsletter-footer.marko"
   }

--- a/packages/web-common/website-context.js
+++ b/packages/web-common/website-context.js
@@ -1,6 +1,7 @@
 const gql = require('graphql-tag');
 const siteFragment = require('./graphql/website-context-fragment');
 
+const { error } = console;
 const query = gql`
 
 query MarkoWebsiteContext {
@@ -17,6 +18,11 @@ ${siteFragment}
  * @param {ApolloClient} apolloClient The BaseCMS Apollo GraphQL client that will perform the query.
  */
 module.exports = async (apolloClient) => {
-  const { data } = await apolloClient.query({ query });
-  return data.websiteContext;
+  try {
+    const { data } = await apolloClient.query({ query });
+    return data.websiteContext;
+  } catch (e) {
+    error(e);
+    throw e;
+  }
 };

--- a/services/example-website/server/components/document.marko
+++ b/services/example-website/server/components/document.marko
@@ -46,6 +46,8 @@ $ const { nativeX, cdn, contentMeterState } = out.global;
       target-tag="body"
     />
 
+    <identity-x-identify />
+
     <${input.head} />
 
     <marko-web-gam-enable />


### PR DESCRIPTION
Ref parameter1/identity-x#45

Sets an `__idx_idt` cookie based on the IdentityX identity. This is pulled first from any logged in user credentials, then from the Omeda customer identifier, if present. If there is no IdentityX user for the Omeda customer, one will be created (unverified) for the purpose of generating the identity id.

To implement, add the `<identity-x-identify />` component to the document header.