### PR TITLE
Allow for pass through of structured data prop with content meta tags

### DIFF
--- a/packages/marko-web-theme-monorail/components/page/content.marko
+++ b/packages/marko-web-theme-monorail/components/page/content.marko
@@ -11,7 +11,11 @@ $ const { document } = out.global;
 
 <${document} ...rest>
   <@head>
-    <marko-web-content-page-metadata id=id />
+    <marko-web-content-page-metadata
+      id=id
+      structured-data-query-fragment=input.structuredDataQueryFragment
+      build-structured-data=input.buildStructuredData
+    />
     <${head} />
   </@head>
   <!-- Note: camelcased vars due to nest input of dynamic document. perhaps a marko bug -->


### PR DESCRIPTION
Used in conjunction with org [PR](https://github.com/parameter1/ac-business-media-websites/pull/712) to cleanup and fix setting of metadata ld+json object. 