### PR TITLE
Adjust setting of uid to prevent id of null error

### DIFF
--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -419,10 +419,8 @@ class IdentityX {
   async generateEntityId({ appId, userId } = {}) {
     const activeContext = await this.loadActiveContext();
     const applicationId = appId || activeContext.application.id;
-    const uid = userId
-      || (activeContext && activeContext.user)
-      ? activeContext.user.id
-      : await this.getIdentity();
+    const activeUserId = (activeContext && activeContext.user) ? activeContext.user.id : await this.getIdentity();
+    const uid = userId || activeUserId;
     return `identity-x.${applicationId}.app-user*${uid}`;
   }
 

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -419,7 +419,8 @@ class IdentityX {
   async generateEntityId({ appId, userId } = {}) {
     const activeContext = await this.loadActiveContext();
     const applicationId = appId || activeContext.application.id;
-    const activeUserId = (activeContext && activeContext.user) ? activeContext.user.id : await this.getIdentity();
+    const activeUserId = (activeContext && activeContext.user)
+      ? activeContext.user.id : await this.getIdentity();
     const uid = userId || activeUserId;
     return `identity-x.${applicationId}.app-user*${uid}`;
   }


### PR DESCRIPTION
prevent pulling of id off of null object and getting the folllowing error An error occurred: Cannot read property 'id' of null