### PR TITLE
Allow for sectionFeed image node css to be overwritten

### DIFF
--- a/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
+++ b/packages/marko-web-theme-monorail/scss/components/blocks/_section-feed.scss
@@ -14,8 +14,8 @@
   $image-width: ab($image-size, $image-mobile-width);
   $image-height: ab($image-size, $image-mobile-height);
 
-  $image-desktop-width: 250px;
-  $image-desktop-height: 167px;
+  $image-desktop-width: 250px !default;
+  $image-desktop-height: 167px !default;
 
 
   display: flex;


### PR DESCRIPTION
Allow for org level scss filed to redefine this allowing for us to set the default desktop from 3:2 to 16:9 menaing 250 x 140(139.5)