### PR TITLE
Support for alias based search routing

### DIFF
--- a/packages/marko-web-search/components/build-href.marko
+++ b/packages/marko-web-search/components/build-href.marko
@@ -1,10 +1,14 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { cleanPath } from "@parameter1/base-cms-utils";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { req, $markoWebSearch: search } = out.global;
 $ const path = defaultValue(input.path, req.path);
+$ const rootAlias = get(search, "config.rootAlias");
 
-$ const queryString = search.buildQueryString(input.queryValues);
+$ const omit = rootAlias && rootaAlias !== "search" ? { assignedToWebsiteSectionIds: true } : {}
+
+$ const queryString = search.buildQueryString(input.queryValues, omit);
 $ const href = `/${cleanPath(path)}${queryString}`;
 
 <${input.renderBody} href=href />

--- a/packages/marko-web-search/components/build-href.marko
+++ b/packages/marko-web-search/components/build-href.marko
@@ -6,7 +6,7 @@ $ const { req, $markoWebSearch: search } = out.global;
 $ const path = defaultValue(input.path, req.path);
 $ const rootAlias = get(search, "config.rootAlias");
 
-$ const omit = rootAlias && rootaAlias !== "search" ? { assignedToWebsiteSectionIds: true } : {}
+$ const omit = rootAlias && rootAlias !== "search" ? { assignedToWebsiteSectionIds: true } : {}
 
 $ const queryString = search.buildQueryString(input.queryValues, omit);
 $ const href = `/${cleanPath(path)}${queryString}`;

