### PR TITLE
Add conditional env check for USE_LINK_INJECTED_BODY to include them in the content page fragment 

### DIFF
--- a/packages/marko-web-theme-monorail/graphql/fragments/content-page.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/content-page.js
@@ -1,12 +1,14 @@
 const gql = require('graphql-tag');
 
+const enableBCL = process.env.ENABLE_BCL === 'true';
+
 module.exports = gql`
 fragment ContentPageFragment on Content {
   id
   name
   teaser(input: { useFallback: false, maxLength: null })
   labels
-  body
+  body(input: { useLinkInjectedBody: ${enableBCL} })
   published
   updated
   siteContext {

--- a/packages/marko-web-theme-monorail/graphql/fragments/content-page.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/content-page.js
@@ -1,6 +1,6 @@
 const gql = require('graphql-tag');
 
-const enableBCL = process.env.ENABLE_BCL === 'true';
+const useLinkInjectedBody = process.env.USE_LINK_INJECTED_BODY === 'true';
 
 module.exports = gql`
 fragment ContentPageFragment on Content {
@@ -8,7 +8,7 @@ fragment ContentPageFragment on Content {
   name
   teaser(input: { useFallback: false, maxLength: null })
   labels
-  body(input: { useLinkInjectedBody: ${enableBCL} })
+  body(input: { useLinkInjectedBody: ${useLinkInjectedBody} })
   published
   updated
   siteContext {


### PR DESCRIPTION
By default nothing changes, no one has this env set.  But if they add and set this to true it will turn on body copy linking.  Assuming this has been setup and run for the given site.