### PR TITLE
Add missing allowed fields, Omeda Identity-X Rapid Identify

### DIFF
--- a/packages/marko-web-omeda-identity-x/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/rapid-identify.js
@@ -55,6 +55,10 @@ module.exports = async ({
     countryCode,
     regionCode,
     postalCode,
+    street,
+    addressExtra,
+    city,
+    phoneNumber,
   } = appUser;
 
   let alpha3;
@@ -148,6 +152,10 @@ module.exports = async ({
     ...(alpha3 && { countryCode: alpha3 }),
     ...(regionCode && { regionCode }),
     ...(postalCode && { postalCode }),
+    ...(street && { street }),
+    ...(addressExtra && { addressExtra }),
+    ...(city && { city }),
+    ...(phoneNumber && { phoneNumber }),
     ...(demographics.length && { demographics }),
     ...(behaviors.length && { behaviors }),
     ...(deploymentTypes.length && { deploymentTypes }),


### PR DESCRIPTION
Ultimately this calls: https://github.com/parameter1/base-cms/blob/master/packages/marko-web-omeda/rapid-identify.js#L40 which supports these additional fields to be included which was resulting in records in Identity-X having them but the data stored within them not being sent to Omeda.


I confirmed via my Omeda record for allured that the appropriate information is pushed.