### PR TITLE
Add providerData layer to the identity-x-identify comp

### DIFF
--- a/packages/marko-web-identity-x/components/identify.marko
+++ b/packages/marko-web-identity-x/components/identify.marko
@@ -1,0 +1,17 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+import getCookieId from "@parameter1/base-cms-marko-web-omeda-identity-x/utils/get-cookie-id";
+import { getResponseCookies } from "@parameter1/base-cms-utils";
+
+$ const { req, res } = out.global;
+$ const { identityX } = req;
+
+<if(Boolean(identityX))>
+  <marko-web-resolve|{ resolved: user }| promise=identityX.getIdentityData()>
+    <if(user || input.providerData)>
+      <!-- additional user data to spread base on provider(omeda, braze...) -->
+      $ const providerData = getAsObject(input, "providerData");
+      $ const data = { user, ...providerData };
+      <marko-web-gtm-push  data=data />
+    </if>
+  </marko-web-resolve>
+</if>

--- a/packages/marko-web-identity-x/components/marko.json
+++ b/packages/marko-web-identity-x/components/marko.json
@@ -76,5 +76,9 @@
     "@url": "string",
     "@load-more-button-class": "string",
     "@login-button-labels": "object"
+  },
+  "<marko-web-identity-x-identify>": {
+    "template": "./identify.marko",
+    "@provider-data": "object"
   }
 }

--- a/packages/marko-web-omeda-identity-x/components/identify.marko
+++ b/packages/marko-web-omeda-identity-x/components/identify.marko
@@ -10,7 +10,7 @@ $ const olyAnonId = cookies.oly_anon_id ? getCookieId(cookies.oly_anon_id, 'anon
 <if(Boolean(identityX))>
   <marko-web-resolve|{ resolved: user }| promise=identityX.getIdentityData()>
     <if(user || olyEncId || olyAnonId)>
-      <marko-web-gtm-push data={ user, oly_enc_id: olyEncId, oly_anon_id: olyAnonId } />
+      <marko-web-identity-x-identify provider-data={ oly_enc_id: olyEncId, oly_anon_id: olyAnonId } />
     </if>
   </marko-web-resolve>
 </if>

--- a/packages/marko-web-omeda-identity-x/components/marko.json
+++ b/packages/marko-web-omeda-identity-x/components/marko.json
@@ -1,0 +1,6 @@
+{
+  "taglib-imports": [],
+  "<marko-web-omeda-identity-x-identify>": {
+    "template": "./identify.marko"
+  }
+}

--- a/packages/marko-web-omeda-identity-x/marko.json
+++ b/packages/marko-web-omeda-identity-x/marko.json
@@ -1,0 +1,6 @@
+{
+  "taglib-id": "@parameter1/base-cms-marko-web-omeda",
+  "taglib-imports": [
+    "./components/marko.json"
+  ]
+}

--- a/packages/marko-web-omeda-identity-x/package.json
+++ b/packages/marko-web-omeda-identity-x/package.json
@@ -22,6 +22,7 @@
     "graphql-tag": "^2.12.6"
   },
   "peerDependencies": {
+    "@parameter1/base-cms-marko-core": "^4.0.0",
     "@parameter1/base-cms-marko-web": "^4.0.0",
     "express": "^4.18.2"
   },

--- a/packages/marko-web-theme-monorail/components/identity-x/marko.json
+++ b/packages/marko-web-theme-monorail/components/identity-x/marko.json
@@ -29,9 +29,6 @@
   "<identity-x-newsletter-form-inline>": {
     "template": "./newsletter-inline.marko"
   },
-  "<identity-x-identify>": {
-    "template": "./identify.marko"
-  },
   "<identity-x-newsletter-form-footer>": {
     "template": "./newsletter-footer.marko"
   }

--- a/services/example-website/server/components/document.marko
+++ b/services/example-website/server/components/document.marko
@@ -46,7 +46,7 @@ $ const { nativeX, cdn, contentMeterState } = out.global;
       target-tag="body"
     />
 
-    <identity-x-identify />
+    <marko-web-omeda-identity-x-identify />
 
     <${input.head} />
 


### PR DESCRIPTION
Move monorail identity-x-identify component to identity-x packaged as well as the omeda-identity-x packages.  The omeda version calls the idX version with providerData passed into it, oly_enc_id & oly_anon_id.  This will also, at some point, have a braze one.  

https://github.com/parameter1/bobit-business-media-websites/pull/167

This will also allow for non omeda groups to still use this component:
https://github.com/parameter1/bizbash-media-websites/pull/214

This will also allow for non monorail sites to utilize it.  
https://github.com/parameter1/ac-business-media-websites/pull/518
https://github.com/parameter1/allured-business-media-websites/pull/315

