### PR TITLE
Add simple contentAccess byPass same as contentDownload

### DIFF
--- a/packages/marko-web-identity-x/browser/authenticate.vue
+++ b/packages/marko-web-identity-x/browser/authenticate.vue
@@ -235,7 +235,7 @@ export default {
         this.requiresCustomFieldAnswers = this.activeUser.customSelectFieldAnswers
           .filter(!ids.length ? ({ field }) => ids.includes(field.id) : () => true)
           .some(({ hasAnswered, field }) => field.required && !hasAnswered);
-        this.bypassProfileForm = data.loginSource === 'contentDownload';
+        this.bypassProfileForm = (data.loginSource === 'contentDownload' || data.loginSource === 'contentAccess');
 
         this.emitAutoSignup(data);
         this.emit('authenticated', {


### PR DESCRIPTION
Add same check we do for contentDownload but for contentAccess.  meaning it will bypass the profile page if refering loginSource was from a contentAccess login form submission.

It in theory will be used with a profile form submission on the content landing route instead. 

