### PR TITLE
Add ability to filter websiteScheduledContent query by company

### DIFF
--- a/packages/web-common/src/block-loaders/website-scheduled-content.js
+++ b/packages/web-common/src/block-loaders/website-scheduled-content.js
@@ -35,6 +35,8 @@ module.exports = async (apolloClient, {
   after,
   sort,
 
+  company,
+
   siteId,
   sectionId,
   sectionAlias,
@@ -72,6 +74,7 @@ module.exports = async (apolloClient, {
     requiresImage,
     sectionAlias,
     sectionBubbling,
+    company,
     siteId,
     sectionId,
     optionId,

--- a/services/graphql-server/src/graphql/definitions/platform/content/index.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/index.js
@@ -690,6 +690,7 @@ input NewsletterScheduledContentQueryInput {
 
 input WebsiteScheduledContentQueryInput {
   siteId: ObjectID
+  company: Int
   sectionId: Int
   sectionAlias: String
   optionId: [Int] = []

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1516,7 +1516,7 @@ module.exports = {
       }
       const query = { sectionQuery: { $elemMatch }, $and: [] };
 
-      if (company) query.$and.push({ company: company });
+      if (company) query.$and.push({ company });
 
       if (requiresImage) query.primaryImage = { $exists: true };
       if (includeContentTypes.length) {

--- a/services/graphql-server/src/graphql/resolvers/platform/content.js
+++ b/services/graphql-server/src/graphql/resolvers/platform/content.js
@@ -1448,6 +1448,7 @@ module.exports = {
      */
     websiteScheduledContent: async (_, { input }, { basedb, cacheLoaders, site }, info) => {
       const {
+        company,
         sectionId,
         sectionAlias,
         optionId,
@@ -1514,6 +1515,9 @@ module.exports = {
         $elemMatch.$and.push({ sectionId: { $nin: excludeSectionIds } });
       }
       const query = { sectionQuery: { $elemMatch }, $and: [] };
+
+      if (company) query.$and.push({ company: company });
+
       if (requiresImage) query.primaryImage = { $exists: true };
       if (includeContentTypes.length) {
         query.$and.push({ type: { $in: includeContentTypes } });


### PR DESCRIPTION
Add the ability to pass set company: id with the websiteScheduledContent query input.  this will then filter all results by that given companies content.   For use in situations like displaying company content within blocks like spec comparison tool.   Also for use within the following pr https://github.com/parameter1/ac-business-media-websites/pull/568