### PR TITLE
Adjust mindful ad preview route with template/layout concepts & update core version with company name

### DIFF
--- a/packages/marko-web-theme-monorail/components/layouts/ad-preview.marko
+++ b/packages/marko-web-theme-monorail/components/layouts/ad-preview.marko
@@ -1,0 +1,83 @@
+$ const { log } = console;
+$ const { get, getAsObject, getAsArray } = require('@parameter1/base-cms-object-path');
+$ const fetch = require('node-fetch');
+$ const fs = require('fs');
+$ const now = new Date();
+
+$ const sections = getAsArray(input, "sections");
+$ const { creativeId, namespace = "parameter1/default" } = input;
+
+$ async function batchQuery({
+  graphURL,
+  creativeId,
+  namespace
+}) {
+  const query = `
+  query {
+    advertisingCreativeInterfaceById(_id: "${creativeId}") {
+      _id
+      _form {
+        label
+      }
+      url
+      name {
+        default
+      }
+      companyEdge {
+        _id
+        node {
+          name {
+            default
+          }
+        }
+      }
+      ... on NativeWebsiteAdvertisingCreative {
+        teaser
+      }
+      clickUrl
+      imageEdge {
+        node {
+          _id
+          src {
+            url
+          }
+        }
+      }
+    }
+  }
+`;
+  const results = await fetch(graphURL, {
+    body: JSON.stringify({ query }),
+    headers: { 'content-type': 'application/json', 'X-Namespace': namespace },
+    method: 'POST',
+  });
+  const res = await results.json();
+  const { data } = res;
+  return data;
+};
+
+
+<marko-web-resolve|{ resolved }| promise=batchQuery({graphURL: 'https://graphql.mindfulcms.com/query', creativeId, namespace})>
+  $ const creative = getAsObject(resolved, 'advertisingCreativeInterfaceById');
+  $ const title = `${get(creative, 'companyEdge.node.name.default')}'s ad preview` ;
+  <marko-web-default-page-layout type="Mindful Ad Preview" title=title>
+    <@head>
+      <${input.head} />
+    </@head>
+    <@page>
+      <marko-web-page-wrapper>
+        <@section>
+          <h1>${title}</h1>
+        </@section>
+        <for|s| of=sections>
+          <@section|{ blockName }| modifiers=s.modifiers>
+            <${s.renderBody}
+              block-name=blockName
+              creative=creative
+            />
+          </@section>
+        </for>
+      </marko-web-page-wrapper>
+    </@page>
+  </marko-web-default-page-layout>
+</marko-web-resolve>

--- a/packages/marko-web-theme-monorail/components/layouts/ad-preview.marko
+++ b/packages/marko-web-theme-monorail/components/layouts/ad-preview.marko
@@ -1,8 +1,9 @@
-$ const { log } = console;
-$ const { get, getAsObject, getAsArray } = require('@parameter1/base-cms-object-path');
-$ const fetch = require('node-fetch');
-$ const fs = require('fs');
-$ const now = new Date();
+import fetch from "node-fetch";
+import { get, getAsObject, getAsArray } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { site, i18n } = out.global;
+$ const graphURl = defaultValue("site.mindful.graphURL", "https://graphql.mindfulcms.com/query");
 
 $ const sections = getAsArray(input, "sections");
 $ const { creativeId, namespace = "parameter1/default" } = input;

--- a/packages/marko-web-theme-monorail/components/layouts/marko.json
+++ b/packages/marko-web-theme-monorail/components/layouts/marko.json
@@ -1,0 +1,15 @@
+{
+  "<theme-ad-preview-layout>": {
+    "template": "./ad-preview.marko",
+    "<head>": {},
+    "@creative-id" : {
+      "type": "Strin",
+      "required": true
+    },
+    "@namespace" : {
+      "type": "Strin",
+      "required": true
+    },
+    "@sections <section>[]": {}
+  }
+}

