### PR TITLE
Allow all input fields in `magazine-scheduled-content` block-loader

### DIFF
--- a/packages/web-common/src/block-loaders/magazine-scheduled-content.js
+++ b/packages/web-common/src/block-loaders/magazine-scheduled-content.js
@@ -19,9 +19,13 @@ module.exports = async (apolloClient, {
   skip,
   after,
   issueId,
+  sectionId,
   excludeContentIds,
   includeSectionNames,
   excludeSectionNames,
+  excludeContentTypes,
+  includeContentTypes,
+  requiresImage,
   sort,
   queryFragment,
   queryName,
@@ -31,9 +35,13 @@ module.exports = async (apolloClient, {
     sort,
     pagination,
     issueId,
+    sectionId,
     excludeContentIds,
     includeSectionNames,
     excludeSectionNames,
+    excludeContentTypes,
+    includeContentTypes,
+    requiresImage,
   };
   const query = buildQuery({ queryFragment, queryName });
   const variables = { input };


### PR DESCRIPTION
Missed in https://github.com/parameter1/base-cms/pull/841 this now updates the block-loader utilized by the sites to accept the same input as documented here: https://github.com/parameter1/base-cms/blob/master/services/graphql-server/src/graphql/definitions/platform/content/index.js#L648