### PR TITLE
Update validation & spreading of idnetity-x-inline-form prop util

### DIFF
--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
@@ -81,7 +81,7 @@ export default {
     modifiers: {
       type: Array,
       default: () => ['large'],
-      validator: (v) => v.every((val) => ['large', 'footer'].includes(val)),
+      validator: (v) => v.every((val) => ['large', 'footer', 'modal'].includes(val)),
     },
     disabled: {
       type: Boolean,

--- a/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
+++ b/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
@@ -47,6 +47,7 @@ module.exports = ({ out, input }) => {
     redirect: input.redirect,
     loginEmailPlaceholder,
     loginEmailLabel: input.loginEmailLabel,
+    modifiers: input.modifiers,
     actionText: input.actionText,
     consentPolicy: input.consentPolicy || get(application, 'organization.consentPolicy'),
     emailConsentRequest: get(application, 'organization.emailConsentRequest'),

--- a/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
+++ b/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
@@ -31,8 +31,8 @@ module.exports = ({ out, input }) => {
   const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
 
   return {
-    imageSrc: withImage && imageSrc,
-    imageSrcset: withImage && imageSrcset,
+    ...((withImage && imageSrc) && { imageSrc }),
+    ...((withImage && imageSrcset) && { imageSrcset }),
     siteName: config.website('name'),
     name,
     description,

--- a/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
+++ b/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
@@ -12,7 +12,7 @@ module.exports = ({ out, input }) => {
   const source = defaultValue(input.source, 'newsletterSignup');
   const configName = defaultValue(input.configName, 'signupBanner');
   const newsletterSignupType = defaultValue(input.type, 'default');
-  const validTypes = ['inlineContent', 'inlineSection', 'footer'];
+  const validTypes = ['inlineContent', 'inlineSection', 'footer', 'modal'];
   const withImage = defaultValue(input.withImage, true);
 
   if (!validTypes.includes(newsletterSignupType)) {


### PR DESCRIPTION
**@NOTE: If modal support is going to be fully integrated with omeda customers we will need to also update https://github.com/parameter1/identity-x-omeda-cli  package to generate a new Parameter1 Newsletter Signup Type & the corresponding values will have to be generated and added to the corresponding configs.**  

 - Add validation for `modal` type
 - Correctly spread imgSrc & imSrcset when present..... currently it will spread a boolean vs a string if with image is false. :( 
 - Pass through modifiers if they are set on input.  
 
 These are required to correctly implement https://github.com/parameter1/science-medicine-group-websites/pull/502