### PR TITLE
Add support for passing withSponsorLogo

### DIFF
--- a/packages/marko-web-theme-monorail/components/flows/section-feed.marko
+++ b/packages/marko-web-theme-monorail/components/flows/section-feed.marko
@@ -54,6 +54,7 @@ $ const nodes = withSponsored ? setSectionNameFromLabel({
       <else>
         <theme-section-feed-content-node
           with-section=withSection
+          with-sponsor-logo=node.withSponsorLogo
           ...input.node
           node=node
           display-image=input.displayImage

--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -27,6 +27,7 @@ $ const multiDateFormats = input.multiDateFormats;
 $ const isUpcoming = content.startDate > Date.now();
 $ if (isUpcoming) modifiers.push("upcoming");
 $ const withSection = defaultValue(input.withSection, true);
+$ const withSponsorLogo = defaultValue(input.withSponsorLogo, false);
 $ const withTeaser = defaultValue(input.withTeaser, true);
 $ const displayImage = defaultValue(input.displayImage, true);
 $ const lazyload = defaultValue(input.lazyload, true);
@@ -180,13 +181,40 @@ $ const blockName = "section-feed-content-node";
         </marko-web-element>
       </if>
 
-      <marko-web-element block-name=blockName name="content-sponsors">
+      $ const hasSponsorsImage = getAsArray(content, "sponsors.edges").map(edge => getAsObject(edge, "node")).some(({primaryImage}) => primaryImage);
+      $ const sponsorsModifiers = hasSponsorsImage ? ['has-logo'] : [];
+      <marko-web-element block-name=blockName name="content-sponsors" modifiers=sponsorsModifiers>
         <marko-web-obj-nodes|{ node, index, length }| type="content" block-name=blockName obj=content field="sponsors" tag="span">
           <if(index === 0)>
             <marko-web-element tag="span" block-name=blockName name="content-sponsors-label">Sponsored By: </marko-web-element>
           </if>
-          <marko-web-content-name tag="span" block-name=blockName obj=node link=true />
-          <if(index + 1 !== length)>, </if>
+          <if(withSponsorLogo && node.primaryImage)>
+            $ const src = buildImgixUrl(node.primaryImage.src, imageOptions, null, true);
+            $ const srcset = [src, `${buildImgixUrl(src, { dpr: 2 })} 2x`];
+
+            $ const srcMobile = buildImgixUrl(node.primaryImage.src, mobileImageOptions, null, true);
+            $ const srcsetMobile = [srcMobile, `${buildImgixUrl(srcMobile, { dpr: 2 })} 2x`];
+            $ const link = linkField && get(node, linkField) ? get(node, linkField) : get(node, "siteContext.path");
+            <marko-web-picture>
+              <@link href=link target=linkTarget attrs=linkAttrs />
+              <@source srcset=srcset media="(min-width: 768px)" width=120 height=80 />
+              <@image
+                src=srcMobile
+                srcset=srcsetMobile
+                class=[`${blockName}__image`]
+                alt=node.primaryImage.alt
+                lazyload=lazyload
+                attrs={ width: "120", height: "80" }
+              />
+            </marko-web-picture>
+          </if>
+          <else>
+            <marko-web-content-name tag="span" block-name=blockName obj=node link=true />
+          </else>
+
+          <if(index + 1 !== length && !hasSponsorsImage)>
+            <marko-web-element tag="span" block-name=blockName name="contentsponsors-seporator">, </marko-web-element>
+          </if>
         </marko-web-obj-nodes>
       </marko-web-element>
       <!-- Force display of CTA button on webinars -->

--- a/packages/marko-web-theme-monorail/graphql/fragments/section-feed-block.js
+++ b/packages/marko-web-theme-monorail/graphql/fragments/section-feed-block.js
@@ -38,6 +38,12 @@ fragment SectionFeedBlockContentFragment on Content {
         node {
           id
           name
+          primaryImage {
+            id
+            src(input: { options: { auto: "format,compress" } })
+            alt
+            isLogo
+          }
           siteContext {
             path
           }

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
@@ -120,6 +120,22 @@
     @include skin-typography($style: "date");
   }
 
+  &__content-sponsors {
+    #{ $self }__content-sponsors-label {
+      @include skin-typography($style: "teaser-text-1", $link-style: "primary", $breakpoint: sm);
+      font-weight: $font-weight-bold;
+    }
+    &--has-logo {
+      #{ $self }__content-sponsors {
+        display: flex;
+        flex-direction: column;
+        .content-sponsors-seporator {
+          display: none;
+        }
+      }
+    }
+  }
+
   &--full-width-native-ad {
     padding: 24px;
     background-color: $gray-100;


### PR DESCRIPTION
Add ability to pass withSponsorLogo prop to section-feed-content flow and node.  This will allow for the display of the sponsor logos vs names in the section feed flow.

**The below would [require](https://github.com/parameter1/bobit-business-media-websites/pull/173).**
<img width="1081" alt="Screenshot 2024-02-09 at 2 28 51 PM" src="https://github.com/parameter1/base-cms/assets/3845869/6d29928b-bcd6-44ef-ba44-17f55eb411d8">

**The below would requie adding `withSponsorLogo: true,` [here](https://github.com/parameter1/watt-global-media-websites/blob/master/packages/global/templates/website-section/webinars.marko#L13)ish.**
![Screenshot 2024-02-11 at 8 03 17 AM](https://github.com/parameter1/base-cms/assets/3845869/47a2f752-7cee-4297-8723-640594e173c5)

