### PR TITLE
Add IdentityX Entity prop to IdX submit events

### DIFF
--- a/packages/marko-web-identity-x/browser/access.vue
+++ b/packages/marko-web-identity-x/browser/access.vue
@@ -313,7 +313,7 @@ export default {
           contentType: content.type,
           userId: this.user.id,
           additionalEventData,
-        });
+        }, data.entity);
 
         if (withReload) {
           this.handleReload();

--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -251,7 +251,7 @@ export default {
             ...(this.additionalEventData || {}),
             ...(data.additionalEventData || {}),
           },
-        });
+        }, data.entity);
 
         if (!this.showProfileForm) this.redirect();
       } catch (e) {

--- a/packages/marko-web-identity-x/browser/change-email-confirm.vue
+++ b/packages/marko-web-identity-x/browser/change-email-confirm.vue
@@ -93,7 +93,7 @@ export default {
 
         if (!res.ok) throw new AuthenticationError(data.message, res.status);
 
-        this.emit('change-email', { data });
+        this.emit('change-email', { data }, data.entity);
 
         this.redirect();
       } catch (e) {

--- a/packages/marko-web-identity-x/browser/change-email-init.vue
+++ b/packages/marko-web-identity-x/browser/change-email-init.vue
@@ -166,7 +166,7 @@ export default {
         const data = await res.json();
         if (!res.ok) throw new FormError(data.message, res.status);
         this.complete = true;
-        this.emit('change-email-link-sent', { data, email: this.email });
+        this.emit('change-email-link-sent', { data, email: this.email }, data.entity);
       } catch (e) {
         this.error = e;
         this.emit('change-email-errored', { message: e.message });

--- a/packages/marko-web-identity-x/browser/download.vue
+++ b/packages/marko-web-identity-x/browser/download.vue
@@ -290,7 +290,7 @@ export default {
       // Only emit event once when downloading
       if (!this.downloaded.includes(content.id)) {
         const company = content.company || {};
-        await post('/download', {
+        const { entity } = await post('/download', {
           contentId: content.id,
           contentType: content.type,
           companyId: company.id,
@@ -328,7 +328,7 @@ export default {
           companyId: company.id,
           userId: this.user.id,
           additionalEventData,
-        });
+        }, entity);
         this.downloaded.push(content.id);
       }
 

--- a/packages/marko-web-identity-x/browser/login.vue
+++ b/packages/marko-web-identity-x/browser/login.vue
@@ -300,6 +300,7 @@ export default {
           },
         });
         const data = await res.json();
+        const { entity } = data;
         if (!res.ok) {
           if (data.requiresUserInput) {
             this.requiresUserInput = true;
@@ -317,7 +318,7 @@ export default {
             ...(this.additionalEventData || {}),
             ...(data.additionalEventData || {}),
           },
-        });
+        }, entity);
       } catch (e) {
         this.error = e;
         this.emit('login-errored', { message: e.message });

--- a/packages/marko-web-identity-x/browser/mixins/global-event-emitter.js
+++ b/packages/marko-web-identity-x/browser/mixins/global-event-emitter.js
@@ -7,7 +7,7 @@ export default {
     },
   },
   methods: {
-    emit(name, data) {
+    emit(name, data, entity) {
       const source = this.loginSource || this.source;
       const dataActionSource = data ? data.actionSource : undefined;
       const actionSource = dataActionSource || window.IdentityX.getLoginSource() || source;
@@ -18,6 +18,7 @@ export default {
         actionSource,
         loginSource: actionSource,
         source: actionSource,
+        entity,
       };
       const { EventBus } = this;
       this.$emit(name, payload);

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -606,7 +606,7 @@ export default {
             ...(this.additionalEventData || {}),
             ...(data.additionalEventData || {}),
           },
-        });
+        }, data.entity);
 
         if (this.reloadPageOnSubmit) {
           this.isReloadingPage = true;

--- a/packages/marko-web-identity-x/routes/access.js
+++ b/packages/marko-web-identity-x/routes/access.js
@@ -11,7 +11,7 @@ const mutation = gql`
 
 module.exports = asyncRoute(async (req, res) => {
   /** @type {import('../middleware').IdentityXRequest} */
-  const { body, apollo } = req;
+  const { body, apollo, identityX } = req;
   const { contentId, payload, cookie } = body;
   const input = {
     contentId,
@@ -21,5 +21,9 @@ module.exports = asyncRoute(async (req, res) => {
   const { name: COOKIE_NAME, maxAge } = cookie;
   await apollo.mutate({ mutation, variables: { input } });
   res.cookie(COOKIE_NAME, true, { maxAge, httpOnly: false });
-  res.json({ ok: true });
+  const entity = await identityX.generateEntityId();
+  res.json({
+    ok: true,
+    entity,
+  });
 });

--- a/packages/marko-web-identity-x/routes/access.js
+++ b/packages/marko-web-identity-x/routes/access.js
@@ -10,6 +10,7 @@ const mutation = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { body, apollo } = req;
   const { contentId, payload, cookie } = body;
   const input = {

--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -45,11 +45,13 @@ module.exports = asyncRoute(async (req, res) => {
   tokenCookie.setTo(res, authToken.value);
   contextCookie.setTo(res, { loginSource });
   identityX.setIdentityCookie(user.id);
+  const entity = await identityX.generateEntityId({ userId: user.id });
   res.json({
     ok: true,
     applicationId: identityX.config.getAppId(),
     user,
     loginSource,
     additionalEventData,
+    entity,
   });
 });

--- a/packages/marko-web-identity-x/routes/change-email-confirm.js
+++ b/packages/marko-web-identity-x/routes/change-email-confirm.js
@@ -51,5 +51,10 @@ module.exports = asyncRoute(async (req, res) => {
   });
   tokenCookie.setTo(res, authToken.value);
   contextCookie.setTo(res, { loginSource });
-  res.json({ ok: true, user });
+  const entity = await identityX.generateEntityId({ userId: user.id });
+  res.json({
+    ok: true,
+    user,
+    entity,
+  });
 });

--- a/packages/marko-web-identity-x/routes/change-email-confirm.js
+++ b/packages/marko-web-identity-x/routes/change-email-confirm.js
@@ -24,6 +24,7 @@ const mutation = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX, body } = req;
   const { token } = body;
   const loginSource = 'change-email';

--- a/packages/marko-web-identity-x/routes/change-email-init.js
+++ b/packages/marko-web-identity-x/routes/change-email-init.js
@@ -4,9 +4,13 @@ module.exports = asyncRoute(async (req, res) => {
   /** @type {import('../middleware').IdentityXRequest} */
   const { identityX, body } = req;
   const { email } = body;
+  const entity = await identityX.generateEntityId();
 
   // Send login link.
   await identityX.sendChangeEmailLink({ email });
   await identityX.logoutAppUser();
-  return res.json({ ok: true });
+  return res.json({
+    ok: true,
+    entity,
+  });
 });

--- a/packages/marko-web-identity-x/routes/change-email-init.js
+++ b/packages/marko-web-identity-x/routes/change-email-init.js
@@ -1,6 +1,7 @@
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX, body } = req;
   const { email } = body;
 

--- a/packages/marko-web-identity-x/routes/comment-count.js
+++ b/packages/marko-web-identity-x/routes/comment-count.js
@@ -10,6 +10,7 @@ const query = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX } = req;
   const { identifier } = req.params;
   const variables = { identifier };

--- a/packages/marko-web-identity-x/routes/comments.js
+++ b/packages/marko-web-identity-x/routes/comments.js
@@ -33,6 +33,7 @@ const query = gql`
 module.exports = asyncRoute(async (req, res) => {
   const { identifier } = req.params;
   const { after } = req.query;
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX } = req;
   const limit = after ? 20 : 5;
   const pagination = { limit, after };

--- a/packages/marko-web-identity-x/routes/countries.js
+++ b/packages/marko-web-identity-x/routes/countries.js
@@ -12,6 +12,7 @@ const localeCountries = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX } = req;
   const { data } = await identityX.client.query({ query: localeCountries });
   res.json(data.localeCountries);

--- a/packages/marko-web-identity-x/routes/create-comment.js
+++ b/packages/marko-web-identity-x/routes/create-comment.js
@@ -10,6 +10,7 @@ const mutation = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX } = req;
   const { displayName, body, stream } = req.body;
 

