### PR TITLE
Add monorail `theme-facebook-connect` component

### DIFF
--- a/packages/marko-web-theme-monorail/components/facebook-connect.marko
+++ b/packages/marko-web-theme-monorail/components/facebook-connect.marko
@@ -1,0 +1,54 @@
+$ const { site } = out.global;
+
+$ const facebookConnect = site.get("facebookConnect");
+
+<if(facebookConnect && facebookConnect.enabled && facebookConnect.ids && facebookConnect.ids.length)>
+  $ const { ids } = facebookConnect;
+  $ const inits = ids.map((id) => `fbq('init', '${id}');`).join('');
+  <!-- Facebook Pixel Code -->
+  <marko-web-deferred-script-loader-register
+    name="facebookConnect"
+    src="https://connect.facebook.net/en_US/fbevents.js"
+    init=`!function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];}(window)`
+    onScriptLoad=`${inits}fbq('track', 'PageView');`
+    on="load"
+    init-only=true
+  />
+
+  <script>
+    window.onload = (event) => {
+      // Create the observed element
+      var scrollDiv = document.createElement("div");
+      scrollDiv.id = "fb-scroll-load";
+      document.body.insertAdjacentElement("afterbegin", scrollDiv);
+
+      var facebookConnectLoad = function(script, distance) {
+        var observer = new IntersectionObserver(function (entries) {
+          entries.forEach(function(entry) {
+            if(entry.boundingClientRect.y < 0) {
+              // Execute scripts
+              script();
+
+              // Remove the listerner
+              observer.unobserve(entry.target);
+            }
+          });
+        }, { rootMargin: distance });
+        observer.observe(document.querySelector("#" + scrollDiv.id));
+      }
+      facebookConnectLoad(function() { deferScript('load', { name: 'facebookConnect' }); }, '50px');
+    };
+  </script>
+
+
+  <noscript>
+    <for|id| of=ids>
+      <img height="1" width="1" style="display:none" src=`https://www.facebook.com/tr?id=${id}&ev=PageView&noscript=1` />
+    </for>
+  </noscript>
+  <!-- End Facebook Pixel Code -->
+</if>

--- a/packages/marko-web-theme-monorail/components/facebook-connect.marko
+++ b/packages/marko-web-theme-monorail/components/facebook-connect.marko
@@ -1,9 +1,7 @@
-$ const { site } = out.global;
+import { getAsArray } from "@parameter1/base-cms-object-path";
+$ const ids = getAsArray(input, "ids");
 
-$ const facebookConnect = site.get("facebookConnect");
-
-<if(facebookConnect && facebookConnect.enabled && facebookConnect.ids && facebookConnect.ids.length)>
-  $ const { ids } = facebookConnect;
+<if(ids.length)>
   $ const inits = ids.map((id) => `fbq('init', '${id}');`).join('');
   <!-- Facebook Pixel Code -->
   <marko-web-deferred-script-loader-register

--- a/packages/marko-web-theme-monorail/components/marko.json
+++ b/packages/marko-web-theme-monorail/components/marko.json
@@ -21,6 +21,9 @@
   "<theme-client-side-block-loader>": {
     "template": "./client-side-block-loader.marko"
   },
+  "<theme-facebook-connect>": {
+    "template": "./facebook-connect.marko"
+  },
   "<theme-menu-toggle-button>": {
     "template": "./menu-toggle-button.marko"
   },

--- a/packages/marko-web-theme-monorail/components/marko.json
+++ b/packages/marko-web-theme-monorail/components/marko.json
@@ -22,7 +22,11 @@
     "template": "./client-side-block-loader.marko"
   },
   "<theme-facebook-connect>": {
-    "template": "./facebook-connect.marko"
+    "template": "./facebook-connect.marko",
+    "@ids": {
+      "type":  "array",
+      "required": true
+    }
   },
   "<theme-menu-toggle-button>": {
     "template": "./menu-toggle-button.marko"


### PR DESCRIPTION
This will be used to replace these once released 

https://github.com/parameter1/transpire-media-websites/pull/1/files/ac4fe0ea022528e16895dd989cd628f34aeeff7d#diff-1afebdf09957f4376786719a272ea3b8a2c30da70411f813e3653719997359b9

&&

https://github.com/parameter1/bobit-business-media-websites/blob/master/packages/global/components/facebook-connect.marko