### PR TITLE
Adjust shared content-meter component setting of gateType & add support for AB, DE & WATT customizations. 

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
@@ -1,3 +1,5 @@
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
 $ const { config, site, contentMeterState } = out.global;
 $ const {
   displayGate,

--- a/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
@@ -11,6 +11,7 @@ $ const additionalEventData = {
   viewLimit,
   displayGate,
   displayOverlay,
+  contentGateType: "metered",
 };
 
 $ const setTextVariables = () => {

--- a/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
@@ -14,9 +14,11 @@ $ const additionalEventData = {
   contentGateType: "metered",
 };
 
+
+
 $ const setTextVariables = () => {
   // Set title based on views remaining
-  let dynamicTitle = "Create an account"
+  let dynamicTitle = defaultValue(input.dynamicTitle, "Create an account");
   if (views < viewLimit) dynamicTitle = `You have ${viewLimit - views} article views remaining.`;
   if (viewLimit - views === 1) dynamicTitle = `You have 1 article view remaining.`;
   if (viewLimit === views && !displayOverlay) dynamicTitle = `This is your last free article.`;

--- a/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/content-meter.marko
@@ -20,6 +20,7 @@ $ const setTextVariables = () => {
   if (views < viewLimit) dynamicTitle = `You have ${viewLimit - views} article views remaining.`;
   if (viewLimit - views === 1) dynamicTitle = `You have 1 article view remaining.`;
   if (viewLimit === views && !displayOverlay) dynamicTitle = `This is your last free article.`;
+  if (viewLimit === 1 && !displayOverlay) 'Enjoy this free article.';
 
   return [
     dynamicTitle,


### PR DESCRIPTION
Set the gateType to metered within the additionalEventData portion of the content meter component.  This will then set the actionSource to content gate and content gate type of meter.

This will go in conjunction with:
 - https://github.com/parameter1/cox-matthews-associates-websites/pull/273
 - https://github.com/parameter1/watt-global-media-websites/pull/272
 - AB will also need a dep upgrade and push to get the `Metered` contentGateType update. 