### PR TITLE
Fix EntityID generation, form access cookie

### DIFF
--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -414,7 +414,7 @@ class IdentityX {
    * @param {GenerateEntityIdArgs} args
    * @returns {?string} The entityId of the active user/identity, if present.
    */
-  async generateEntityId({ appId, userId }) {
+  async generateEntityId({ appId, userId } = {}) {
     const applicationId = appId || (await this.loadActiveContext()).application.id;
     const uid = userId || (await this.loadActiveContext()).user.id || await this.getIdentity();
     return `identity-x.${applicationId}.app-user*${uid}`;

--- a/services/example-website/middleware/format-content-response.js
+++ b/services/example-website/middleware/format-content-response.js
@@ -9,6 +9,9 @@ const formatContentResponse = ({ res, content }) => {
   res.locals.contentIdxFormState = {
     displayForm: false,
     formId: 'default',
+    cookie: {
+      name: `${cookieNamePrefix}_${content.id}`,
+    },
   };
   if (surveyType === 'idx') {
     const cookieName = `${cookieNamePrefix}_${surveyId}_${content.id}`;

--- a/services/example-website/server/templates/content.marko
+++ b/services/example-website/server/templates/content.marko
@@ -31,7 +31,7 @@ $ const { recaptcha } = out.global;
                 content=content
                 block-name=blockName
                 display-read-next=false
-                display-comments=false
+                display-comments=true
               />
             </theme-page-contents>
           </div>


### PR DESCRIPTION
- Adds a default value to the `generateEntityId` function added in #873 
- Sets default value for IdX form access cookie on example website
- Enables comments on content body on example website