--- a/packages/marko-web-theme-monorail/components/marko.json
+++ b/packages/marko-web-theme-monorail/components/marko.json
@@ -10,6 +10,7 @@
     "./flows/marko.json",
     "./gam/marko.json",
     "./identity-x/marko.json",
+    "./layouts/marko.json",
     "./native-x/marko.json",
     "./nodes/marko.json",
     "./page/marko.json",

--- a/packages/marko-web-theme-monorail/templates/ad-preview.marko
+++ b/packages/marko-web-theme-monorail/templates/ad-preview.marko
@@ -1,5 +1,6 @@
-$ const { get } = require('@parameter1/base-cms-object-path');
-$ const converter = require('../utils/convert-mindful-ad-preview');
+import { get } from "@parameter1/base-cms-object-path";
+import converter from "../utils/convert-mindful-ad-preview";
+
 $ const { creativeId, namespace } = input;
 <theme-ad-preview-layout
   creative-id=creativeId
@@ -11,7 +12,7 @@ $ const { creativeId, namespace } = input;
       <div class="node-list node-list--latest-content-list node-list--flush-x">
         <div class="node-list__header">Preview #1</div>
       </div>
-      <theme-section-feed-flow nodes=[creativeNode] header="Standard Setion Feed List Flow">
+      <theme-section-feed-flow nodes=[creativeNode]>
         <@node-list inner-justified=false />
         <@node with-dates=false with-section/>
       </theme-section-feed-flow>

--- a/packages/marko-web-theme-monorail/templates/ad-preview.marko
+++ b/packages/marko-web-theme-monorail/templates/ad-preview.marko
@@ -1,168 +1,78 @@
-$ const { req, GAM } = out.global;
-$ const now = new Date();
-$ const { creativeId, namespace = "parameter1/default" } = input;
-$ const fetch = require('node-fetch');
-$ const fs = require('fs');
-$ const { get, getAsObject } = require('@parameter1/base-cms-object-path');
+$ const { get } = require('@parameter1/base-cms-object-path');
+$ const converter = require('../utils/convert-mindful-ad-preview');
+$ const { creativeId, namespace } = input;
+<theme-ad-preview-layout
+  creative-id=creativeId
+  namespace=namespace
+>
+  <@section|{creative}| >
+    $ const creativeNode = converter(creative);
+    <if(creative && get(creative, '_form.label') === 'Native Website')>
+      <div class="node-list node-list--latest-content-list node-list--flush-x">
+        <div class="node-list__header">Preview #1</div>
+      </div>
+      <theme-section-feed-flow nodes=[creativeNode] header="Standard Setion Feed List Flow">
+        <@node-list inner-justified=false />
+        <@node with-dates=false with-section/>
+      </theme-section-feed-flow>
+      <hr>
+    </if>
+  </@section>
 
-$ const converter = (creative) => {
-  const { _id, url } = creative;
-  return {
-    id: _id,
-    name: get(creative, 'name.default'),
-    // linkText: creative.linkText,
-    shortName: get(creative, 'name.default'),
-    typeTitled: 'Mindful',
-    type: 'mindful',
-    teaser: get(creative, 'teaser'),
-    published: now,
-    siteContext: {
-      path: url,
-      canonicalUrl: url,
-      url,
-    },
-    primaryImage: {
-      id: get(creative, 'imageEdge.node.id'),
-      src: get(creative, 'imageEdge.node.src.url'),
-    },
-    primarySection: {
-      name: 'Sponsored',
-      fullName: 'Sponsored',
-    },
-    company: {
-      id: get(creative, 'companyEdge.node.id'),
-      name: get(creative, 'companyEdge.node.name.default'),
-    },
-  }
-}
+  <@section|{creative}| >
+    $ const creativeNode = converter(creative);
+    <if(creative && get(creative, '_form.label') === 'Native Website')>
+      <div class="row">
+        <div class="col-lg-4" >
+          <theme-latest-content-list-block
+            title="Preview #2"
+            alias="home"
+            nodes=[creativeNode]
+          />
+        </div>
+      </div>
+      <hr>
+    </if>
+  </@section>
 
