### PR TITLE
Add userRegistration to content in GTM dataLayer

### DIFF
--- a/packages/marko-web-gtm/components/context/content.marko
+++ b/packages/marko-web-gtm/components/context/content.marko
@@ -47,6 +47,10 @@ fragment ContentContextFragment on Content {
       }
     }
   }
+  userRegistration {
+    isCurrentlyRequired
+    accessLevels
+  }
   ... on Authorable {
     authors {
       edges {

--- a/packages/marko-web-gtm/context/content.js
+++ b/packages/marko-web-gtm/context/content.js
@@ -7,6 +7,7 @@ module.exports = ({ obj, req }) => {
   const company = getAsObject(content, 'company');
   const createdBy = getAsObject(content, 'createdBy');
   const section = getAsObject(content, 'primarySection');
+  const userRegistration = getAsObject(content, 'userRegistration');
   const hierarchy = getAsArray(section, 'hierarchy').map((s) => ({
     id: s.id,
     name: s.name,
@@ -32,6 +33,7 @@ module.exports = ({ obj, req }) => {
       name: content.name,
       published: content.published ? new Date(content.published).toISOString() : undefined,
       labels: getAsArray(content, 'labels'),
+      userRegistration,
     },
     created_by: {
       id: createdBy.id,


### PR DESCRIPTION
Add the userRegistration to the content object being passed to the gtm layer.  This will allow for variables to be set and triggers to know when a piece of content has gates applied.

Example is within EQW's GTM container 

Defines a GTM variable from dataLayer content.userRegistration.isCurrentlyRequired. with a default of false.  Then in Olytics tag conditionally append data prior to sending to olytics.  