### PR TITLE
Appropriately return whether or not the user was deleted, Identity-X `deleteAppUserForCurrentApplication` service action

### DIFF
--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -462,7 +462,7 @@ class IdentityX {
   }) {
     const apiToken = this.config.getApiToken();
     if (!apiToken) throw new Error('Unable to delete user: No API token has been configured.');
-    this.client.mutate({
+    const { data } = this.client.mutate({
       mutation: deleteAppUserForCurrentApplicationMutation,
       variables: {
         input: {
@@ -472,6 +472,7 @@ class IdentityX {
       },
       context: { apiToken },
     });
+    return data.deleteAppUserForCurrentApplication;
   }
 }
 


### PR DESCRIPTION
Corrects an oversight in this service action where it didn't return whether or not the user was actually deleted or not.