### PR TITLE
Add the ability to configure additional form questions support, not active, on /profile submit route handler

### DIFF
--- a/packages/marko-web-identity-x/config.js
+++ b/packages/marko-web-identity-x/config.js
@@ -25,6 +25,7 @@ class IdentityXConfiguration {
     requiredClientFields = [],
     requiredCreateFields = [],
     activeCustomFieldIds = [],
+    additionalCustomFieldIds = [],
     defaultFieldLabels = {},
     hiddenFields = ['city', 'street', 'addressExtra', 'phoneNumber', 'mobileNumber'],
     defaultCountryCode,
@@ -42,6 +43,7 @@ class IdentityXConfiguration {
       requiredClientFields,
       requiredCreateFields,
       activeCustomFieldIds,
+      additionalCustomFieldIds,
       defaultFieldLabels,
       hiddenFields,
       defaultCountryCode,
@@ -137,6 +139,10 @@ class IdentityXConfiguration {
 
   getActiveCustomFieldIds() {
     return this.getAsArray('activeCustomFieldIds');
+  }
+
+  getAdditionalCustomFieldIds() {
+    return this.getAsArray('additionalCustomFieldIds');
   }
 
   get(path, def) {

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -85,7 +85,12 @@ module.exports = asyncRoute(async (req, res) => {
     receiveEmail,
   };
 
-  const customFieldIds = [...getAsArray(identityX, 'config.options.activeCustomFieldIds'), ...getAsArray(identityX, 'config.options.additionalCustomFieldIds')];
+  const customFieldIds = [
+    ...new Set([
+      ...getAsArray(identityX, 'config.options.activeCustomFieldIds'),
+      ...getAsArray(identityX, 'config.options.additionalCustomFieldIds'),
+    ]),
+  ];
 
   const answers = regionalConsentAnswers
     .map((answer) => ({ policyId: answer.id, given: answer.given }));

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -85,7 +85,7 @@ module.exports = asyncRoute(async (req, res) => {
     receiveEmail,
   };
 
-  const activeCustomFieldIds = getAsArray(identityX, 'config.options.activeCustomFieldIds');
+  const customFieldIds = [...getAsArray(identityX, 'config.options.activeCustomFieldIds'), ...getAsArray(identityX, 'config.options.additionalCustomFieldIds')];
 
   const answers = regionalConsentAnswers
     .map((answer) => ({ policyId: answer.id, given: answer.given }));
@@ -102,8 +102,8 @@ module.exports = asyncRoute(async (req, res) => {
       // the form submit is effectively answers the question.
       value: Boolean(fieldAnswer.answer),
     })).filter(
-      activeCustomFieldIds.length > 0
-        ? ({ fieldId }) => activeCustomFieldIds.includes(fieldId)
+      customFieldIds.length > 0
+        ? ({ fieldId }) => customFieldIds.includes(fieldId)
         : () => true,
     );
     await identityX.client.mutate({
@@ -122,8 +122,8 @@ module.exports = asyncRoute(async (req, res) => {
         ...(writeInValue ? [{ optionId: id, value: writeInValue }] : []),
       ]), []),
     })).filter(
-      activeCustomFieldIds.length > 0
-        ? ({ fieldId }) => activeCustomFieldIds.includes(fieldId)
+      customFieldIds.length > 0
+        ? ({ fieldId }) => customFieldIds.includes(fieldId)
         : () => true,
     );
     await identityX.client.mutate({
@@ -139,8 +139,8 @@ module.exports = asyncRoute(async (req, res) => {
       // the form submit is effectively answers the question.
       value: fieldAnswer.value,
     })).filter(
-      activeCustomFieldIds.length > 0
-        ? ({ fieldId }) => activeCustomFieldIds.includes(fieldId)
+      customFieldIds.length > 0
+        ? ({ fieldId }) => customFieldIds.includes(fieldId)
         : () => true,
     );
     await identityX.client.mutate({


### PR DESCRIPTION
This allows for sites to set additional, not activeCustomQuestionIds, questions to ask on other IdX forms. They are not actively being asked on the profile route but need to be handle on profile submit.  This is due to them be submitted to /profile via a content access form where they are being configured.

Example would be as follows for ACBM.  /user/profile asks FCP specific Job Title & Primary Business, but then on their content access forms they are gating by specific topic based ones for Asphalt, concret, equipment, ect...

```
activeCustomFieldIds: [
  // Genral FCP
  '66c4dd5510ae66087480bb09', // Primary Business
  '66c4dedd10ae66008d80ea98', // Job Title
],
additionalCustomFieldIds: [
  // asphalt
  '66436fceafb6131c4a841f26',
  '66437894235da5b2358f59e9',
  // concrete
  '664370dc0635be5a37ae38f5',
  '66437775eab51a24312718de',
  // equipment
  '664b5f1cafb6137ba8469acc',
  '664b5d760635bea8c46106f0',
  // pavement
  '664b630aeab51a9936d99d59',
  '664b61a70635be184a616332',
  // rental
  '664b66b5a370d8a8013ab885',
  '664b6576eab51a8a95d9d881',
],
```

This would allow for those forms, on content access, where they are asking topic specific question to be submitted to the user profile as well and saved in identityX to their profile. 