### PR TITLE
Spread input.node within monorail's related-stories block

### DIFF
--- a/packages/marko-web-theme-monorail/components/blocks/related-stories.marko
+++ b/packages/marko-web-theme-monorail/components/blocks/related-stories.marko
@@ -51,7 +51,7 @@ $ const blockName = "related-stories";
             modifiers=[blockName]
             ...(withNativeX && { nativeX })
           >
-            <@node modifiers=[blockName] />
+            <@node modifiers=[blockName] ...input.node />
           </theme-content-card-deck-col-flow>
         </marko-web-block>
       </if>
@@ -67,7 +67,7 @@ $ const blockName = "related-stories";
         modifiers=[blockName]
         ...(withNativeX && { nativeX })
       >
-        <@node modifiers=[blockName] />
+        <@node modifiers=[blockName] ...input.node />
       </theme-content-card-deck-col-flow>
     </marko-web-block>
   </else>


### PR DESCRIPTION
Ultimately this is to push node.image.ar = 16:9 to update setting up aspect ratio.

An example using this would be in this [Draft PR](https://github.com/parameter1/transpire-media-websites/pull/18) 