### PR TITLE
Correctly move semicolon to outside of string value, generic `createIdentityBuilder` util

### DIFF
--- a/packages/marko-web-identity-x/utils/create-identity-builder.js
+++ b/packages/marko-web-identity-x/utils/create-identity-builder.js
@@ -27,7 +27,7 @@ module.exports = (context = {}, identity = null) => {
     return `return 'identity-x.${context.application.id}.app-user*' + '${context.user.id}';`;
   }
   if (identity) {
-    return `return 'identity-x.${context.application.id}.app-user*' + '${identity};'`;
+    return `return 'identity-x.${context.application.id}.app-user*' + '${identity}';`;
   }
   return '';
 };


### PR DESCRIPTION
A very easy to understand missing it within: https://github.com/parameter1/base-cms/pull/924

This resulted in some identification events return the identifier with a semicolon appended to it, rather than returning from the function with a semicolon at end of line.