### PR TITLE
Allow inclusion of specific types only, when `contentTypes` is specified, Most Popular blocks, Monorail

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/most-popular-list.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/most-popular-list.marko
@@ -12,7 +12,7 @@ $ const getMostPopular = async () => {
   const uri = MOST_POPULAR_API_URI || 'https://most-popular-content.base.parameter1.com';
   const tenant = site.get("p1events.tenant");
   const realm = config.website("id");
-  const contentTypes = site.getAsArray("mostPopularAllowedTypes") || [];
+  const contentTypes = getAsArray(input, 'input.includeContentTypes');
 
   const defaultUrl = `${uri}/retrieve?tenant=${tenant}&realm=${realm}`;
   const url = contentTypes.length ? `${defaultUrl}&types=${contentTypes.join(',')}` : defaultUrl;

--- a/packages/marko-web-theme-monorail/components/blocks/most-popular-list.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/most-popular-list.marko
@@ -12,8 +12,10 @@ $ const getMostPopular = async () => {
   const uri = MOST_POPULAR_API_URI || 'https://most-popular-content.base.parameter1.com';
   const tenant = site.get("p1events.tenant");
   const realm = config.website("id");
+  const contentTypes = site.getAsArray("mostPopularAllowedTypes") || [];
 
-  const url = `${uri}/retrieve?tenant=${tenant}&realm=${realm}`;
+  const defaultUrl = `${uri}/retrieve?tenant=${tenant}&realm=${realm}`;
+  const url = contentTypes.length ? `${defaultUrl}&types=${contentTypes.join(',')}` : defaultUrl;
   const res = await fetch(url);
   const json = await res.json();
   if (!res.ok) {

--- a/packages/marko-web-theme-monorail/components/blocks/most-popular.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/most-popular.marko
@@ -13,8 +13,10 @@ $ const getMostPopular = async () => {
   const uri = MOST_POPULAR_API_URI || 'https://most-popular-content.base.parameter1.com';
   const tenant = site.get("p1events.tenant");
   const realm = config.website("id");
+  const contentTypes = site.getAsArray("mostPopularAllowedTypes") || [];
 
-  const url = `${uri}/retrieve?tenant=${tenant}&realm=${realm}`;
+  const defaultUrl = `${uri}/retrieve?tenant=${tenant}&realm=${realm}`;
+  const url = contentTypes.length ? `${defaultUrl}&types=${contentTypes.join(',')}` : defaultUrl;
   const res = await fetch(url);
   const json = await res.json();
   if (!res.ok) {

--- a/packages/marko-web-theme-monorail/components/blocks/most-popular.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/most-popular.marko
@@ -13,7 +13,7 @@ $ const getMostPopular = async () => {
   const uri = MOST_POPULAR_API_URI || 'https://most-popular-content.base.parameter1.com';
   const tenant = site.get("p1events.tenant");
   const realm = config.website("id");
-  const contentTypes = site.getAsArray("mostPopularAllowedTypes") || [];
+  const contentTypes = getAsArray(input, 'input.includeContentTypes');
 
   const defaultUrl = `${uri}/retrieve?tenant=${tenant}&realm=${realm}`;
   const url = contentTypes.length ? `${defaultUrl}&types=${contentTypes.join(',')}` : defaultUrl;


### PR DESCRIPTION
Ex: https://most-popular-content.base.parameter1.com/retrieve?tenant=bobit&realm=63a54060da01648223f94c58&types=article



REF: https://github.com/parameter1/base-cms/pull/846