### PR TITLE
Add check on activeContext & activeContext.user before using.

### DIFF
--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -417,8 +417,12 @@ class IdentityX {
    * @returns {?string} The entityId of the active user/identity, if present.
    */
   async generateEntityId({ appId, userId } = {}) {
-    const applicationId = appId || (await this.loadActiveContext()).application.id;
-    const uid = userId || (await this.loadActiveContext()).user.id || await this.getIdentity();
+    const activeContext = await this.loadActiveContext();
+    const applicationId = appId || activeContext.application.id;
+    const uid = userId
+      || (activeContext && activeContext.user)
+      ? activeContext.user.id
+      : await this.getIdentity();
     return `identity-x.${applicationId}.app-user*${uid}`;
   }
 


### PR DESCRIPTION
Add this to prevent `An error occurred: FormError: Cannot read property 'id' of null`

At the moment this would need to be udpate on SMG & ACBM
<img width="897" alt="Screenshot 2024-05-16 at 8 55 47 AM" src="https://github.com/parameter1/base-cms/assets/3845869/d8b55e48-3a2e-4db4-9e53-74980e569fed">

