### PR TITLE
Migrate error handling for `deleted` content to after redirect handling, `withContent` middleware

### DIFF
--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -17,7 +17,7 @@ module.exports = ({
   pathFn,
   formatResponse,
   sideloadDataFn,
-  contentIdStatusExceptions,
+  contentIdStatusExceptions = [],
 } = {}) => asyncRoute(async (req, res) => {
   const id = isFn(idResolver) ? await idResolver(req, res) : req.params.id;
   const { apollo, query } = req;

--- a/packages/marko-web/middleware/with-content.js
+++ b/packages/marko-web/middleware/with-content.js
@@ -17,11 +17,12 @@ module.exports = ({
   pathFn,
   formatResponse,
   sideloadDataFn,
+  contentIdStatusExceptions,
 } = {}) => asyncRoute(async (req, res) => {
   const id = isFn(idResolver) ? await idResolver(req, res) : req.params.id;
   const { apollo, query } = req;
 
-  const additionalInput = buildContentInput({ req });
+  const additionalInput = buildContentInput({ req, contentIdStatusExceptions });
   const content = await loader(apollo, { id, additionalInput, queryFragment: loaderQueryFragment });
   const requestingSiteId = req.app.locals.config.website('id');
 

--- a/packages/marko-web/utils/build-content-input.js
+++ b/packages/marko-web/utils/build-content-input.js
@@ -1,6 +1,9 @@
-module.exports = ({ req }) => {
+module.exports = ({ req, contentIdStatusExceptions }) => {
   const input = {};
-  if (req.cookies['preview-mode'] || req.query['preview-mode']) {
+  if (req.cookies['preview-mode']
+    || req.query['preview-mode']
+    || contentIdStatusExceptions.includes(Number(req.params.id))
+  ) {
     input.status = 'any';
   } else {
     input.since = Date.now();

--- a/packages/marko-web/utils/build-content-input.js
+++ b/packages/marko-web/utils/build-content-input.js
@@ -1,9 +1,6 @@
-module.exports = ({ req, contentIdStatusExceptions }) => {
+module.exports = ({ req }) => {
   const input = {};
-  if (req.cookies['preview-mode']
-    || req.query['preview-mode']
-    || contentIdStatusExceptions.includes(Number(req.params.id))
-  ) {
+  if (req.cookies['preview-mode'] || req.query['preview-mode']) {
     input.status = 'any';
   } else {
     input.since = Date.now();

--- a/packages/web-common/src/page-loaders/content.js
+++ b/packages/web-common/src/page-loaders/content.js
@@ -26,6 +26,14 @@ module.exports = async (apolloClient, {
   const { content } = data;
 
   if (!content) {
+    // Try again except this time using status deleted
+    const { data: deletedData } = await apolloClient.query({
+      query: buildQuery({ queryFragment }),
+      variables: { input: { id: Number(id), status: 'deleted' } },
+    });
+    const { content: deletedContent } = deletedData;
+    if (deletedContent) return { ...deletedContent, deletedContent: true };
+
     // No content was found for this id. Return a 404.
     throw createError(404, `No content was found for id '${id}'`);
   }


### PR DESCRIPTION
Due to the content routes across all sites matching on 8 digit IDs, additional handling must be done here in order to verify that the 8 digits passed in are indeed a valid Base content ID for the given tenant to allow for additional handling elsewhere, by which deleted items can be handled via the redirectToFn function by which will then redirect based on the returned item when applicable otherwise these will error with a distinct "published content" qualifier in their error message.

In my testing this cannot simply be handled in the Express redirectHandler pass-through function outlined/passed through via these files: https://github.com/parameter1/base-cms/blob/master/packages/marko-web/start-server.js#L120 https://github.com/parameter1/base-cms/blob/master/packages/marko-web/express/error-handlers.js#L55 https://github.com/parameter1/base-cms/blob/master/packages/marko-web/express/get-redirect.js#L36 as the content routing hard errors prior to these being reached when a content item is not found with the appropriate status due to this 8 digit ID match.

![Screenshot from 2023-12-27 17-15-54](https://github.com/parameter1/base-cms/assets/46794001/beaa4fc0-5845-4799-9ac7-5c89a909136a)
