### PR TITLE
Query for taxonomyIds and relatedSectionIds separately, Leaders Contextual

### DIFF
--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -331,11 +331,19 @@ export default {
         }
       }
       if (!taxonomyIds.length && !sectionIds.length) return [];
-      const v2 = { taxonomyIds, relatedSectionIds: sectionIds };
+      const v2 = { taxonomyIds: [], relatedSectionIds: sectionIds };
       const r2 = await this.$graphql.query({ query: fromContentQuery, variables: v2 });
       const sections = getEdgeNodes(r2, 'data.websiteSections');
-      return sections
+      const applicableSections = sections
         .filter((s) => s.hierarchy.some(({ alias }) => alias === this.sectionAlias));
+      if (applicableSections.length) return applicableSections;
+      const v3 = { taxonomyIds: [], relatedSectionIds: [] };
+      const r3 = await this.$graphql.query({ query: fromContentQuery, variables: v3 });
+      const taxonomyRelatedSections = getEdgeNodes(r3, 'data.websiteSections');
+      const lastChanceSections = taxonomyRelatedSections
+        .filter((s) => s.hierarchy.some(({ alias }) => alias === this.sectionAlias));
+      if (lastChanceSections.length) return lastChanceSections;
+      return [];
     },
 
     async loadAllSections() {

--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -331,18 +331,22 @@ export default {
         }
       }
       if (!taxonomyIds.length && !sectionIds.length) return [];
-      const v2 = { taxonomyIds: [], relatedSectionIds: sectionIds };
-      const r2 = await this.$graphql.query({ query: fromContentQuery, variables: v2 });
-      const sections = getEdgeNodes(r2, 'data.websiteSections');
-      const applicableSections = sections
-        .filter((s) => s.hierarchy.some(({ alias }) => alias === this.sectionAlias));
-      if (applicableSections.length) return applicableSections;
-      const v3 = { taxonomyIds: [], relatedSectionIds: [] };
-      const r3 = await this.$graphql.query({ query: fromContentQuery, variables: v3 });
-      const taxonomyRelatedSections = getEdgeNodes(r3, 'data.websiteSections');
-      const lastChanceSections = taxonomyRelatedSections
-        .filter((s) => s.hierarchy.some(({ alias }) => alias === this.sectionAlias));
-      if (lastChanceSections.length) return lastChanceSections;
+      if (sectionIds.length) {
+        const v2 = { taxonomyIds: [], relatedSectionIds: sectionIds };
+        const r2 = await this.$graphql.query({ query: fromContentQuery, variables: v2 });
+        const sections = getEdgeNodes(r2, 'data.websiteSections');
+        const applicableSections = sections
+          .filter((s) => s.hierarchy.some(({ alias }) => alias === this.sectionAlias));
+        if (applicableSections.length) return applicableSections;
+      }
+      if (taxonomyIds.length) {
+        const v3 = { taxonomyIds, relatedSectionIds: [] };
+        const r3 = await this.$graphql.query({ query: fromContentQuery, variables: v3 });
+        const taxonomyRelatedSections = getEdgeNodes(r3, 'data.websiteSections');
+        const lastChanceSections = taxonomyRelatedSections
+          .filter((s) => s.hierarchy.some(({ alias }) => alias === this.sectionAlias));
+        if (lastChanceSections.length) return lastChanceSections;
+      }
       return [];
     },
 


### PR DESCRIPTION
Using: https://www.packworld.com/news/sustainability/article/21577187/sacred-serve-debuts-first-100-recyclable-ice-cream-carton as an example

Previous query logic:
![image](https://github.com/parameter1/base-cms/assets/46794001/a0fbb907-d849-42d4-8e7c-38d98ab66ef9)

This PR's query logic:
![image](https://github.com/parameter1/base-cms/assets/46794001/56ef7f98-8b80-4cc4-9ef1-df21e8117bf7)

Page following change in query logic (in conjunction with appropriately including the `useContentSchedules` prop)
![image](https://github.com/parameter1/base-cms/assets/46794001/c4afac76-ba9a-4385-ad0c-0622b49be7ed)