### PR TITLE
Only "path reset" using configured `rootAlias` when applicable

### DIFF
--- a/packages/marko-web-search/components/filters/selected/item.marko
+++ b/packages/marko-web-search/components/filters/selected/item.marko
@@ -14,7 +14,14 @@ $ const path = get(search, "config.rootAlias");
       ${input.label}
     </else>
   </marko-web-element>
-  <marko-web-search-reset-filter-link name=input.filterKey path=path class=`${blockName}__reset`>
-    <marko-web-icon name="x" modifiers=[blockName] />
-  </marko-web-search-reset-filter-link>
+  <if(input.filterKey === "assignedToWebsiteSectionIds" && path !== "search")>
+    <marko-web-search-reset-filter-link name=input.filterKey path=path class=`${blockName}__reset`>
+      <marko-web-icon name="x" modifiers=[blockName] />
+    </marko-web-search-reset-filter-link>
+  </if>
+  <else>
+    <marko-web-search-reset-filter-link name=input.filterKey class=`${blockName}__reset`>
+      <marko-web-icon name="x" modifiers=[blockName] />
+    </marko-web-search-reset-filter-link>
+  </else>
 </marko-web-block>


### PR DESCRIPTION
Missed in https://github.com/parameter1/base-cms/pull/869 this would cause when non-section based filters were removed to also reset the routing path to the configured `rootAlias`

Screenshot showing example of corrected behavior when going to remove the Company content type filter.
![image](https://github.com/parameter1/base-cms/assets/46794001/a1b37105-8280-4fda-aa87-b8599abfb067)
