### PR TITLE
Add content-page fragment support for factory call

### DIFF
--- a/packages/marko-web-theme-monorail/graphql/fragments/content-page.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/content-page.js
@@ -7,34 +7,23 @@ const factory = ({ useLinkInjectedBody = false } = {}) => {
     id
     name
     teaser(input: { useFallback: false, maxLength: null })
+    labels
     body(input: { useLinkInjectedBody: ${useLinkInjectedBody} })
     published
-    labels
+    updated
     siteContext {
       path
       canonicalUrl
-      url
     }
     company {
       id
       name
-      siteContext {
-        path
-      }
+      canonicalPath
       enableRmi
-      primaryImage {
-        id
-        src(input: { options: { auto: "format,compress" } })
-        alt
-        caption
-        credit
-        isLogo
-      }
     }
     primarySection {
       id
       name
-      fullName
       alias
       canonicalPath
       hierarchy {
@@ -42,34 +31,31 @@ const factory = ({ useLinkInjectedBody = false } = {}) => {
         name
         alias
         canonicalPath
-        logo {
-          id
-          src(input: { options: { auto: "format,compress" } })
-        }
       }
     }
     primaryImage {
       id
-      src(input: { options: { auto: "format,compress" } })
+      src(input: { useCropRectangle: true, options: { auto: "format,compress" } })
+      cropRectangle {
+        width
+        height
+      }
       alt
       caption
       credit
       isLogo
+      cropDimensions {
+        aspectRatio
+      }
+      primaryImageDisplay
     }
     gating {
       surveyType
       surveyId
     }
     userRegistration {
-      bypassGating
       isCurrentlyRequired
       accessLevels
-    }
-    createdBy {
-      id
-      username
-      firstName
-      lastName
     }
     ... on ContentVideo {
       embedCode
@@ -83,14 +69,19 @@ const factory = ({ useLinkInjectedBody = false } = {}) => {
       byline
     }
     ... on ContentEvent {
-      endDate
-      startDate
+      ends
+      starts
     }
-    ... on ContentArticle {
-      sidebars
+    ... on SidebarEnabledInterface {
+      sidebars: sidebarStubs {
+        name
+        body
+        label
+      }
     }
     ... on ContentWebinar {
       linkUrl
+      starts
       startDate
       transcript
       sponsors {
@@ -98,9 +89,7 @@ const factory = ({ useLinkInjectedBody = false } = {}) => {
           node {
             id
             name
-            siteContext {
-              path
-            }
+            canonicalPath
           }
         }
       }
@@ -143,59 +132,34 @@ const factory = ({ useLinkInjectedBody = false } = {}) => {
             id
             name
             type
+            body
+            labels
             siteContext {
               path
             }
-          }
-        }
-      }
-      contributors {
-        edges {
-          node {
-            id
-            name
-            type
-            siteContext {
-              path
-            }
-          }
-        }
-      }
-      photographers {
-        edges {
-          node {
-            id
-            name
-            type
-            siteContext {
-              path
+            primaryImage {
+              id
+              src(input: { options: { auto: "format,compress" } })
+              alt(input: { append: "Headshot" })
             }
           }
         }
       }
     }
-    images(input: { pagination: { limit: 100 }, sort: { order: values } }) {
+    images(input:{ pagination: { limit: 0 }, sort: { order: values } }) {
       edges {
         node {
           id
           src(input: { options: { auto: "format,compress" } })
           alt
+          displayName
+          caption
+          credit
+          inCarousel
           source {
             width
             height
           }
-          displayName
-          caption
-          credit
-          isLogo
-        }
-      }
-    }
-    taxonomy {
-      edges {
-        node {
-          id
-          name
         }
       }
     }

--- a/packages/marko-web-theme-monorail/graphql/fragments/content-page.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/content-page.js
@@ -1,165 +1,208 @@
 const gql = require('graphql-tag');
 
-module.exports = gql`
-fragment ContentPageFragment on Content {
-  id
-  name
-  teaser(input: { useFallback: false, maxLength: null })
-  labels
-  body
-  published
-  updated
-  siteContext {
-    path
-    canonicalUrl
-  }
-  company {
+const factory = ({ useLinkInjectedBody = false } = {}) => {
+  const fragment = gql`
+
+  fragment ContentPageFragment on Content {
     id
     name
-    canonicalPath
-    enableRmi
-  }
-  primarySection {
-    id
-    name
-    alias
-    canonicalPath
-    hierarchy {
+    teaser(input: { useFallback: false, maxLength: null })
+    body(input: { useLinkInjectedBody: ${useLinkInjectedBody} })
+    published
+    labels
+    siteContext {
+      path
+      canonicalUrl
+      url
+    }
+    company {
       id
       name
-      alias
-      canonicalPath
-    }
-  }
-  primaryImage {
-    id
-    src(input: { useCropRectangle: true, options: { auto: "format,compress" } })
-    cropRectangle {
-      width
-      height
-    }
-    alt
-    caption
-    credit
-    isLogo
-    cropDimensions {
-      aspectRatio
-    }
-    primaryImageDisplay
-  }
-  gating {
-    surveyType
-    surveyId
-  }
-  userRegistration {
-    isCurrentlyRequired
-    accessLevels
-  }
-  ... on ContentVideo {
-    embedCode
-    transcript
-  }
-  ... on ContentPodcast {
-    transcript
-  }
-  ... on ContentNews {
-    source
-    byline
-  }
-  ... on ContentEvent {
-    ends
-    starts
-  }
-  ... on SidebarEnabledInterface {
-    sidebars: sidebarStubs {
-      name
-      body
-      label
-    }
-  }
-  ... on ContentWebinar {
-    linkUrl
-    starts
-    startDate
-    transcript
-    sponsors {
-      edges {
-        node {
-          id
-          name
-          canonicalPath
-        }
+      siteContext {
+        path
       }
-    }
-  }
-  ... on Addressable {
-    address1
-    address2
-    cityStateZip
-    country
-  }
-  ... on Contactable {
-    phone
-    tollfree
-    fax
-    website
-    title
-    mobile
-    publicEmail
-  }
-  ... on ContentCompany {
-    email
-  }
-  ... on SocialLinkable {
-    socialLinks {
-      provider
-      url
-      label
-    }
-  }
-  ... on Media {
-    fileSrc
-  }
-  ... on Inquirable {
-    enableRmi
-  }
-  ... on Authorable {
-    authors {
-      edges {
-        node {
-          id
-          name
-          type
-          body
-          labels
-          siteContext {
-            path
-          }
-          primaryImage {
-            id
-            src(input: { options: { auto: "format,compress" } })
-            alt(input: { append: "Headshot" })
-          }
-        }
-      }
-    }
-  }
-  images(input:{ pagination: { limit: 0 }, sort: { order: values } }) {
-    edges {
-      node {
+      enableRmi
+      primaryImage {
         id
         src(input: { options: { auto: "format,compress" } })
         alt
-        displayName
         caption
         credit
-        inCarousel
-        source {
-          width
-          height
+        isLogo
+      }
+    }
+    primarySection {
+      id
+      name
+      fullName
+      alias
+      canonicalPath
+      hierarchy {
+        id
+        name
+        alias
+        canonicalPath
+        logo {
+          id
+          src(input: { options: { auto: "format,compress" } })
+        }
+      }
+    }
+    primaryImage {
+      id
+      src(input: { options: { auto: "format,compress" } })
+      alt
+      caption
+      credit
+      isLogo
+    }
+    gating {
+      surveyType
+      surveyId
+    }
+    userRegistration {
+      bypassGating
+      isCurrentlyRequired
+      accessLevels
+    }
+    createdBy {
+      id
+      username
+      firstName
+      lastName
+    }
+    ... on ContentVideo {
+      embedCode
+      transcript
+    }
+    ... on ContentPodcast {
+      transcript
+    }
+    ... on ContentNews {
+      source
+      byline
+    }
+    ... on ContentEvent {
+      endDate
+      startDate
+    }
+    ... on ContentArticle {
+      sidebars
+    }
+    ... on ContentWebinar {
+      linkUrl
+      startDate
+      transcript
+      sponsors {
+        edges {
+          node {
+            id
+            name
+            siteContext {
+              path
+            }
+          }
+        }
+      }
+    }
+    ... on Addressable {
+      address1
+      address2
+      cityStateZip
+      country
+    }
+    ... on Contactable {
+      phone
+      tollfree
+      fax
+      website
+      title
+      mobile
+      publicEmail
+    }
+    ... on ContentCompany {
+      email
+    }
+    ... on SocialLinkable {
+      socialLinks {
+        provider
+        url
+        label
+      }
+    }
+    ... on Media {
+      fileSrc
+    }
+    ... on Inquirable {
+      enableRmi
+    }
+    ... on Authorable {
+      authors {
+        edges {
+          node {
+            id
+            name
+            type
+            siteContext {
+              path
+            }
+          }
+        }
+      }
+      contributors {
+        edges {
+          node {
+            id
+            name
+            type
+            siteContext {
+              path
+            }
+          }
+        }
+      }
+      photographers {
+        edges {
+          node {
+            id
+            name
+            type
+            siteContext {
+              path
+            }
+          }
+        }
+      }
+    }
+    images(input: { pagination: { limit: 100 }, sort: { order: values } }) {
+      edges {
+        node {
+          id
+          src(input: { options: { auto: "format,compress" } })
+          alt
+          source {
+            width
+            height
+          }
+          displayName
+          caption
+          credit
+          isLogo
+        }
+      }
+    }
+    taxonomy {
+      edges {
+        node {
+          id
+          name
         }
       }
     }
   }
-}
-`;
+  `;
+  fragment.factory = factory;
+  return fragment;
+};
+
+module.exports = factory();


### PR DESCRIPTION
currently we are mostly using this on content routes this will now allow for

queryFragment: queryFragment,

OR

queryFragment: queryFragment.factory({ useLinkInjectedBody: true })

Allowing it to not be backwards breaking as well as allowing you to configure it on a per condition based when needed.

Example site update: https://github.com/parameter1/watt-global-media-websites/pull/282