### PR TITLE
Allow use of Base Videos in Featured Videos section of Leaders Data card when `featureYoutubeVideos` is false

### DIFF
--- a/packages/leaders-program/src/components/card/index.vue
+++ b/packages/leaders-program/src/components/card/index.vue
@@ -93,7 +93,7 @@
             :video-id="convertToString(item.id)"
             :title="item.name"
             :href="item.canonicalPath"
-            :image-src="item.primaryImage.src"
+            :image-src="get(item, 'primaryImage.src')"
             @click="handleVideoClick"
           />
         </template>

--- a/packages/leaders-program/src/components/card/index.vue
+++ b/packages/leaders-program/src/components/card/index.vue
@@ -76,6 +76,28 @@
           />
         </template>
       </content-deck>
+      <content-deck :value="relatedVideos" :limit="3" :item-modifiers="['video']">
+        <template #header-left>
+          Featured Videos
+        </template>
+        <template #header-right>
+          <view-more
+            label="videos"
+            :href="profileHref"
+            target="_blank"
+            @click="handleAllVideosClick"
+          />
+        </template>
+        <template #default="{ item }">
+          <video-card
+            :video-id="convertToString(item.id)"
+            :title="item.name"
+            :href="item.canonicalPath"
+            :image-src="item.primaryImage.src"
+            @click="handleVideoClick"
+          />
+        </template>
+      </content-deck>
     </div>
   </div>
 </template>
@@ -137,11 +159,14 @@ export default {
     promotions() {
       return getEdgeNodes(this.company, 'promotions');
     },
+    relatedVideos() {
+      return getEdgeNodes(this.company, 'relatedVideos');
+    },
     videos() {
       return getEdgeNodes(this.company, 'videos');
     },
     displayBody() {
-      return Boolean(this.promotions.length || this.videos.length);
+      return Boolean(this.promotions.length || this.videos.length || this.relatedVideos.length);
     },
     displayRightHeader() {
       return this.displayRightTopHeader || this.displayRightBottomHeader;
@@ -168,6 +193,9 @@ export default {
   },
 
   methods: {
+    convertToString(value) {
+      return String(value);
+    },
     get(obj, path) {
       return get(obj, path);
     },

--- a/packages/leaders-program/src/components/card/index.vue
+++ b/packages/leaders-program/src/components/card/index.vue
@@ -54,7 +54,12 @@
           />
         </template>
       </content-deck>
-      <content-deck :value="videos" :limit="3" :item-modifiers="['video']">
+      <content-deck
+        v-if="featureYoutubeVideos"
+        :value="videos"
+        :limit="3"
+        :item-modifiers="['video']"
+      >
         <template #header-left>
           Featured Videos
         </template>
@@ -76,7 +81,12 @@
           />
         </template>
       </content-deck>
-      <content-deck :value="relatedVideos" :limit="3" :item-modifiers="['video']">
+      <content-deck
+        v-else
+        :value="relatedVideos"
+        :limit="3"
+        :item-modifiers="['video']"
+      >
         <template #header-left>
           Featured Videos
         </template>
@@ -137,6 +147,10 @@ export default {
     featuredProductLabel: {
       type: String,
       default: 'Featured Products',
+    },
+    featureYoutubeVideos: {
+      type: Boolean,
+      default: true,
     },
   },
 

--- a/packages/leaders-program/src/components/containers/section-wrapper.vue
+++ b/packages/leaders-program/src/components/containers/section-wrapper.vue
@@ -27,6 +27,7 @@
             :promotion-limit="promotionLimit"
             :video-limit="videoLimit"
             :featured-product-label="featuredProductLabel"
+            :feature-youtube-videos="featureYoutubeVideos"
             :icon-style="iconStyle"
             @action="emitAction"
           />
@@ -116,6 +117,10 @@ export default {
     featuredProductLabel: {
       type: String,
       default: 'Featured Products',
+    },
+    featureYoutubeVideos: {
+      type: Boolean,
+      default: true,
     },
   },
 

--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -37,6 +37,7 @@
             :company="item"
             :is-active="isActive"
             :featured-product-label="featuredProductLabel"
+            :feature-youtube-videos="featureYoutubeVideos"
             @action="emitAction"
           />
         </template>
@@ -113,6 +114,10 @@ export default {
     featuredProductLabel: {
       type: String,
       default: 'Featured Products',
+    },
+    featureYoutubeVideos: {
+      type: Boolean,
+      default: true,
     },
     iconStyle: {
       type: String,

--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -36,6 +36,7 @@
         :promotion-limit="promotionLimit"
         :video-limit="videoLimit"
         :featured-product-label="featuredProductLabel"
+        :feature-youtube-videos="featureYoutubeVideos"
         :icon-style="iconStyle"
         @action="emitAction"
       />
@@ -187,6 +188,10 @@ export default {
     featuredProductLabel: {
       type: String,
       default: 'Featured Products',
+    },
+    featureYoutubeVideos: {
+      type: Boolean,
+      default: true,
     },
     iconStyle: {
       type: String,

--- a/packages/leaders-program/src/graphql/queries/content-for-section.js
+++ b/packages/leaders-program/src/graphql/queries/content-for-section.js
@@ -117,6 +117,33 @@ query ContentForLeadersSection(
               }
             }
           }
+          relatedVideos: relatedContent(input: {
+            withSite: false,
+            queryTypes: [company],
+            includeContentTypes: [Video],
+            pagination: { limit: $videoLimit },
+          }) {
+            edges {
+              node {
+                id
+                name
+                primaryImage{
+                  id
+                  src(input: {
+                    options: {
+                      auto: "format",
+                      fit: "crop",
+                      h: 180,
+                      w: 240,
+                    }
+                  })
+                  alt
+                  isLogo
+                }
+                canonicalPath
+              }
+            }
+          }
         }
       }
     }

--- a/packages/leaders-program/src/graphql/queries/content-for-section.js
+++ b/packages/leaders-program/src/graphql/queries/content-for-section.js
@@ -122,6 +122,7 @@ query ContentForLeadersSection(
             queryTypes: [company],
             includeContentTypes: [Video],
             pagination: { limit: $videoLimit },
+            requiresImage: true,
           }) {
             edges {
               node {


### PR DESCRIPTION
![image](https://github.com/parameter1/base-cms/assets/46794001/fb898fdf-62ec-4203-983b-f29d94f09f40)
(Screenshot showing use of relatedVideos over Youtube videos with `featureYoutubeVideos` set to `false`, lack of images is just to show that the query works with the usable data and is not reflective of what it will look like "finalized")