### PR TITLE
Omeda text demographic support

### DIFF
--- a/packages/marko-web-omeda-identity-x/omeda-data/get-answered-question-map.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/get-answered-question-map.js
@@ -11,5 +11,9 @@ module.exports = (user) => {
     if (!boolean.hasAnswered) return;
     answeredQuestionMap.set(boolean.field.id, true);
   });
+  user.customTextFieldAnswers.forEach((field) => {
+    if (!field.hasAnswered) return;
+    answeredQuestionMap.set(field.field.id, true);
+  });
   return answeredQuestionMap;
 };

--- a/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-customer-record.js
+++ b/packages/marko-web-omeda-identity-x/omeda-data/get-omeda-customer-record.js
@@ -25,6 +25,7 @@ const query = gql`
       demographics {
         demographic { id description }
         value { id description }
+        valueText
         writeInDesc
       }
       primaryEmailAddress {

--- a/packages/marko-web-omeda-identity-x/rapid-identify.js
+++ b/packages/marko-web-omeda-identity-x/rapid-identify.js
@@ -85,6 +85,18 @@ module.exports = async ({
     };
   });
 
+  getAsArray(appUser, 'customTextFieldAnswers').forEach((text) => {
+    const { field, hasAnswered } = text;
+    const { externalId } = field;
+    if (!field.active || !externalId || !hasAnswered) return;
+
+    const { identifier } = field.externalId;
+    const id = parseInt(identifier.value, 10);
+    if (isOmedaDemographicId({ externalId, brandKey })) {
+      demographics.push({ id, values: [`${text.value}`] });
+    }
+  });
+
   const subscriptions = [];
   getAsArray(appUser, 'customBooleanFieldAnswers').forEach((boolean) => {
     const { field, hasAnswered } = boolean;


### PR DESCRIPTION
Adds support for priming freeform text demographics to IdentityX records, and sending updated values to Omeda through the Rapid Identify/SCANDO APIs