### PR TITLE
Include externalContentUrl on heroImageNode TOP STORY

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/top-stories.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/top-stories.marko
@@ -24,6 +24,7 @@ $ const queryName = (queryParams.optionName) ? "website-optioned-content" : "web
       type: heroNode.type,
       siteContext: heroNode.siteContext,
       primaryImage: heroNode.primaryImage,
+      ...(heroNode.externalContentUrl && { externalContentUrl: heroNode.externalContentUrl }),
     };
     $ const cardNodes = nodes.slice(1);
 


### PR DESCRIPTION
Accounts for the instances in which items with a `externalContentUrl` are the TOP top story in the block and correctly links the image.

![image](https://github.com/user-attachments/assets/aba27f3a-ef1e-4d22-b485-936feca71ae0)
