### PR TITLE
Support "collapsing" of empty Leaders categories when configured

### DIFF
--- a/packages/leaders-program/src/components/containers/section-wrapper.vue
+++ b/packages/leaders-program/src/components/containers/section-wrapper.vue
@@ -28,6 +28,7 @@
             :video-limit="videoLimit"
             :featured-product-label="featuredProductLabel"
             :feature-youtube-videos="featureYoutubeVideos"
+            :collapse-empty-categories="collapseEmptyCategories"
             :icon-style="iconStyle"
             @action="emitAction"
           />
@@ -121,6 +122,10 @@ export default {
     featureYoutubeVideos: {
       type: Boolean,
       default: true,
+    },
+    collapseEmptyCategories: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/packages/leaders-program/src/components/containers/section.vue
+++ b/packages/leaders-program/src/components/containers/section.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="classes" :data-section-id="sectionId">
+  <div v-if="!collapse" :class="classes" :data-section-id="sectionId">
     <button class="leaders-section__toggle-button" @click="toggleExpanded">
       <component :is="collapsedIcon" v-show="!isExpanded" :modifiers="iconModifiers" />
       <component :is="expandedIcon" v-show="isExpanded" :modifiers="iconModifiers" />
@@ -119,6 +119,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    collapseEmptyCategories: {
+      type: Boolean,
+      default: false,
+    },
     iconStyle: {
       type: String,
       default: 'plus-minus',
@@ -128,6 +132,7 @@ export default {
 
   data: () => ({
     blockName: 'leaders-section',
+    collapse: false,
     items: [],
     isLoading: false,
     hasLoaded: false,
@@ -187,7 +192,10 @@ export default {
     },
 
     emitCategoryItems(items) {
-      if (!items || !items.length) return;
+      if (!items || !items.length) {
+        this.collapse = this.collapseEmptyCategories;
+        return;
+      }
       this.emitAction({
         type: 'viewed',
         label: 'Section Company Items',

--- a/packages/leaders-program/src/components/leaders.vue
+++ b/packages/leaders-program/src/components/leaders.vue
@@ -37,6 +37,7 @@
         :video-limit="videoLimit"
         :featured-product-label="featuredProductLabel"
         :feature-youtube-videos="featureYoutubeVideos"
+        :collapse-empty-categories="collapseEmptyCategories"
         :icon-style="iconStyle"
         @action="emitAction"
       />
@@ -192,6 +193,10 @@ export default {
     featureYoutubeVideos: {
       type: Boolean,
       default: true,
+    },
+    collapseEmptyCategories: {
+      type: Boolean,
+      default: false,
     },
     iconStyle: {
       type: String,


### PR DESCRIPTION
When `collapseEmptyCategories` is `false` (default/existing behavior)
![Screenshot from 2024-05-22 09-09-45](https://github.com/parameter1/base-cms/assets/46794001/4372b5a7-4ee1-47e9-8212-e74563d0bead)

When `collapseEmptyCategories` is `true` (new behavior)
![Screenshot from 2024-05-22 09-10-09](https://github.com/parameter1/base-cms/assets/46794001/2d22f626-fc05-4369-9e9a-63100ccb1815)