--- a/packages/marko-web-search/components/filters/load-website-sections.js
+++ b/packages/marko-web-search/components/filters/load-website-sections.js
@@ -5,16 +5,19 @@ const selectedQueryFragment = gql`
   fragment MarkoWebSearchSeletedWebsiteSectionFragment on WebsiteSection {
     id
     name
+    alias
     isRoot
     hierarchy {
       id
       name
+      alias
     }
     children(input: { pagination: { limit: 100 }, sort: { field: name, order: asc } }) {
       edges {
         node {
           id
           name
+          alias
         }
       }
     }

--- a/packages/marko-web-search/components/filters/marko.json
+++ b/packages/marko-web-search/components/filters/marko.json
@@ -29,5 +29,8 @@
   },
   "<marko-web-search-website-sections-filter>": {
     "template": "./website-sections.marko"
+  },
+  "<marko-web-search-website-sections-by-alias-filter>": {
+    "template": "./website-sections-by-alias.marko"
   }
 }

--- a/packages/marko-web-search/components/filters/selected/item.marko
+++ b/packages/marko-web-search/components/filters/selected/item.marko
@@ -1,5 +1,9 @@
+import { get } from "@parameter1/base-cms-object-path";
+
+$ const { $markoWebSearch: search } = out.global;
 $ const blockName = "marko-web-search-selected-filter";
 $ const { prefix } = input;
+$ const path = get(search, "config.rootAlias");
 
 <marko-web-block name=blockName>
   <marko-web-element block-name=blockName name="label">
@@ -10,7 +14,7 @@ $ const { prefix } = input;
       ${input.label}
     </else>
   </marko-web-element>
-  <marko-web-search-reset-filter-link name=input.filterKey class=`${blockName}__reset`>
+  <marko-web-search-reset-filter-link name=input.filterKey path=path class=`${blockName}__reset`>
     <marko-web-icon name="x" modifiers=[blockName] />
   </marko-web-search-reset-filter-link>
 </marko-web-block>

--- a/packages/marko-web-search/components/filters/website-sections-by-alias.marko
+++ b/packages/marko-web-search/components/filters/website-sections-by-alias.marko
@@ -1,0 +1,46 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+import { isFunction } from '@parameter1/base-cms-utils';
+import loadWebsiteSections from "./load-website-sections";
+
+$ const { $markoWebSearch, apollo, i18n } = out.global;
+$ const filterKey = "assignedToWebsiteSectionIds";
+$ const title = isFunction(i18n) ? i18n("Website Sections") : "Website Sections";
+
+<marko-web-resolve|{ resolved }| promise=loadWebsiteSections({
+  $markoWebSearch,
+  apolloBaseCMS: apollo,
+})>
+  $ const { selectedSection, configuredSections } = resolved;
+  <marko-web-search-filter-block filter-key=filterKey items=configuredSections>
+    <@title value=title />
+    <@item|{ node, blockName }|>
+      <if(selectedSection && selectedSection.hierarchyMap.has(node.id))>
+        $ // loop through hierarchy to create "breadcrumb" links
+        $ const { hierarchy } = selectedSection;
+        <marko-web-element block-name=blockName name="item" modifiers=["breadcrumbs"]>
+          <for|section| of=hierarchy>
+            <marko-web-search-set-filter-value-link path=section.alias name=filterKey value=section.id reset-class=`${blockName}__clear-item`>
+              ${section.name}
+            </marko-web-search-set-filter-value-link>
+          </for>
+        </marko-web-element>
+
+        $ // then display children
+        $ const children = getAsArray(selectedSection, "children.edges").map(edge => edge.node);
+        <marko-web-search-filter-block filter-key=filterKey items=children modifiers=["children"]>
+          <@item|{ node: child, blockName }|>
+            <marko-web-search-set-filter-value-link path=child.alias name=filterKey reset-class=`${blockName}__clear-item`>
+              ${child.name}
+            </marko-web-search-set-filter-value-link>
+          </@item>
+        </marko-web-search-filter-block>
+      </if>
+      <else>
+        $ // display the "normal" section
+        <marko-web-search-set-filter-value-link path=node.alias name=filterKey>
+          ${node.name}
+        </marko-web-search-set-filter-value-link>
+      </else>
+    </@item>
+  </marko-web-search-filter-block>
+</marko-web-resolve>

--- a/packages/marko-web-search/config/index.js
+++ b/packages/marko-web-search/config/index.js
@@ -24,6 +24,7 @@ class MarkoWebSearchConfig {
    *                                                      Defaults to none. Should be an array of
    *                                                      section IDs, e.g. [123, 321]
    *
+   * @param {string} [params.rootAlias] The root alias for the search page defaults to 'search'
    */
   constructor(params = {}) {
     const {
@@ -31,6 +32,7 @@ class MarkoWebSearchConfig {
       contentTypes,
       assignedToWebsiteSectionIds,
       defaultSortField,
+      rootAlias,
     } = validate(Joi.object({
       resultsPerPage: Joi.object({
         min: Joi.number().integer().default(1),
@@ -51,6 +53,8 @@ class MarkoWebSearchConfig {
       ).default([]),
 
       defaultSortField: Joi.string().allow('NAME', 'PUBLISHED', 'SCORE').default('PUBLISHED'),
+
+      rootAlias: Joi.string().default('search'),
     }).default(), params);
 
     this.contentTypeObjects = contentTypes.sort().map((type) => (type.label ? ({
@@ -73,6 +77,7 @@ class MarkoWebSearchConfig {
       contentTypeIds: this.contentTypeObjects.map(({ id }) => id),
       defaultSortField,
     });
+    this.rootAlias = rootAlias;
   }
 }
 


### PR DESCRIPTION
When `rootAlias` is passed in and set to something aside from `search` MarkoWebSearch, will now operate via an "alias based" approach, by which something like `directory/engineering-design-construction-services?contentTypes=COMPANY`

Will result in the following: 
![image](https://github.com/parameter1/base-cms/assets/46794001/572f23e3-f1d1-4f19-831b-42f6ef55d9ee)

If this behavior is opted into use of `marko-web-search-website-sections-filter` will need to be replaced with `marko-web-search-website-sections-by-alias-filter` and can otherwise be used identically.

This needs to be use _in conjunction_ with the `assignedToWebsiteSectionIds` configuration option to load the initial section list into `marko-web-search-website-sections-by-alias-filter`.