### PR TITLE
Unify IdentityX profile updates from access & download components

### DIFF
--- a/packages/marko-web-identity-x/browser/access.vue
+++ b/packages/marko-web-identity-x/browser/access.vue
@@ -65,8 +65,8 @@
       <login
         :additional-event-data="additionalEventData"
         :source="loginSource"
-        :endpoints="endpoints"
         :redirect="redirect"
+        :endpoints="endpoints"
         :app-context-id="appContextId"
         :consent-policy="consentPolicy"
         :consent-policy-enabled="consentPolicyEnabled"
@@ -242,7 +242,7 @@ export default {
         return this.content.siteContext.url;
       }
       if (this.content) {
-        return this.content.id;
+        return `/${this.content.id}`;
       }
       return '/';
     },

--- a/packages/marko-web-identity-x/browser/access.vue
+++ b/packages/marko-web-identity-x/browser/access.vue
@@ -66,6 +66,7 @@
         :additional-event-data="additionalEventData"
         :source="loginSource"
         :endpoints="endpoints"
+        :redirect="redirect"
         :app-context-id="appContextId"
         :consent-policy="consentPolicy"
         :consent-policy-enabled="consentPolicyEnabled"
@@ -231,6 +232,19 @@ export default {
      */
     hasActiveUser() {
       return this.user && this.user.email;
+    },
+
+    /**
+     *
+     */
+    redirect() {
+      if (this.content.siteContext && this.content.siteContext.url) {
+        return this.content.siteContext.url;
+      }
+      if (this.content) {
+        return this.content.id;
+      }
+      return '/';
     },
 
     /**

--- a/packages/marko-web-identity-x/browser/download.vue
+++ b/packages/marko-web-identity-x/browser/download.vue
@@ -245,7 +245,7 @@ export default {
         return this.content.siteContext.url;
       }
       if (this.content) {
-        return this.content.id;
+        return `/${this.content.id}`;
       }
       return '/';
     },

--- a/packages/marko-web-identity-x/browser/download.vue
+++ b/packages/marko-web-identity-x/browser/download.vue
@@ -68,6 +68,7 @@
         :additional-event-data="additionalEventData"
         :source="loginSource"
         :endpoints="endpoints"
+        :redirect="redirect"
         :app-context-id="appContextId"
         :consent-policy="consentPolicy"
         :consent-policy-enabled="consentPolicyEnabled"
@@ -234,6 +235,19 @@ export default {
      */
     hasActiveUser() {
       return this.user && this.user.email;
+    },
+
+    /**
+     *
+     */
+    redirect() {
+      if (this.content.siteContext && this.content.siteContext.url) {
+        return this.content.siteContext.url;
+      }
+      if (this.content) {
+        return this.content.id;
+      }
+      return '/';
     },
 
     /**

--- a/packages/marko-web-identity-x/browser/download.vue
+++ b/packages/marko-web-identity-x/browser/download.vue
@@ -202,7 +202,7 @@ export default {
     updateProfileOnSubmit: {
       type: Boolean,
       defualt: true,
-    }
+    },
   },
 
   /**
@@ -293,12 +293,10 @@ export default {
       try {
         const additionalEventData = { ...this.additionalEventData, actionSource: this.loginSource };
         let data = {};
-
         if ( this.canUpdateProfile) {
           const res = await post('/profile', { ...this.user, additionalEventData });
-          const data = await res.json();
+          data = await res.json();
           if (!res.ok) throw new FormError(data.message, res.status);
-
           this.user = data.user;
         }
 

--- a/packages/marko-web-identity-x/browser/download.vue
+++ b/packages/marko-web-identity-x/browser/download.vue
@@ -293,7 +293,7 @@ export default {
       try {
         const additionalEventData = { ...this.additionalEventData, actionSource: this.loginSource };
         let data = {};
-        if ( this.canUpdateProfile) {
+        if (this.canUpdateProfile) {
           const res = await post('/profile', { ...this.user, additionalEventData });
           data = await res.json();
           if (!res.ok) throw new FormError(data.message, res.status);

--- a/packages/marko-web-theme-monorail/components/content/download/identity-x.marko
+++ b/packages/marko-web-theme-monorail/components/content/download/identity-x.marko
@@ -14,7 +14,8 @@ $ const title = defaultValue(input.title, "Complete the form to download this co
 
 <if(identityX && form.fieldRows)>
   <div class="content-download-idx__wrapper">
-    <marko-web-identity-x-context|{ user, isEnabled, application }|>
+    <marko-web-identity-x-context|{ hasUser, user, isEnabled, application }|>
+      $ console.log('content-download: ', hasUser, user);
       $ const props = {
         // Download form props
         content: content,
@@ -44,7 +45,16 @@ $ const title = defaultValue(input.title, "Complete the form to download this co
         regionalConsentPolicies: get(application, "organization.regionalConsentPolicies"),
         showRelated: defaultValue(input.showRelated, true),
       };
-      <marko-web-browser-component name="IdentityXDownload" props=props />
+      <if(!hasUser)>
+        <marko-web-identity-x-non-auth-identify|{ user: identifiedUser }|>
+          $ props.updateProfileOnSubmit = false;
+          $ props.activeUser = identifiedUser;
+          <marko-web-browser-component name="IdentityXDownload" props=props />
+        </marko-web-identity-x-non-auth-identify>
+      </if>
+      <else>
+        <marko-web-browser-component name="IdentityXDownload" props=props />
+      </else>
     </marko-web-identity-x-context>
   </div>
 </if>

--- a/packages/marko-web-theme-monorail/components/content/download/identity-x.marko
+++ b/packages/marko-web-theme-monorail/components/content/download/identity-x.marko
@@ -15,7 +15,6 @@ $ const title = defaultValue(input.title, "Complete the form to download this co
 <if(identityX && form.fieldRows)>
   <div class="content-download-idx__wrapper">
     <marko-web-identity-x-context|{ hasUser, user, isEnabled, application }|>
-      $ console.log('content-download: ', hasUser, user);
       $ const props = {
         // Download form props
         content: content,


### PR DESCRIPTION
This will be used mainly when there is a non logged in, but identified user being passed in that we dont want to be able to update the profile but rather pre pop the form and allow for them to easily submit data to the access route.

Better explination of what the heck this should now work like:

Condition(nothing to work with, no cookies, no user logged in):
<img width="1404" alt="Screenshot 2024-10-03 at 8 58 19 AM" src="https://github.com/user-attachments/assets/4f777873-f68c-43ec-8af9-cc445ff9c13a">

This would still render the coponents with no user context and force them to login... setting the related cookies. 

SO say you you did that and now are logged in: you would get the following: 
<img width="1316" alt="Screenshot 2024-10-03 at 9 38 44 AM" src="https://github.com/user-attachments/assets/a74cdc7c-aa69-46b7-8021-a74b9384a58a">

In this case you can also hit log out and it will still prepop your stuff as it still uses your idx cookie id to look up the user. 

The cookie state can sometimes cause odd conditionss meaning if the incoming query parmas and cookie don't match I'm not sure at the moment who wins. :( 

But your example with oly_enc_id being present with no cookies would work.  You could also get someones Idx(Richeles) info if you knew how to do it, but you can subit as her, but not change her record in identityX:
http://www-acbm-fcp.dev.parameter1.com:9721/covid-19/whitepaper/22921299/brians-test-expired-company-brians-company-whitepaper?oly_enc_id=1084G1356867G5F

You can submit it with her data, but it will only submit to content access & not update her profile.
<img width="1764" alt="Screenshot 2024-10-03 at 10 29 08 AM" src="https://github.com/user-attachments/assets/89ba1f5f-fa7f-4527-9586-95856c5877a9">
