### PR TITLE
Return refreshed user after auth is complete

### DIFF
--- a/packages/marko-web-identity-x/routes/authenticate.js
+++ b/packages/marko-web-identity-x/routes/authenticate.js
@@ -46,10 +46,11 @@ module.exports = asyncRoute(async (req, res) => {
   contextCookie.setTo(res, { loginSource });
   identityX.setIdentityCookie(user.id);
   const entity = await identityX.generateEntityId({ userId: user.id });
+  const refreshed = await identityX.findUserById(user.id);
   res.json({
     ok: true,
     applicationId: identityX.config.getAppId(),
-    user,
+    user: refreshed,
     loginSource,
     additionalEventData,
     entity,


### PR DESCRIPTION
Returns the refreshed user with the response from the authenticate action. This allows changes that were made during awaited hooks (such as subscriptions or demographic changes) to be present when/if the user profile intercept is displayed.