### PR TITLE
`newsletterEmailSchedules` query

### DIFF
--- a/services/graphql-server/src/graphql/definitions/email/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/email/schedule.js
@@ -11,6 +11,7 @@ extend type Query {
     model: "email.Schedule",
     using: { contentId: "content.$id" },
   )
+  emailSchedulesForDateRange(input: EmailScheduleByDayQueryInput!): [EmailSchedule]!
 }
 
 extend type Mutation {
@@ -86,6 +87,12 @@ input ContentEmailSchedulesQueryInput {
 input EmailScheduleSortInput {
   field: EmailScheduleSortField = id
   order: SortOrder = desc
+}
+
+input EmailScheduleByDayQueryInput {
+  newsletterId: ObjectID!
+  startingStartOf: Date!
+  beforeEndOf: Date!
 }
 
 input QuickCreateEmailSchedulesMutationInput {

--- a/services/graphql-server/src/graphql/definitions/email/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/email/schedule.js
@@ -93,6 +93,7 @@ input EmailScheduleByDayQueryInput {
   newsletterId: ObjectID!
   startingStartOf: Date!
   beforeEndOf: Date!
+  timezone: String # tz database format, e.g. America/Chicago
 }
 
 input QuickCreateEmailSchedulesMutationInput {

--- a/services/graphql-server/src/graphql/definitions/email/schedule.js
+++ b/services/graphql-server/src/graphql/definitions/email/schedule.js
@@ -11,7 +11,8 @@ extend type Query {
     model: "email.Schedule",
     using: { contentId: "content.$id" },
   )
-  emailSchedulesForDateRange(input: EmailScheduleByDayQueryInput!): [EmailSchedule]!
+  "Query for newsletter schedules by newlsetter product id and specified date range"
+  newsletterEmailSchedules(input: NewsletterEmailSchedulesQueryInput!): [EmailSchedule]!
 }
 
 extend type Mutation {
@@ -89,11 +90,14 @@ input EmailScheduleSortInput {
   order: SortOrder = desc
 }
 
-input EmailScheduleByDayQueryInput {
+"Input for retrieiving newsletter schedules for a specified time range"
+input NewsletterEmailSchedulesQueryInput {
+  "The newsletter product id"
   newsletterId: ObjectID!
-  startingStartOf: Date!
-  beforeEndOf: Date!
-  timezone: String # tz database format, e.g. America/Chicago
+  "The millisecond precision UNIX timestamp to start looking for schedules at (inclusive)"
+  after: Date!
+  "The millsecond precision UNIX timestamp to stop looking for schedules at (inclusive"
+  before: Date!
 }
 
 input QuickCreateEmailSchedulesMutationInput {

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -677,9 +677,6 @@ input NewsletterScheduledContentQueryInput {
   newsletterId: ObjectID!
   sectionId: Int
   sectionName: String
-  "If specified the start of the time range to look for schedules for"
-  startDate: Date
-  "The UNIX timestamp to look for schedules for, if ignoreStartDate is false or startDate is specified this functions as an end date exclusively"
   date: Date!
   timezone: String
   ignoreStartDate: Boolean = false

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -677,6 +677,9 @@ input NewsletterScheduledContentQueryInput {
   newsletterId: ObjectID!
   sectionId: Int
   sectionName: String
+  "If specified the start of the time range to look for schedules for"
+  startDate: Date
+  "The UNIX timestamp to look for schedules for, if ignoreStartDate is false or startDate is specified this functions as an end date exclusively"
   date: Date!
   timezone: String
   ignoreStartDate: Boolean = false

--- a/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/interfaces/content.js
@@ -91,6 +91,8 @@ interface Content @requiresProject(fields: ["type"]) {
   websiteSchedules: [ContentWebsiteSchedule]!
   # Returns the magazine schedules
   magazineSchedules: [MagazineSchedule]! @projection(localField: "_id")
+  # Returns the email schedules
+  emailSchedules: [EmailSchedule]! @projection(localField: "_id")
 
   hasWebsiteSchedule(input: ContentHasWebsiteScheduleInput!): Boolean! @projection(localField: "sectionQuery")
 

--- a/services/graphql-server/src/graphql/resolvers/email/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/email/schedule.js
@@ -48,7 +48,7 @@ module.exports = {
         projection: {
           _id: 1,
           product: 1,
-          content: 1,
+          'content.$id': 1,
           section: 1,
           deploymentDate: 1,
           sequence: 1,

--- a/services/graphql-server/src/graphql/resolvers/email/schedule.js
+++ b/services/graphql-server/src/graphql/resolvers/email/schedule.js
@@ -41,14 +41,7 @@ module.exports = {
         sort: scheduleSort,
         projection,
       });
-      const output = schedules.reduce((array, schedule) => {
-        const { content: contentItem, ...rest } = schedule;
-        if (contentItem && contentItem.oid) {
-          array.push({ ...rest, content: contentItem.oid });
-        }
-        return array;
-      }, []);
-      return output;
+      return schedules;
     },
   },
   /**

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -418,6 +418,8 @@ module.exports = {
 
     magazineSchedules: ({ _id }, _, { basedb }) => basedb.find('magazine.Schedule', { 'content.$id': _id }),
 
+    emailSchedules: ({ _id }, _, { basedb }) => basedb.find('email.Schedule', { 'content.$id': _id, status: 1 }),
+
     /**
      * Load primary section of content.
      * If primary section's site matches the current site, return the section.
@@ -1545,7 +1547,8 @@ module.exports = {
       const section = await basedb.strictFindOne('email.Section', sectionQuery, { projection: { _id: 1 } });
 
       const date = momentTZ(input.date).tz(timezone);
-      const start = date.startOf('day').toDate();
+      const startDate = input.startDate ? momentTZ(input.startDate).tz(timezone) : null;
+      const start = startDate ? startDate.startOf('day').toDate() : date.startOf('day').toDate();
       const end = date.endOf('day').toDate();
 
       const scheduleSort = ignoreStartDate

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1547,8 +1547,7 @@ module.exports = {
       const section = await basedb.strictFindOne('email.Section', sectionQuery, { projection: { _id: 1 } });
 
       const date = momentTZ(input.date).tz(timezone);
-      const startDate = input.startDate ? momentTZ(input.startDate).tz(timezone) : null;
-      const start = startDate ? startDate.startOf('day').toDate() : date.startOf('day').toDate();
+      const start = date.startOf('day').toDate();
       const end = date.endOf('day').toDate();
 
       const scheduleSort = ignoreStartDate


### PR DESCRIPTION
![image](https://github.com/parameter1/base-cms/assets/46794001/c9d20ce4-d9fb-46cf-bb92-79da016b4329)

This returns the schedules sorted by deployment date from oldest to newest for the range provided.