### PR TITLE
SCSS & Marko section feed  mobile card & 16:9 image ratio support within section feeds

### DIFF
--- a/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
+++ b/packages/marko-web-theme-monorail/components/nodes/section-feed-content.marko
@@ -241,14 +241,14 @@ $ const blockName = "section-feed-content-node";
       $ const link = linkField && get(content, linkField) ? get(content, linkField) : get(content, "siteContext.path");
       <marko-web-picture>
         <@link href=link target=linkTarget attrs=linkAttrs />
-        <@source srcset=srcset media="(min-width: 768px)" width=250 height=167 />
+        <@source srcset=srcset media="(min-width: 768px)" width=imageOptions.w height=imageOptions.h />
         <@image
           src=srcMobile
           srcset=srcsetMobile
           class=[`${blockName}__image`]
           alt=primaryImage.alt
           lazyload=lazyload
-          attrs={ width: "112", height: "112" }
+          attrs={ width: mobileImageOptions.w, height: mobileImageOptions.h }
         />
       </marko-web-picture>
     </marko-web-element>

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
@@ -2,6 +2,9 @@
   $self: &;
 
   $image-size: 112px;
+  $image-width: $image-size;
+  $image-height: $image-size;
+
   $image-desktop-width: 250px;
   $image-desktop-height: 167px;
 
@@ -30,9 +33,9 @@
   }
 
   &__image-wrapper {
-    width: $image-size;
-    min-width: $image-size;
-    height: $image-size;
+    width: $image-width;
+    min-width: $image-width;
+    height: $image-height;
     margin-left: 15px;
     @include media-breakpoint-up(md) {
       width: $image-desktop-width;
@@ -44,8 +47,8 @@
   }
 
   &__image {
-    width: $image-size;
-    height: $image-size;
+    width: $image-width;
+    height: $image-height;
     object-fit: cover;
     object-position: left;
     border: 1px solid rgba(239, 239, 239, .9);

--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
@@ -1,12 +1,22 @@
 .section-feed-content-node {
   $self: &;
 
-  $image-size: 112px;
-  $image-width: $image-size;
-  $image-height: $image-size;
+  @function ab($a, $b: null) {
+    @if $b != null {
+        @return $b;
+    }
+    @return $a;
+  }
+
+  $image-size: 112px ;
+  $image-mobile-width: null !default;
+  $image-mobile-height: null !default;
+  $image-width: ab($image-size, $image-mobile-width);
+  $image-height: ab($image-size, $image-mobile-height);
 
   $image-desktop-width: 250px;
   $image-desktop-height: 167px;
+
 
   display: flex;
   width: 100%;
@@ -219,6 +229,24 @@
       &__node {
         padding-top: .5rem;
         padding-bottom: 0;
+      }
+    }
+  }
+  //@todo this should also be dependend on the image width/height differing from 112
+  @include media-breakpoint-down(sm) {
+    &--section-feed-mobile-cards {
+      .section-feed-content-node {
+        &:first-child {
+          border-top: none;
+        }
+        flex-direction: column-reverse;
+        .section-feed-content-node__image-wrapper {
+          margin-left: 0;
+          margin-bottom: map-get($spacers, block);
+        }
+        .section-feed-content-node__content-teaser {
+          display: initial;
+        }
       }
     }
   }


### PR DESCRIPTION
By default if you apply the modifier of 
<img width="527" alt="Screenshot 2024-08-26 at 3 07 00 PM" src="https://github.com/user-attachments/assets/15e43442-e4c3-4e1b-a63b-a722045914c0">


by adding the following the flow call and the following the SCSS 
[Marko](https://github.com/parameter1/transpire-media-websites/pull/18/files#diff-523b5c20abfb303beb636f918bff23d279697789bb1ed730bb119a1226346086R13) with the following scss also being included

```scss
$image-mobile-width: 100% !default;
$image-mobile-height: initial !default;
```

will produce:
<img width="1467" alt="Screenshot 2024-08-26 at 2 55 17 PM" src="https://github.com/user-attachments/assets/72dfcd25-c071-479d-ae4e-da3f84cce168">
<img width="479" alt="Screenshot 2024-08-26 at 2 55 41 PM" src="https://github.com/user-attachments/assets/abdc26cd-7fcc-4300-8006-88b0624478d6">