-$ const { log } = console;
-$ async function batchQuery({
-  graphURL,
-  creativeId,
-  namespace
-}) {
-  const query = `
-  query {
-    advertisingCreativeInterfaceById(_id: "${creativeId}") {
-      _id
-      _form {
-        label
-      }
-      url
-      name {
-        default
-      }
-      companyEdge {
-        _id
-        node {
-          name {
-            default
-          }
-        }
-      }
-      ... on NativeWebsiteAdvertisingCreative {
-        teaser
-      }
-      clickUrl
-      imageEdge {
-        node {
-          _id
-          src {
-            url
-          }
-        }
-      }
-    }
-  }
-`;
-  const results = await fetch(graphURL, {
-    body: JSON.stringify({ query }),
-    headers: { 'content-type': 'application/json', 'X-Namespace': namespace },
-    method: 'POST',
-  });
-  const res = await results.json();
-  const { data } = res;
-  return data;
-};
-
-<marko-web-resolve|{ resolved }| promise=batchQuery({graphURL: 'https://graphql.mindfulcms.com/query', creativeId, namespace})>
-
-$ const creative = getAsObject(resolved, 'advertisingCreativeInterfaceById');
-$ const pageType = "preview";
-$ const title = `${get(creative, 'companyEdge.node.name.default')}'s ad preview` ;
-
-  <marko-web-default-page-layout type=pageType title=title>
-    <@page>
-      <marko-web-page-wrapper>
-        <@section>
-          <h1>${title}</h1>
-        </@section>
-        <@section>
-          <if(creative)>
-            $ const creativeNode = converter(creative);
-            <if(get(creative, '_form.label') === 'Native Website')>
-              <div class="node-list node-list--latest-content-list node-list--flush-x">
-                <div class="node-list__header">Preview #1</div>
-              </div>
-              <theme-section-feed-flow nodes=[creativeNode] header="Standard Setion Feed List Flow">
-                <@node-list inner-justified=false />
-                <@node with-dates=false with-section/>
-              </theme-section-feed-flow>
-
-              <hr>
-              <div class="row">
-                <div class="col-lg-4" >
-                  <theme-latest-content-list-block
-                    title="Preview #2"
-                    alias="home"
-                    nodes=[creativeNode]
-                  />
-                </div>
-              </div>
-
-              <hr>
-              <div class="node-list node-list--latest-content-list node-list--flush-x">
-                <div class="node-list__header">Preview #3<span class="small">(with/without teaser)</span></div>
-              </div>
-              <theme-card-deck-flow
-                cols=3
-                nodes=[creativeNode, creativeNode]
-              >
-                <@slot|{ node, index }|>
-                  <if(index === 0)>
-                    <theme-content-node
-                      node=node
-                      with-teaser=true
-                      image-position="top"
-                      card=true
-                      flush=true
-                      modifiers=["section-tag"]
-                    >
-                      <@image fluid=true width=330 ar="3:2" />
-                    </theme-content-node>
-                  </if>
-                  <else>
-                    <theme-content-node
-                      node=node
-                      with-teaser=false
-                      image-position="top"
-                      card=true
-                      flush=true
-                      modifiers=["section-tag"]
-                    >
-                      <@image fluid=true width=330 ar="3:2" />
-                    </theme-content-node>
-                  </else>
-                </@slot>
-              </theme-card-deck-flow>
-            </if>
-            <else-if(get(creative, '_form.label') === 'Native Email')>
-
-            </else-if>
+  <@section|{creative}| >
+    $ const creativeNode = converter(creative);
+    <if(creative && get(creative, '_form.label') === 'Native Website')>
+      <div class="node-list node-list--latest-content-list node-list--flush-x">
+        <div class="node-list__header">Preview #3<span class="small">(with/without teaser)</span></div>
+      </div>
+      <theme-card-deck-flow
+        cols=3
+        nodes=[creativeNode, creativeNode]
+      >
+        <@slot|{ node, index }|>
+          <if(index === 0)>
+            <theme-content-node
+              node=node
+              with-teaser=true
+              image-position="top"
+              card=true
+              flush=true
+              modifiers=["section-tag"]
+            >
+              <@image fluid=true width=330 ar="3:2" />
+            </theme-content-node>
           </if>
