### PR TITLE
Include alias on sitemap url query projection.

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1097,6 +1097,7 @@ module.exports = {
 
       const projection = {
         type: 1,
+        'mutations.Website.alias': 1,
         'mutations.Website.slug': 1,
         'mutations.Website.primarySection': 1,
         'mutations.Website.primaryCategory': 1,


### PR DESCRIPTION
Likewise to https://github.com/parameter1/base-cms/pull/743. This was preventing URLs to resolve in the same fashion they do within the fields returned within `Content.siteContext` (`path`,`url`,`canonicalUrl`) and causing the sitemap URLs for Pages (as defined within https://github.com/parameter1/base-cms/blob/master/services/graphql-server/src/graphql/definitions/platform/content/types/page.js#L16 and is the only type allowed to use this field) to resolve incorrectly.

BEFORE:
![Screenshot from 2023-11-29 13-20-01](https://github.com/parameter1/base-cms/assets/46794001/8a7c7b34-bc9f-44a7-8c38-b36fa1a14cd6)

AFTER:
![Screenshot from 2023-11-29 13-20-19](https://github.com/parameter1/base-cms/assets/46794001/b7ff25b4-33c2-40af-bc82-5358aea746e1)
