### PR TITLE
Change category for Mindful Adversting Post events to Advertising Post

### DIFF
--- a/packages/marko-web-p1-events/components/track-native-story.marko
+++ b/packages/marko-web-p1-events/components/track-native-story.marko
@@ -25,7 +25,7 @@ $ const mindfulConfig = site.getAsObject("mindful");
   }
   $ const data = {
     action: "View",
-    category: "Content",
+    category: "Advertising Post",
     entity,
   };
   <script>

--- a/packages/marko-web-p1-events/components/track-scroll-depth/native-story.marko
+++ b/packages/marko-web-p1-events/components/track-scroll-depth/native-story.marko
@@ -31,7 +31,7 @@ $ const mindfulConfig = site.getAsObject("mindful");
     name="P1EventsTrackScrollDepth"
     props={
       entity,
-      category: 'Content',
+      category: 'Advertising Post',
       selector,
       targetScrollDepths,
     }


### PR DESCRIPTION
Incorrectly assumed to be `Content` in https://github.com/parameter1/base-cms/pull/934 and https://github.com/parameter1/base-cms/pull/952