### PR TITLE
Set active custom selects from IdentityX form configs

### DIFF
--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -1,6 +1,6 @@
 const gql = require('graphql-tag');
 const { asyncRoute } = require('@parameter1/base-cms-utils');
-const { getAsArray } = require('@parameter1/base-cms-object-path');
+const { getAsArray, getAsObject } = require('@parameter1/base-cms-object-path');
 const userFragment = require('../api/fragments/active-user');
 const callHooksFor = require('../utils/call-hooks-for');
 
@@ -85,10 +85,24 @@ module.exports = asyncRoute(async (req, res) => {
     receiveEmail,
   };
 
+  // get identity-x.forms custom-select question ids to append to ActiveCustomQuestionIds
+  const customFormFieldIds = Object.values(getAsObject(identityX, 'config.options.forms')).reduce((questions, form) => {
+    // loop over the fieldRows
+    const newQuestions = getAsArray(form, 'fieldRows').reduce((q, row) => {
+      // push the custom-select form being used with those forms to accaptable profile inputs
+      // @todo fiugre out if other types should also make it... custom-boolean specifically.
+      row.forEach((question) => {
+        if (question.type === 'custom-select') q.push(question.id);
+      });
+      return q;
+    }, []);
+    return questions.concat(newQuestions);
+  }, []);
+
   const customFieldIds = [
     ...new Set([
       ...getAsArray(identityX, 'config.options.activeCustomFieldIds'),
-      ...getAsArray(identityX, 'config.options.additionalCustomFieldIds'),
+      ...customFormFieldIds,
     ]),
   ];
 

--- a/packages/marko-web-identity-x/routes/profile.js
+++ b/packages/marko-web-identity-x/routes/profile.js
@@ -88,15 +88,12 @@ module.exports = asyncRoute(async (req, res) => {
   // get identity-x.forms custom-select question ids to append to ActiveCustomQuestionIds
   const customFormFieldIds = Object.values(getAsObject(identityX, 'config.options.forms')).reduce((questions, form) => {
     // loop over the fieldRows
-    const newQuestions = getAsArray(form, 'fieldRows').reduce((q, row) => {
-      // push the custom-select form being used with those forms to accaptable profile inputs
-      // @todo fiugre out if other types should also make it... custom-boolean specifically.
-      row.forEach((question) => {
-        if (question.type === 'custom-select') q.push(question.id);
-      });
-      return q;
-    }, []);
-    return questions.concat(newQuestions);
+    getAsArray(form, 'fieldRows').forEach((row) => row.forEach((question) => {
+      // push the custom-select form being used with those forms to acceptable profile inputs
+      // @todo figure out if other types should also make it... custom-boolean specifically.
+      if (question.type === 'custom-select') questions.push(question.id);
+    }));
+    return questions;
   }, []);
 
   const customFieldIds = [


### PR DESCRIPTION
@solocommand  I beleive this is what you where getting at in order to limit additional configuration and or it would now just allow for all custom-selects ids that are configured in a give sites identity-x forms fieldRows. 

If this is not what you where thinking let me know and I can adjust accordingly.  