### PR TITLE
Properly await client.mutate, `deleteAppUserForCurrentApplication` Identity-X service action

### DIFF
--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -462,7 +462,7 @@ class IdentityX {
   }) {
     const apiToken = this.config.getApiToken();
     if (!apiToken) throw new Error('Unable to delete user: No API token has been configured.');
-    const { data } = this.client.mutate({
+    const { data } = await this.client.mutate({
       mutation: deleteAppUserForCurrentApplicationMutation,
       variables: {
         input: {


### PR DESCRIPTION
![image](https://github.com/parameter1/base-cms/assets/46794001/477cd8eb-ac09-4a24-a0a0-c2b40b517000)
