### PR TITLE
Add custom text input support for identity x

### DIFF
--- a/packages/marko-web-identity-x/api/fragments/active-user.js
+++ b/packages/marko-web-identity-x/api/fragments/active-user.js
@@ -84,6 +84,25 @@ fragment ActiveUserFragment on AppUser {
       }
     }
   }
+  customTextFieldAnswers(input: {
+    onlyActive: true
+    sort: { field: createdAt, order: asc }
+  }) {
+    id
+    hasAnswered
+    value
+    field {
+      id
+      label
+      active
+      required
+      externalId {
+        id
+        namespace { provider tenant type }
+        identifier { value type }
+      }
+    }
+  }
 }
 
 `;

--- a/packages/marko-web-identity-x/browser/form/fields/custom-text.vue
+++ b/packages/marko-web-identity-x/browser/form/fields/custom-text.vue
@@ -1,0 +1,62 @@
+<template>
+  <form-group :class-name="className">
+    <form-label :for="id" :required="required">
+      {{ label }}
+    </form-label>
+    <input
+      :id="id"
+      v-model="customText"
+      class="form-control"
+      type="text"
+      :required="required"
+      @change="$emit('change', customText)"
+    >
+  </form-group>
+</template>
+
+<script>
+import FormGroup from '../common/form-group.vue';
+import FormLabel from '../common/form-label.vue';
+
+export default {
+  components: {
+    FormGroup,
+    FormLabel,
+  },
+  props: {
+    /**
+     * The unique field id.
+     */
+    id: {
+      type: String,
+      required: true,
+    },
+    required: {
+      type: Boolean,
+      default: false,
+    },
+    label: {
+      type: String,
+      default: 'Custom Input',
+    },
+    value: {
+      type: String,
+      default: '',
+    },
+    className: {
+      type: String,
+      default: 'col-md-12',
+    },
+  },
+  computed: {
+    customText: {
+      get() {
+        return this.value || '';
+      },
+      set(customText) {
+        this.$emit('change', customText);
+      },
+    },
+  },
+};
+</script>

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -130,6 +130,22 @@
           :default-field-labels="defaultFieldLabels"
         />
 
+        <div v-if="customTextFieldAnswers.length" class="row mt-3">
+          <div
+            v-for="fieldAnswer in customTextFieldAnswers"
+            :key="fieldAnswer.id"
+            class="col-12"
+          >
+            <custom-text
+              :id="fieldAnswer.id"
+              :label="fieldAnswer.field.label"
+              :required="fieldAnswer.field.required"
+              :value="fieldAnswer.value"
+              @change="onCustomTextChange(fieldAnswer.id, $event)"
+            />
+          </div>
+        </div>
+
         <div v-if="customSelectFieldAnswers.length" class="row">
           <custom-select
             v-for="fieldAnswer in customSelectFieldAnswers"
@@ -242,6 +258,7 @@ import AddressBlock from './form/address-block.vue';
 import FormConsent from './form/consent.vue';
 import CustomBoolean from './form/fields/custom-boolean.vue';
 import CustomSelect from './form/fields/custom-select.vue';
+import CustomText from './form/fields/custom-text.vue';
 import GivenName from './form/fields/given-name.vue';
 import FamilyName from './form/fields/family-name.vue';
 import Organization from './form/fields/organization.vue';
@@ -262,6 +279,7 @@ export default {
     AddressBlock,
     CustomBoolean,
     CustomSelect,
+    CustomText,
     GivenName,
     FamilyName,
     FormConsent,
@@ -450,6 +468,17 @@ export default {
         .sort(this.sortByActiveCustomFieldIds);
     },
 
+    /**
+     *
+     */
+    customTextFieldAnswers() {
+      const { activeCustomFieldIds: ids } = this;
+      const { customTextFieldAnswers } = this.user;
+      const answers = isArray(customTextFieldAnswers) ? customTextFieldAnswers : [];
+      return answers.filter(ids.length > 0 ? ({ field }) => ids.includes(field.id) : () => true)
+        .sort(this.sortByActiveCustomFieldIds);
+    },
+
     showAddressBlock() {
       // Don't show at all until country is selected.
       if (!this.countryCode) return false;
@@ -586,6 +615,12 @@ export default {
       const ids = Array.isArray($event) ? [...$event] : [...($event ? [$event] : [])];
       answers.splice(0);
       if (ids.length) answers.push(...ids.map((id) => ({ id })));
+    },
+
+    onCustomTextChange(id, customText) {
+      const objIndex = this.customTextFieldAnswers.findIndex(((obj) => obj.id === id));
+      this.customTextFieldAnswers[objIndex].value = customText;
+      this.user.customTextFieldAnswers = this.customTextFieldAnswers;
     },
 
     customSelectIsRequired(fieldAnswer) {

--- a/packages/marko-web-identity-x/browser/profile.vue
+++ b/packages/marko-web-identity-x/browser/profile.vue
@@ -131,19 +131,15 @@
         />
 
         <div v-if="customTextFieldAnswers.length" class="row mt-3">
-          <div
+          <custom-text
             v-for="fieldAnswer in customTextFieldAnswers"
+            :id="fieldAnswer.id"
             :key="fieldAnswer.id"
-            class="col-12"
-          >
-            <custom-text
-              :id="fieldAnswer.id"
-              :label="fieldAnswer.field.label"
-              :required="fieldAnswer.field.required"
-              :value="fieldAnswer.value"
-              @change="onCustomTextChange(fieldAnswer.id, $event)"
-            />
-          </div>
+            :label="fieldAnswer.field.label"
+            :required="fieldAnswer.field.required"
+            :value="fieldAnswer.value"
+            @change="onCustomTextChange(fieldAnswer.id, $event)"
+          />
         </div>
 
         <div v-if="customSelectFieldAnswers.length" class="row">

--- a/packages/marko-web-identity-x/service.js
+++ b/packages/marko-web-identity-x/service.js
@@ -60,6 +60,7 @@ const IDENTITY_COOKIE_NAME = '__idx_idt';
  * @prop {RegionalConsentAnswer[]} regionalConsentAnswers
  * @prop {CustomBooleanFieldAnswer[]} customBooleanFieldAnswers
  * @prop {CustomSelectFieldAnswer[]} customSelectFieldAnswers
+ * @prop {CustomTextFieldAnswer[]} customTextFieldAnswers
  *
  * @typedef ExternalId
  * @prop {String} id


### PR DESCRIPTION
This will be used in conjuction with this [Identity X PR/release](https://github.com/parameter1/identity-x/pull/12).  When used with external esp it should also be able to send the custom text demo based on external demo ids 

```js
appId: '66183c5e0635be32a6f07115',
  activeCustomFieldIds: [
    '66bca3c5c1a23e001452a175',
    '66ba3866531cb31b38619ec2',
    '66ba2b8b4204dd454af95102',
  ],
  ```
I pointed at my local identityX copy from the above branch with a copy of prod data. 

@todo vet that the demos are mapping to omeda correctly. 

<img width="1212" alt="Screenshot 2024-08-15 at 8 11 48 AM" src="https://github.com/user-attachments/assets/a0536bac-b8e3-4365-bc7f-d52f5ddace84">
