### PR TITLE
Allow sending and retrieval of `additionalContext` within authentication flow

### DIFF
--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -247,6 +247,11 @@ export default {
           isProfileComplete: this.isProfileComplete,
           requiresCustomFieldAnswers: this.requiresCustomFieldAnswers,
           actionSource: data.loginSource,
+          ...(
+            data.additionalEventData
+            && data.additionalEventData.newsletterSignupType
+            && { newsletterSignupType: data.additionalEventData.newsletterSignupType }
+          ),
           additionalEventData: {
             ...(this.additionalEventData || {}),
             ...(data.additionalEventData || {}),

--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -248,9 +248,9 @@ export default {
           requiresCustomFieldAnswers: this.requiresCustomFieldAnswers,
           actionSource: data.loginSource,
           ...(
-            data.additionalEventData
-            && data.additionalEventData.newsletterSignupType
-            && { newsletterSignupType: data.additionalEventData.newsletterSignupType }
+            data.additionalContext
+            && data.additionalContext.newsletterSignupType
+            && { newsletterSignupType: data.additionalContext.newsletterSignupType }
           ),
           additionalEventData: {
             ...(this.additionalEventData || {}),

--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -1,4 +1,5 @@
 const gql = require('graphql-tag');
+const { getAsObject } = require('@parameter1/base-cms-object-path');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
 const tokenCookie = require('../utils/token-cookie');
 const contextCookie = require('../utils/context-cookie');
@@ -16,6 +17,7 @@ const loginAppUser = gql`
         ...ActiveUserFragment
       }
       loginSource
+      additionalEventData
     }
   }
 
@@ -51,7 +53,7 @@ module.exports = asyncRoute(async (req, res) => {
     applicationId: identityX.config.getAppId(),
     user,
     loginSource,
-    additionalEventData,
+    additionalEventData: { ...additionalEventData, ...getAsObject(data, 'loginAppUser.additionalEventData') },
     entity,
   });
 });

--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -17,7 +17,7 @@ const loginAppUser = gql`
         ...ActiveUserFragment
       }
       loginSource
-      additionalEventData
+      additionalContext
     }
   }
 
@@ -53,7 +53,8 @@ module.exports = asyncRoute(async (req, res) => {
     applicationId: identityX.config.getAppId(),
     user,
     loginSource,
-    additionalEventData: { ...additionalEventData, ...getAsObject(data, 'loginAppUser.additionalEventData') },
+    additionalContext: getAsObject(data, 'loginAppUser.additionalContext'),
+    additionalEventData,
     entity,
   });
 });

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -444,7 +444,7 @@ class IdentityX {
           appContextId: this.config.get('appContextId'),
           source,
           redirectTo,
-          additionalEventData,
+          additionalContext: additionalEventData,
         },
       },
     });

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -444,6 +444,7 @@ class IdentityX {
           appContextId: this.config.get('appContextId'),
           source,
           redirectTo,
+          additionalEventData,
         },
       },
     });


### PR DESCRIPTION
**REQUIRES https://github.com/parameter1/identity-x/pull/54 TO BE MERGED AND DEPLOYED**

From https://github.com/parameter1/identity-x/pull/54: "This allows for the passthrough of a JSON object called `additionalContext`, this will allow for the `newsletterSignupType` (amongst other potential points of data) to be specified and returned namely for the login-link-click event tracking within P1 Events in order to enable correct event recording for reporting purposes."

![Screenshot from 2024-07-29 14-12-42](https://github.com/user-attachments/assets/1de3cd66-8442-45b1-ad7e-6613ce85cb4c)
![image](https://github.com/user-attachments/assets/508ac8fc-dd37-4f42-9571-ef4b51c75675)
