### PR TITLE
Send `{ actionSource }` prop when emitting the login-mounted event & add queryString debug support for identityX event emitter

### DIFF
--- a/packages/marko-web-identity-x/browser/index.js
+++ b/packages/marko-web-identity-x/browser/index.js
@@ -102,7 +102,7 @@ export default (Browser, {
       };
       const { searchParams } = new URL(window.location.href);
       if (searchParams.has('idxDebugger')) {
-        log(`identity-x event: ${event}) `, payload);
+        log(`identity-x event: ${event} `, payload);
       }
       window.dataLayer.push(payload);
     });

--- a/packages/marko-web-identity-x/browser/index.js
+++ b/packages/marko-web-identity-x/browser/index.js
@@ -13,6 +13,8 @@ const CommentStream = () => import(/* webpackChunkName: "identity-x-comment-stre
 
 const $graphql = createGraphqlClient({ uri: '/__graphql' });
 
+const { log } = console;
+
 export default (Browser, {
   CustomAccessComponent,
   CustomAuthenticateComponent,
@@ -91,13 +93,18 @@ export default (Browser, {
   ].forEach((event) => {
     EventBus.$on(event, (args) => {
       if (!window.IdentityX) return;
-      window.dataLayer.push({
+      const payload = {
         event,
         'identity-x': {
           ...args,
           event,
         },
-      });
+      };
+      const { searchParams } = new URL(window.location.href);
+      if (searchParams.has('idxDebugger')) {
+        log(`identity-x event: ${event}) `, payload);
+      }
+      window.dataLayer.push(payload);
     });
   });
 };

--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -268,7 +268,14 @@ export default {
    */
   mounted() {
     if (cookiesEnabled()) {
-      this.emit('login-mounted', this.data);
+      const data = {
+        actionSource: this.source,
+        additionalEventData: {
+          ...this.additionalEventData,
+          actionSource: this.source,
+        }
+      };
+      this.emit('login-mounted', data);
     } else {
       this.error = new FeatureError('Your browser does not support cookies. Please enable cookies to use this feature.');
       this.emit('login-errored', { message: this.error.message });

--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -268,14 +268,7 @@ export default {
    */
   mounted() {
     if (cookiesEnabled()) {
-      const data = {
-        actionSource: this.source,
-        additionalEventData: {
-          ...this.additionalEventData,
-          actionSource: this.source,
-        }
-      };
-      this.emit('login-mounted', data);
+      this.emit('login-mounted', { actionSource: this.source });
     } else {
       this.error = new FeatureError('Your browser does not support cookies. Please enable cookies to use this feature.');
       this.emit('login-errored', { message: this.error.message });

--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -268,7 +268,7 @@ export default {
    */
   mounted() {
     if (cookiesEnabled()) {
-      this.emit('login-mounted');
+      this.emit('login-mounted', this.data);
     } else {
       this.error = new FeatureError('Your browser does not support cookies. Please enable cookies to use this feature.');
       this.emit('login-errored', { message: this.error.message });

--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -4,6 +4,8 @@
 
 <script>
 
+const { log } = console;
+
 export default {
   props: {
     views: {
@@ -39,7 +41,7 @@ export default {
       if (event[0].isIntersecting) {
         const { dataLayer } = window;
         if (dataLayer) {
-          dataLayer.push({
+          const payload = {
             event: 'identity-x-content-meter-view',
             'identity-x': {
               label: 'content-meter',
@@ -47,7 +49,12 @@ export default {
               remaining,
               overlayDisplayed,
             },
-          });
+          };
+          dataLayer.push(payload);
+          const { searchParams } = new URL(window.location.href);
+          if (searchParams.has('idxDebugger')) {
+            log('identity-x event: identity-x-content-meter-view', payload);
+          }
         }
       }
     });


### PR DESCRIPTION
This will ensure that the actionSource is being passed in & set correctly vs reading the actionSource off of the window.identityX.getActionSource() fallback.  See the emit call in [global-event-emitter mixin](https://github.com/parameter1/base-cms/blob/master/packages/marko-web-identity-x/browser/mixins/global-event-emitter.js#L13). 

This will ensure that login form events are being emitted with the corresponding actionSources as well.  

New example content-meter login form mounted call emits the action of login-mounted with a payload: 
```js
{
    "actionSource": "content_meter_login",
    "promoCode": "registration_meter",
    "views": 1,
    "viewLimit": 2,
    "displayGate": true,
    "displayOverlay": false,
    "contentGateType": "metered",
    "additionalEventData": {
        "promoCode": "registration_meter",
        "views": 1,
        "viewLimit": 2,
        "displayGate": true,
        "displayOverlay": false,
        "contentGateType": "metered"
    },
    "loginSource": "content_meter_login",
    "source": "content_meter_login"
}
```

Also with this update it ensure things like the mounted event emitters in comment login and such are correctly referencing the actionSource 
```js
{
    "identifier": "15663175",
    "additionalEventData": {},
    "actionSource": "comments",
    "loginSource": "comments",
    "source": "comments"
}
vs
{
    "identifier": "15663104",
    "additionalEventData": {},
    "actionSource": "default",
    "loginSource": "default",
    "source": "default"
}
```