### PR TITLE
Return empty string to render instead of null or undefined when using block loader

### DIFF
--- a/packages/marko-web-theme-monorail/browser/block-loader.vue
+++ b/packages/marko-web-theme-monorail/browser/block-loader.vue
@@ -50,7 +50,7 @@ export default {
           this.hasLoaded = true;
           const template = document.createElement('template');
           template.innerHTML = html;
-          const toInsert = template.content.firstChild;
+          const toInsert = template.content.firstChild || '';
           this.$el.replaceWith(toInsert);
         } catch (e) {
           this.error = e;


### PR DESCRIPTION
Prevents null from showing when the most popular block is not returned in the case like on content.nrwa.org