--- a/packages/marko-web-identity-x/routes/create-comment.js
+++ b/packages/marko-web-identity-x/routes/create-comment.js
@@ -17,5 +17,9 @@ module.exports = asyncRoute(async (req, res) => {
   const input = { displayName, body, stream };
   const variables = { input };
   await identityX.client.mutate({ mutation, variables });
-  res.json({ ok: true });
+  const entity = await identityX.generateEntityId();
+  res.json({
+    ok: true,
+    entity,
+  });
 });

--- a/packages/marko-web-identity-x/routes/download.js
+++ b/packages/marko-web-identity-x/routes/download.js
@@ -11,7 +11,7 @@ const mutation = gql`
 
 module.exports = asyncRoute(async (req, res) => {
   /** @type {import('../middleware').IdentityXRequest} */
-  const { body, apollo } = req;
+  const { body, apollo, identityX } = req;
   const { contentId, payload } = body;
   const input = {
     contentId,
@@ -19,5 +19,9 @@ module.exports = asyncRoute(async (req, res) => {
     ipAddress: req.ip,
   };
   await apollo.mutate({ mutation, variables: { input } });
-  res.json({ ok: true });
+  const entity = await identityX.generateEntityId();
+  res.json({
+    ok: true,
+    entity,
+  });
 });

--- a/packages/marko-web-identity-x/routes/download.js
+++ b/packages/marko-web-identity-x/routes/download.js
@@ -10,6 +10,7 @@ const mutation = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { body, apollo } = req;
   const { contentId, payload } = body;
   const input = {

--- a/packages/marko-web-identity-x/routes/flag-comment.js
+++ b/packages/marko-web-identity-x/routes/flag-comment.js
@@ -11,6 +11,7 @@ const mutation = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX } = req;
   const { id } = req.params;
   const variables = { id };

--- a/packages/marko-web-identity-x/routes/flag-comment.js
+++ b/packages/marko-web-identity-x/routes/flag-comment.js
@@ -16,5 +16,6 @@ module.exports = asyncRoute(async (req, res) => {
   const { id } = req.params;
   const variables = { id };
   await identityX.client.mutate({ mutation, variables });
-  res.json({ ok: true });
+  const entity = await identityX.generateEntityId();
+  res.json({ ok: true, entity });
 });

--- a/packages/marko-web-identity-x/routes/login-fields.js
+++ b/packages/marko-web-identity-x/routes/login-fields.js
@@ -30,5 +30,6 @@ module.exports = asyncRoute(async (req, res) => {
     email,
   };
   await identityX.client.mutate({ mutation, variables: { input } });
-  return res.json({ ok: true });
+  const entity = await identityX.generateEntityId();
+  return res.json({ ok: true, entity });
 });

--- a/packages/marko-web-identity-x/routes/login-fields.js
+++ b/packages/marko-web-identity-x/routes/login-fields.js
@@ -12,6 +12,7 @@ const mutation = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX, body } = req;
   const {
     email,

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -19,6 +19,7 @@ const forceProfileReVerificationUser = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX, body } = req;
   const {
     email,

--- a/packages/marko-web-identity-x/routes/login.js
+++ b/packages/marko-web-identity-x/routes/login.js
@@ -74,6 +74,7 @@ module.exports = asyncRoute(async (req, res) => {
   if (additionalEventData.forceProfileReVerification || additionalEventData.createdNewUser) {
     appUser = await identityX.loadAppUserByEmail(email);
   }
+  const entity = await identityX.generateEntityId({ userId: appUser.id });
 
   // Send login link.
   await identityX.sendLoginLink({
@@ -83,5 +84,10 @@ module.exports = asyncRoute(async (req, res) => {
     additionalEventData,
   });
   const returnedAppUser = { id: appUser.id, email: appUser.email };
-  return res.json({ ok: true, additionalEventData, appUser: returnedAppUser });
+  return res.json({
+    ok: true,
+    additionalEventData,
+    appUser: returnedAppUser,
+    entity,
+  });
 });

--- a/packages/marko-web-identity-x/routes/logout.js
+++ b/packages/marko-web-identity-x/routes/logout.js
@@ -4,6 +4,7 @@ const tokenCookie = require('../utils/token-cookie');
 const callHooksFor = require('../utils/call-hooks-for');
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX } = req;
   contextCookie.removeFrom(res);
   const token = tokenCookie.getFrom(req);

--- a/packages/marko-web-identity-x/routes/logout.js
+++ b/packages/marko-web-identity-x/routes/logout.js
@@ -13,5 +13,7 @@ module.exports = asyncRoute(async (req, res) => {
   } else {
     await identityX.logoutAppUser({ token });
   }
-  res.json({ ok: true });
+  res.json({
+    ok: true,
+  });
 });

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -129,5 +129,11 @@ module.exports = asyncRoute(async (req, res) => {
     req,
     user,
   });
-  res.json({ ok: true, user, additionalEventData });
+  const entity = await identityX.generateEntityId({ userId: user.id });
+  res.json({
+    ok: true,
+    user,
+    additionalEventData,
+    entity,
+  });
 });

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -39,6 +39,7 @@ const customSelectFieldsMutation = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX, body } = req;
   const {
     givenName,

--- a/packages/marko-web-identity-x/routes/regions.js
+++ b/packages/marko-web-identity-x/routes/regions.js
@@ -15,6 +15,7 @@ const localeRegions = gql`
 `;
 
 module.exports = asyncRoute(async (req, res) => {
+  /** @type {import('../middleware').IdentityXRequest} */
   const { identityX } = req;
   const { data } = await identityX.client.query({ query: localeRegions });
   res.json(data.localeRegions);

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -407,6 +407,20 @@ class IdentityX {
   }
 
   /**
+   * @typedef GenerateEntityIdArgs
+   * @prop {?string} appId The application id to generate for
+   * @prop {?string} userId The user id to genereate for
+   *
+   * @param {GenerateEntityIdArgs} args
+   * @returns {?string} The entityId of the active user/identity, if present.
+   */
+  async generateEntityId({ appId, userId }) {
+    const applicationId = appId || (await this.loadActiveContext()).application.id;
+    const uid = userId || (await this.loadActiveContext()).user.id || await this.getIdentity();
+    return `identity-x.${applicationId}.app-user*${uid}`;
+  }
+
+  /**
    * Sends a login link to an existing user
    */
   async sendLoginLink({

--- a/packages/marko-web-p1-events/browser/index.js
+++ b/packages/marko-web-p1-events/browser/index.js
@@ -52,6 +52,11 @@ export default (Browser) => {
       action: 'Submit',
       label: 'Profile',
     }],
+    ['identity-x-authenticated', {
+      category: 'Identity',
+      action: 'Click',
+      label: 'Login Link',
+    }],
   ]).entries()].forEach(([event, payload]) => {
     EventBus.$on(event, (args) => {
       if (!window.p1events) return;
@@ -59,6 +64,7 @@ export default (Browser) => {
       window.p1events('track', {
         ...payload,
         props: {
+          idxEntity: args.entity,
           ...(actionSource && { actionSource }),
           ...(newsletterSignupType && { newsletterSignupType }),
           ...(contentGatingType && { contentGatingType }),

--- a/packages/marko-web-theme-monorail/browser/index.js
+++ b/packages/marko-web-theme-monorail/browser/index.js
@@ -28,24 +28,6 @@ const setP1EventsIdentity = ({ p1events, brandKey, encryptedId }) => {
   p1events('setIdentity', `omeda.${brandKey}.customer*${encryptedId}~encrypted`);
 };
 
-const dispatchP1EAuthenticate = (args) => {
-  const {
-    loginSource: actionSource,
-    newsletterSignupType,
-    contentGatingType,
-  } = args;
-  window.p1events('track', {
-    category: 'Identity',
-    action: 'Click',
-    label: 'Login Link',
-    props: {
-      ...(actionSource && { actionSource }),
-      ...(newsletterSignupType && { newsletterSignupType }),
-      ...(contentGatingType && { contentGatingType }),
-    },
-  });
-};
-
 /**
  * @typedef ThemeConfig
  * @prop {boolean} [enableOmedaIdentityX=true]
@@ -82,26 +64,22 @@ export default (Browser, configOverrides = {}) => {
   }
 
   /**
-   * Sets the P1E Identity and explicitly dispatches the authenticate converion event
-   * @see @parameter1/marko-web-p1-events/browser for post-auth conversion events
+   * Sets the P1E Identity. @see @parameter1/marko-web-p1-events/browser other events
    */
   if (enableOmedaIdentityX) {
     EventBus.$on('omeda-identity-x-authenticated', (args) => {
       const { brandKey, encryptedId } = args;
       setP1EventsIdentity({ p1events: window.p1events, brandKey, encryptedId });
-      dispatchP1EAuthenticate(args);
     });
     EventBus.$on('omeda-identity-x-rapid-identify-response', (args) => {
       const { brandKey, encryptedId } = args;
       setP1EventsIdentity({ p1events: window.p1events, brandKey, encryptedId });
-      dispatchP1EAuthenticate(args);
     });
   } else {
     EventBus.$on('identity-x-authenticated', (args) => {
       const { applicationId, user } = args;
       if (!window.p1events || !applicationId || !user) return;
       window.p1events('setIdentity', `identity-x.${applicationId}.app-user*${user.id}`);
-      dispatchP1EAuthenticate(args);
     });
   }
 


### PR DESCRIPTION
- Adds entity to all server route responses
- Adds entity into event payloads via mixin
- Sets `idxEntity` on P1E props
- Moves login link click event to P1E library
- Removes invalid authenticate dispatch from omeda rapid identify event