### PR TITLE
Add login-link-sent event listener & class setter to content meter tracker component

### DIFF
--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -1,10 +1,12 @@
 <template>
-  <div id="content-meter-gtm-event" />
+  <div id="content-meter-gtm-event" :class="classes.join(', ')"/>
 </template>
 
 <script>
 
 export default {
+  inject: ['EventBus'],
+
   props: {
     views: {
       type: Number,
@@ -23,6 +25,9 @@ export default {
       required: false,
     },
   },
+  data: () => ({
+    classes: [],
+  }),
   computed: {
     remaining() {
       const { viewLimit, views } = this;
@@ -54,6 +59,11 @@ export default {
   },
   mounted() {
     this.observer.observe(this.$el);
+    this.EventBus.$on('identity-x-login-link-sent', ({ actionSource }) => {
+      if (actionSource === 'content_meter_login') {
+        this.classes.push('login-link-sent');
+      }
+    });
   },
 };
 </script>

--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -184,5 +184,7 @@ export default (Browser, configOverrides = {}) => {
   Browser.register('ThemeTopStoriesMenu', TopStoriesMenu);
   Browser.register('WufooForm', WufooForm);
   Browser.register('RevealAdHandler', RevealAdHandler);
-  Browser.register('ContentMeterTrack', ContentMeterTrack);
+  Browser.register('ContentMeterTrack', ContentMeterTrack, {
+    provide: { EventBus },
+  });
 };

--- a/packages/marko-web-theme-monorail/scss/components/_content-meter.scss
+++ b/packages/marko-web-theme-monorail/scss/components/_content-meter.scss
@@ -2,6 +2,12 @@ $content-meter-mobile-breakpoint: 600px !default;
 
 .content-meter {
   $self: &;
+  .login-link-sent {
+    & ~ #{ $self }__title,
+    & ~ #{ $self }__call-to-action {
+      display: none;
+    }
+  }
   &__overlay {
     z-index: 1499;
     position: fixed;


### PR DESCRIPTION
This will allow you to better target sibling elements with css when the form is submitted within the content meter.  This will allow you to hide verbiage asking the user to submit info and only show the post submit message.

### Current: 
<img width="917" alt="Screenshot 2024-02-06 at 3 18 55 PM" src="https://github.com/parameter1/base-cms/assets/3845869/30e7069a-151e-4705-9847-1bf84a521635">

### New:
<img width="836" alt="Screenshot 2024-02-06 at 3 20 05 PM" src="https://github.com/parameter1/base-cms/assets/3845869/a5608152-7aa4-4d6f-81bc-dd491a9df58f">
