### PR TITLE
Remove the spread of querySection as it is not avaiable

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/content-card-deck.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/content-card-deck.marko
@@ -30,7 +30,7 @@ $ const linkHeader = input.linkHeader || false;
 $ const link = getAsObject(input, "link");
 
 <if(input.nodes && input.nodes.length)>
-  $ const section = { ...querySection, ...input.section };
+  $ const section = { ...input.section };
   $ const title = input.title || section && section.name;
   $ const description = input.description || section && section.description || input.defaultDescription;
   <marko-web-block name=blockName>


### PR DESCRIPTION
This was an over site when accounting for pushing of nodes in and not having the section returned with the query.  only spread input.section when input.nodes is sent in.