### PR TITLE
Set default download cookie experation to 24hrs vs 0

### DIFF
--- a/packages/marko-web-identity-x/middleware/content-download-state.js
+++ b/packages/marko-web-identity-x/middleware/content-download-state.js
@@ -3,7 +3,7 @@ const { get } = require('@parameter1/base-cms-object-path');
 const cookieNamePrefix = '__idx_form';
 const maxAge = process.env.IDX_CONTENT_DOWNLOAD_MAXAGE
   ? Number(process.env.IDX_CONTENT_DOWNLOAD_MAXAGE)
-  : 0;
+  : (24 * 60 * 60 * 1000);
 
 const contentDownloadState = ({ res, content }) => {
   // Handle setting of contentDownloadState Object


### PR DESCRIPTION
Update to allow user to access the download for 24 hours vs having to fill the form out ever time.

This also now exactly matches [content access](https://github.com/parameter1/base-cms/blob/master/packages/marko-web-identity-x/middleware/content-access-state.js#L7)