### PR TITLE
Limit user values being returned on loginLinkSend response

### DIFF
--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -81,5 +81,6 @@ module.exports = asyncRoute(async (req, res) => {
     redirectTo,
     additionalEventData,
   });
-  return res.json({ ok: true, additionalEventData });
+  const returnedAppUser = { id: appUser.id, email: appUser.email };
+  return res.json({ ok: true, additionalEventData, appUser: returnedAppUser });
 });

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -81,5 +81,5 @@ module.exports = asyncRoute(async (req, res) => {
     redirectTo,
     additionalEventData,
   });
-  return res.json({ ok: true, additionalEventData, appUser });
+  return res.json({ ok: true, additionalEventData });
 });


### PR DESCRIPTION
Limit the values being returned on appUser to id and email.  the new response object pushed with the login link sent event should look like: 
```js
{
    "ok": true,
    "additionalEventData": {
        "actionSource": "default"
    },
    "appUser": {
        "id": "64aff722628cfd445867c788",
        "email": "brian@parameter1.com"
    }
}
```

None of this is being utilized in the response from what I can tell: https://github.com/parameter1/base-cms/blob/master/packages/marko-web-identity-x/browser/login.vue#L289.

Was put in place, I believe, in an attempt to determine the creation of a new user within IdentityX.  This is no longer being handled in this way. 

**Related PR:**
 - [Removes custom event emitter - NEED TO BE MERGED](https://github.com/parameter1/randall-reilly-websites/pull/556)
 - [Original PR adding this](https://github.com/parameter1/base-cms/pull/569)
 - [PR with ref to GTM changes no longer in use](https://github.com/parameter1/randall-reilly-websites/pull/511)