### PR TITLE
Add unified email-x render component

### DIFF
--- a/packages/marko-newsletters-email-x/components/marko.json
+++ b/packages/marko-newsletters-email-x/components/marko.json
@@ -33,5 +33,25 @@
       "@include-advertiser": "boolean"
     },
     "@decoded-params":  "array"
+  },
+  "<marko-newsletters-email-x-render>": {
+    "template": "./render.marko",
+    "<response>": {
+      "<data>": {
+        "<ad>": {
+          "@height": "number",
+          "@mindfulCreativeId": "string",
+          "@width": "number"
+        }
+      },
+      "@imageSrc": "string"
+    },
+    "<link>": {
+      "@href": "string",
+      "@attrs": "object"
+    },
+    "<image>": {
+      "@attrs": "object"
+    }
   }
 }

--- a/packages/marko-newsletters-email-x/components/render.marko
+++ b/packages/marko-newsletters-email-x/components/render.marko
@@ -1,0 +1,25 @@
+import { getAsObject, get } from "@parameter1/base-cms-object-path";
+
+$ const response = getAsObject(input, "response");
+$ const imageSrc = get(input, "response.imageSrc");
+$ const { ad } = response.data;
+
+$ const imageAttrs = {
+  ...getAsObject(input, "image.attrs"),
+  width: ad.width,
+  height: ad.height,
+};
+
+$ const mindfulCreativeId = get(response, "data.ad.mindfulCreativeId");
+$ const linkAttrs = {
+  href: ad.url,
+  ...(getAsObject(input, "link")),
+  attrs: {
+    ...(getAsObject(input, "link.attrs")),
+    ...(mindfulCreativeId && { "data-mindful-creative-id": mindfulCreativeId }),
+  },
+};
+
+<marko-core-img ...input.image src=imageSrc attrs=imageAttrs>
+  <@link target="_blank" ...linkAttrs />
+</marko-core-img>


### PR DESCRIPTION
Extracts the reusable rendering logic for EmailX ads into a new component.