### PR TITLE
Set image|creative height & width attribute within ad render component

### DIFF
--- a/packages/marko-web-mindful-ads/components/render.marko
+++ b/packages/marko-web-mindful-ads/components/render.marko
@@ -17,7 +17,7 @@ $ /** @type {import("../utils/fetch-ads").MindfulWebsiteBannerCreative} **/
     data-unit-id=unit._id
   >
     <a href=creative.clickUrl target="_blank">
-      <img src=creative.src alt=creative.name />
+      <img src=creative.src alt=creative.name height=creative.height width=creative.width />
     </a>
   </div>
 </for>


### PR DESCRIPTION
This will help reserver the correct space for the given creative/ad and helps prevent issues with cls  & lighthouse scoring.

At the moment I have test it on the repos currently using mindful ads package: 
<img width="1655" alt="Screenshot 2024-10-15 at 12 56 02 PM" src="https://github.com/user-attachments/assets/526c2527-edbf-4a3e-ba2b-d4d6957a4a8f">
<img width="2186" alt="Screenshot 2024-10-15 at 12 56 15 PM" src="https://github.com/user-attachments/assets/8d6d7762-2747-4714-8c45-7b009ef39cc5">

<img width="2133" alt="Screenshot 2024-10-15 at 12 55 44 PM" src="https://github.com/user-attachments/assets/fa31d03f-1bd8-461f-b744-7ca020f1ea2d">
<img width="1741" alt="Screenshot 2024-10-15 at 12 57 41 PM" src="https://github.com/user-attachments/assets/18646efb-3dd3-4c96-ab30-9a3774db5d3c">
