### PR TITLE
Allow for explicit image sizing on Native-X promo cards and newsletter signups

### DIFF
--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/inline.vue
@@ -3,7 +3,13 @@
     <div ref="lazyload" class="lazyload" />
     <div :class="bem()">
       <div v-if="imageSrc" :class="bem('left-col')">
-        <img :src="imageSrc" :srcset="imageSrcset" :alt="name">
+        <img
+          :src="imageSrc"
+          :srcset="imageSrcset"
+          :alt="name"
+          :width="imageWidth"
+          :height="imageHeight"
+        >
       </div>
       <div :class="bem('right-col')">
         <div v-if="!submitted" :class="bem('name')">
@@ -94,6 +100,14 @@ export default {
     imageSrcset: {
       type: String,
       default: null,
+    },
+    imageWidth: {
+      type: String,
+      default: '',
+    },
+    imageHeight: {
+      type: String,
+      default: '',
     },
     lang: {
       type: String,

--- a/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
+++ b/packages/marko-web-theme-monorail/browser/idx-newsletter-form/pushdown.vue
@@ -9,6 +9,8 @@
             :srcset="imageSrcset"
             :alt="name"
             :class="element('image')"
+            :width="imageWidth"
+            :height="imageHeight"
           >
         </div>
         <div :class="element('form-wrapper', ['col-12', 'col-md-6', 'col-lg-7'])">
@@ -90,6 +92,14 @@ export default {
     imageSrcset: {
       type: String,
       default: null,
+    },
+    imageWidth: {
+      type: String,
+      default: '',
+    },
+    imageHeight: {
+      type: String,
+      default: '',
     },
     initiallyExpanded: {
       type: Boolean,

--- a/packages/marko-web-theme-monorail/components/blocks/native-x-promo-card.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/native-x-promo-card.marko
@@ -15,12 +15,20 @@ $ const placement = nxConfig.getPlacement({ name: placementName, aliases });
       <marko-web-element block-name=blockName name="row">
         <marko-web-element block-name=blockName name="col">
           <if(ads[0] && ads[0].hasCampaign)>
-            <theme-standard-promo-node ...convertAdToNode(ads[0]) />
+            <theme-standard-promo-node
+              ...convertAdToNode(ads[0])
+              image-width=input.imageWidth
+              image-height=input.imageHeight
+            />
           </if>
         </marko-web-element>
         <marko-web-element block-name=blockName name="col" modifiers=["last"]>
           <if(ads[1] && ads[1].hasCampaign)>
-            <theme-standard-promo-node ...convertAdToNode(ads[1]) />
+            <theme-standard-promo-node
+              ...convertAdToNode(ads[1])
+              image-width=input.imageWidth
+              image-height=input.imageHeight
+            />
           </if>
         </marko-web-element>
       </marko-web-element>

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-pushdown.marko
@@ -38,6 +38,8 @@ $ const imageSrcset = imageSrc ? `${imageSrc}&dpr=2 2x` : null;
           disabled,
           imageSrc,
           imageSrcset,
+          imageWidth: input.imageWidth,
+          imageHeight: input.imageHeight,
           initiallyExpanded,
           lang,
           additionalEventData,

--- a/packages/marko-web-theme-monorail/components/nodes/standard-promo.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/standard-promo.marko
@@ -1,7 +1,7 @@
 import { get } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { node } = input;
+$ const { node, imageWidth, imageHeight } = input;
 
 $ const linkText = get(node, "linkText") || defaultValue(input.linkText, "Read More");
 $ const blockName = defaultValue(input.blockName, "pib-page-card");
@@ -31,6 +31,7 @@ $ const blockName = defaultValue(input.blockName, "pib-page-card");
         src=node.primaryImage.src
         srcset=[`${node.primaryImage.src}&dpr=2 2x`]
         alt=node.primaryImage.alt
+        attrs={ width: imageWidth, height: imageHeight }
       />
     </if>
   </marko-web-element>

--- a/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
+++ b/packages/marko-web-theme-monorail/utils/site-idx-newsletter-menu-props.js
@@ -33,6 +33,8 @@ module.exports = ({ out, input }) => {
   return {
     ...((withImage && imageSrc) && { imageSrc }),
     ...((withImage && imageSrcset) && { imageSrcset }),
+    imageWidth: defaultValue(input.imageWidth, ''),
+    imageHeight: defaultValue(input.imageHeight, ''),
     siteName: config.website('name'),
     name,
     description,


### PR DESCRIPTION
![Screenshot from 2024-07-11 11-08-19](https://github.com/parameter1/base-cms/assets/46794001/4aa0f162-e474-4c71-ad03-35599ddc8a47)
![Screenshot from 2024-07-11 11-08-36](https://github.com/parameter1/base-cms/assets/46794001/f765f39f-ccc9-4a5c-891c-cddfa6ea9478)
![Screenshot from 2024-07-11 11-08-46](https://github.com/parameter1/base-cms/assets/46794001/9c3bd424-a44e-47c1-99e9-dd8d5a658800)
