### PR TITLE
Properly support all allowed input fields `magazineScheduledContent` query

### DIFF
--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1307,7 +1307,7 @@ module.exports = {
         idQuery.section = {
           ...(sectionId && { $eq: sectionId }),
           ...(include.length && { $in: include.map((section) => section._id) }),
-          ...(exclude.length && {
+          ...((exclude.length || excludeSectionIds.length) && {
             $nin: [
               ...exclude.map((section) => section._id),
               ...excludeSectionIds,


### PR DESCRIPTION
This allows all the fields defined here: https://github.com/parameter1/base-cms/blob/master/services/graphql-server/src/graphql/definitions/platform/content/index.js#L648 to be properly utilized via the respective resolver.