### PR TITLE
Make contentAccess submission mimic contentDownload submission functionality...Will now update profile info.

### DIFF
--- a/packages/marko-web-identity-x/browser/access.vue
+++ b/packages/marko-web-identity-x/browser/access.vue
@@ -285,7 +285,7 @@ export default {
         }
       } catch (e) {
         this.error = e;
-        this.emit('download-errored', { message: e.message });
+        this.emit('access-errored', { message: e.message });
       } finally {
         this.isLoading = false;
       }

--- a/packages/marko-web-identity-x/browser/access.vue
+++ b/packages/marko-web-identity-x/browser/access.vue
@@ -192,6 +192,10 @@ export default {
       type: String,
       default: null,
     },
+    updateProfileOnAccess: {
+      type: Boolean,
+      default: false,
+    },
     enableChangeEmail: {
       type: Boolean,
       default: false,
@@ -314,6 +318,19 @@ export default {
           userId: this.user.id,
           additionalEventData,
         }, data.entity);
+
+        // @todo investigate if this should just be on by default or finalize optin????
+        if (this.updateProfileOnAccess) {
+          const profileRes = await post('/profile', {
+            ...this.user,
+            additionalEventData: {
+              ...this.additionalEventData,
+              actionSource: this.loginSource,
+            },
+          });
+          const profileData = await profileRes.json();
+          if (!profileData.ok) throw new FormError(profileData.message, profileRes.status);
+        }
 
         if (withReload) {
           this.handleReload();

--- a/packages/marko-web-identity-x/components/form-access.marko
+++ b/packages/marko-web-identity-x/components/form-access.marko
@@ -11,6 +11,7 @@ $ const callToAction = defaultValue(input.callToAction, `${ctaPrefix}, please fi
 $ const callToActionLoggedOut = defaultValue(input.callToAction, `${ctaPrefix}, please enter your email address below. You will receive an email containing a verification link.`);
 $ const buttonLabel = defaultValue(input.buttonLabel, "Submit & Access");
 $ const title = defaultValue(input.title, "Complete the form to access this content");
+$ const updateProfileOnAccess = defaultValue(input.updateProfileOnAccess, false);
 $ const { displayForm, cookie } = getAsObject(out, "global.contentIdxFormState");
 $ const consentPolicy = defaultValue(form.consentPolicy, get(application, "organization.consentPolicy"));
 $ const emailConsentRequest = defaultValue(form.emailConsentRequest, get(application, "organization.emailConsentRequest"));
@@ -24,6 +25,7 @@ $ const emailConsentRequest = defaultValue(form.emailConsentRequest, get(applica
       fieldRows: form.fieldRows,
       loginSource: "contentAccess",
       title: title,
+      updateProfileOnAccess,
       cookie,
       displayForm,
       callToAction: callToAction,

--- a/packages/marko-web-identity-x/components/form-access.marko
+++ b/packages/marko-web-identity-x/components/form-access.marko
@@ -11,7 +11,6 @@ $ const callToAction = defaultValue(input.callToAction, `${ctaPrefix}, please fi
 $ const callToActionLoggedOut = defaultValue(input.callToAction, `${ctaPrefix}, please enter your email address below. You will receive an email containing a verification link.`);
 $ const buttonLabel = defaultValue(input.buttonLabel, "Submit & Access");
 $ const title = defaultValue(input.title, "Complete the form to access this content");
-$ const updateProfileOnAccess = defaultValue(input.updateProfileOnAccess, false);
 $ const { displayForm, cookie } = getAsObject(out, "global.contentIdxFormState");
 $ const consentPolicy = defaultValue(form.consentPolicy, get(application, "organization.consentPolicy"));
 $ const emailConsentRequest = defaultValue(form.emailConsentRequest, get(application, "organization.emailConsentRequest"));
@@ -25,7 +24,6 @@ $ const emailConsentRequest = defaultValue(form.emailConsentRequest, get(applica
       fieldRows: form.fieldRows,
       loginSource: "contentAccess",
       title: title,
-      updateProfileOnAccess,
       cookie,
       displayForm,
       callToAction: callToAction,


### PR DESCRIPTION
This change is to make contentAccess now work similar or identical to [contentDownload](https://github.com/parameter1/base-cms/blob/master/packages/marko-web-identity-x/browser/download.vue#L260).  Meaning it would push to /profile await the response and get the update user and then send the content and user to the content access endpoint to generate the db insertion of access.  Allowing for the reporting aspect of this.  

@todo: in digging into this I discovered that with the introduction of the custom forms it allows for questions to be asked that are not configured to show on the profile page.  Not a huge deal, but in doing such those question do not pass as activeCustomeIds for the profile config and are not saved to the user profile.