-        </@section>
-      </marko-web-page-wrapper>
-    </@page>
-  </marko-web-default-page-layout>
-</marko-web-resolve>
+          <else>
+            <theme-content-node
+              node=node
+              with-teaser=false
+              image-position="top"
+              card=true
+              flush=true
+              modifiers=["section-tag"]
+            >
+              <@image fluid=true width=330 ar="3:2" />
+            </theme-content-node>
+          </else>
+        </@slot>
+      </theme-card-deck-flow>
+    </if>
+  </@section>
+
+</theme-ad-preview-layout>

--- a/packages/marko-web-theme-monorail/templates/ad-preview.marko
+++ b/packages/marko-web-theme-monorail/templates/ad-preview.marko
@@ -89,10 +89,10 @@ $ async function batchQuery({
 <marko-web-resolve|{ resolved }| promise=batchQuery({graphURL: 'https://graphql.mindfulcms.com/query', creativeId, namespace})>
 
 $ const creative = getAsObject(resolved, 'advertisingCreativeInterfaceById');
-$ const type = "preview";
+$ const pageType = "preview";
 $ const title = `${get(creative, 'companyEdge.node.name.default')}'s ad preview` ;
 
-  <marko-web-default-page-layout type=type title=title>
+  <marko-web-default-page-layout type=pageType title=title>
     <@page>
       <marko-web-page-wrapper>
         <@section>
@@ -123,45 +123,37 @@ $ const title = `${get(creative, 'companyEdge.node.name.default')}'s ad preview`
 
               <hr>
               <div class="node-list node-list--latest-content-list node-list--flush-x">
-                <div class="node-list__header">Preview #3</div>
+                <div class="node-list__header">Preview #3<span class="small">(with/without teaser)</span></div>
               </div>
               <theme-card-deck-flow
                 cols=3
-                nodes=[creativeNode]
+                nodes=[creativeNode, creativeNode]
               >
                 <@slot|{ node, index }|>
-                  <theme-content-node
-                    node=node
-                    with-teaser=false
-                    image-position="top"
-                    card=true
-                    flush=true
-                    modifiers=["section-tag"]
-                  >
-                    <@image fluid=true width=330 ar="3:2" />
-                  </theme-content-node>
-                </@slot>
-              </theme-card-deck-flow>
-
-              <hr>
-              <div class="node-list node-list--latest-content-list node-list--flush-x">
-                <div class="node-list__header">Preview #4</div>
-              </div>
-              <theme-card-deck-flow
-                cols=3
-                nodes=[creativeNode]
-              >
-                <@slot|{ node, index }|>
-                  <theme-content-node
-                    node=node
-                    with-teaser=true
-                    image-position="top"
-                    card=true
-                    flush=true
-                    modifiers=["section-tag"]
-                  >
-                    <@image fluid=true width=330 ar="3:2" />
-                  </theme-content-node>
+                  <if(index === 0)>
+                    <theme-content-node
+                      node=node
+                      with-teaser=true
+                      image-position="top"
+                      card=true
+                      flush=true
+                      modifiers=["section-tag"]
+                    >
+                      <@image fluid=true width=330 ar="3:2" />
+                    </theme-content-node>
+                  </if>
+                  <else>
+                    <theme-content-node
+                      node=node
+                      with-teaser=false
+                      image-position="top"
+                      card=true
+                      flush=true
+                      modifiers=["section-tag"]
+                    >
+                      <@image fluid=true width=330 ar="3:2" />
+                    </theme-content-node>
+                  </else>
                 </@slot>
               </theme-card-deck-flow>
             </if>

--- a/packages/marko-web-theme-monorail/templates/ad-preview.marko
+++ b/packages/marko-web-theme-monorail/templates/ad-preview.marko
@@ -132,6 +132,29 @@ $ const title = `${get(creative, 'companyEdge.node.name.default')}'s ad preview`
                 <@slot|{ node, index }|>
                   <theme-content-node
                     node=node
+                    with-teaser=false
+                    image-position="top"
+                    card=true
+                    flush=true
+                    modifiers=["section-tag"]
+                  >
+                    <@image fluid=true width=330 ar="3:2" />
+                  </theme-content-node>
+                </@slot>
+              </theme-card-deck-flow>
+
+              <hr>
+              <div class="node-list node-list--latest-content-list node-list--flush-x">
+                <div class="node-list__header">Preview #4</div>
+              </div>
+              <theme-card-deck-flow
+                cols=3
+                nodes=[creativeNode]
+              >
+                <@slot|{ node, index }|>
+                  <theme-content-node
+                    node=node
+                    with-teaser=true
                     image-position="top"
                     card=true
                     flush=true

--- a/packages/marko-web-theme-monorail/templates/ad-preview.marko
+++ b/packages/marko-web-theme-monorail/templates/ad-preview.marko
@@ -86,68 +86,68 @@ $ async function batchQuery({
   return data;
 };
 
+<marko-web-resolve|{ resolved }| promise=batchQuery({graphURL: 'https://graphql.mindfulcms.com/query', creativeId, namespace})>
+
+$ const creative = getAsObject(resolved, 'advertisingCreativeInterfaceById');
 $ const type = "preview";
-$ const title = `Customer Preview - ${creativeId}` ;
+$ const title = `${get(creative, 'companyEdge.node.name.default')}'s ad preview` ;
 
-<marko-web-default-page-layout type=type title=title>
-  <@page>
-    <marko-web-page-wrapper>
-      <@section>
-        <h1>${title}</h1>
-      </@section>
-      <@section>
-      <marko-web-resolve|{ resolved }| promise=batchQuery({graphURL: 'https://graphql.mindfulcms.com/query', creativeId, namespace})>
-        $ const creative = getAsObject(resolved, 'advertisingCreativeInterfaceById');
-        <if(creative)>
-          $ const creativeNode = converter(creative);
-          <if(get(creative, '_form.label') === 'Native Website')>
-
-            <div class="node-list node-list--latest-content-list node-list--flush-x">
-              <div class="node-list__header">List/Section Feed Preview</div>
-            </div>
-            <theme-section-feed-flow nodes=[creativeNode] header="Standard Setion Feed List Flow">
-              <@node-list inner-justified=false />
-              <@node with-dates=false with-section/>
-            </theme-section-feed-flow>
-
-            <hr>
-            <div class="row">
-              <div class="col-lg-4" >
-                <theme-latest-content-list-block
-                  title="Related Content Preview"
-                  alias="home"
-                  nodes=[creativeNode]
-                />
+  <marko-web-default-page-layout type=type title=title>
+    <@page>
+      <marko-web-page-wrapper>
+        <@section>
+          <h1>${title}</h1>
+        </@section>
+        <@section>
+          <if(creative)>
+            $ const creativeNode = converter(creative);
+            <if(get(creative, '_form.label') === 'Native Website')>
+              <div class="node-list node-list--latest-content-list node-list--flush-x">
+                <div class="node-list__header">Preview #1</div>
               </div>
-            </div>
+              <theme-section-feed-flow nodes=[creativeNode] header="Standard Setion Feed List Flow">
+                <@node-list inner-justified=false />
+                <@node with-dates=false with-section/>
+              </theme-section-feed-flow>
 
-            <hr>
-            <div class="node-list node-list--latest-content-list node-list--flush-x">
-              <div class="node-list__header">Loadmore/Section Feed Preview</div>
-            </div>
-            <theme-card-deck-flow
-              cols=3
-              nodes=[creativeNode]
-            >
-              <@slot|{ node, index }|>
-                <theme-content-node
-                  node=node
-                  image-position="top"
-                  card=true
-                  flush=true
-                  modifiers=["section-tag"]
-                >
-                  <@image fluid=true width=330 ar="3:2" />
-                </theme-content-node>
-              </@slot>
-            </theme-card-deck-flow>
+              <hr>
+              <div class="row">
+                <div class="col-lg-4" >
+                  <theme-latest-content-list-block
+                    title="Preview #2"
+                    alias="home"
+                    nodes=[creativeNode]
+                  />
+                </div>
+              </div>
+
+              <hr>
+              <div class="node-list node-list--latest-content-list node-list--flush-x">
+                <div class="node-list__header">Preview #3</div>
+              </div>
+              <theme-card-deck-flow
+                cols=3
+                nodes=[creativeNode]
+              >
+                <@slot|{ node, index }|>
+                  <theme-content-node
+                    node=node
+                    image-position="top"
+                    card=true
+                    flush=true
+                    modifiers=["section-tag"]
+                  >
+                    <@image fluid=true width=330 ar="3:2" />
+                  </theme-content-node>
+                </@slot>
+              </theme-card-deck-flow>
+            </if>
+            <else-if(get(creative, '_form.label') === 'Native Email')>
+
+            </else-if>
           </if>
-          <else-if(get(creative, '_form.label') === 'Native Email')>
-
-          </else-if>
-        </if>
-      </marko-web-resolve>
-      </@section>
-    </marko-web-page-wrapper>
-  </@page>
-</marko-web-default-page-layout>
+        </@section>
+      </marko-web-page-wrapper>
+    </@page>
+  </marko-web-default-page-layout>
+</marko-web-resolve>

--- a/packages/marko-web-theme-monorail/utils/convert-mindful-ad-preview.js
+++ b/packages/marko-web-theme-monorail/utils/convert-mindful-ad-preview.js
@@ -1,0 +1,34 @@
+const { get } = require('@parameter1/base-cms-object-path');
+
+const now = new Date();
+
+module.exports = (creative) => {
+  const { _id, url } = creative;
+  return {
+    id: _id,
+    name: get(creative, 'name.default'),
+    // linkText: creative.linkText,
+    shortName: get(creative, 'name.default'),
+    typeTitled: 'Mindful',
+    type: 'mindful',
+    teaser: get(creative, 'teaser'),
+    published: now,
+    siteContext: {
+      path: url,
+      canonicalUrl: url,
+      url,
+    },
+    primaryImage: {
+      id: get(creative, 'imageEdge.node.id'),
+      src: get(creative, 'imageEdge.node.src.url'),
+    },
+    primarySection: {
+      name: 'Sponsored',
+      fullName: 'Sponsored',
+    },
+    company: {
+      id: get(creative, 'companyEdge.node.id'),
+      name: get(creative, 'companyEdge.node.name.default'),
+    },
+  };
+};


### PR DESCRIPTION
This is now setup similar to the other template layout version of pages we uses.  This version will allow you to utiliz the standard global template with the three previews or you can override this template while utilize the orgs/sites version of nativeX block calls 

the global version now says ${Advertisers’s Name} ad preview for the title & set preview titles as such.  Preview #1, Preview #2 & Preview #3.  

This will hopefully remove any concern about naming of positions or allow the groups an easier way to override this route. 


Loaded on example website base-cms:
<img width="823" alt="Screenshot 2024-08-20 at 9 23 31 AM" src="https://github.com/user-attachments/assets/0c5cfc78-3efe-4c88-92d3-5de5ab4029e6">

Loaded on IEN:
![ad-preview](https://github.com/user-attachments/assets/ca1aab66-ee82-4276-8e7d-9cb52f259cd5)

