### PR TITLE
Make newsletter-modal signup component self contained with configurations

### DIFF
--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-modal.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-modal.marko
@@ -3,7 +3,12 @@ import { getAsObject } from "@parameter1/base-cms-object-path";
 $ const { site, req } = out.global;
 $ const { cookieName, cookieValue, hasCookie } = getAsObject(out.global, "newsletterModalState");
 $ const { enabled: modalEnabled, cookieValueToMatch } =  site.getAsObject("newsletter.modal");
-$ const routesToExclude =  site.getAsArray("newsletter.modal.routesToExclude");
+$ const routesToExclude =  [...new Set(
+  // by default exclude /user, /subscribe & /page
+  ...['user', 'page', 'subscribe'],
+  // aditional site specific routes to exclude
+  ...site.getAsArray("newsletter.modal.routesToExclude")
+)];
 $ const excludeRoute = req.path.match(`^\/${routesToExclude.join('|')}`)
 
 <marko-web-identity-x-context|{ hasUser }|>

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-modal.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-modal.marko
@@ -3,12 +3,9 @@ import { getAsObject } from "@parameter1/base-cms-object-path";
 $ const { site, req } = out.global;
 $ const { cookieName, cookieValue, hasCookie } = getAsObject(out.global, "newsletterModalState");
 $ const { enabled: modalEnabled, cookieValueToMatch } =  site.getAsObject("newsletter.modal");
-$ const routesToExclude =  [...new Set(
-  // by default exclude /user, /subscribe & /page
-  ...['user', 'page', 'subscribe'],
-  // aditional site specific routes to exclude
-  ...site.getAsArray("newsletter.modal.routesToExclude")
-)];
+$ const exclusions = ["user", "page", "subscribe"]
+$ const siteExclusions = site.getAsArray("newsletter.modal.routesToExclude");
+$ const routesToExclude = siteExclusions.length ? [...new Set(...exclusions.concat(siteExclusions))] : exclusions;
 $ const excludeRoute = req.path.match(`^\/${routesToExclude.join('|')}`)
 
 <marko-web-identity-x-context|{ hasUser }|>

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-modal.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-modal.marko
@@ -1,5 +1,22 @@
+import { getAsObject } from "@parameter1/base-cms-object-path";
+
+$ const { site, req } = out.global;
+$ const { cookieName, cookieValue, hasCookie } = getAsObject(out.global, "newsletterModalState");
+$ const { enabled: modalEnabled, cookieValueToMatch } =  site.getAsObject("newsletter.modal");
+$ const routesToExclude =  site.getAsArray("newsletter.modal.routesToExclude");
+$ const excludeRoute = req.path.match(`^\/${routesToExclude.join('|')}`)
+
 <marko-web-identity-x-context|{ hasUser }|>
-  <if(!hasUser)>
+  <if(
+    !hasUser
+    && !excludeRoute
+    && modalEnabled
+    && (
+      (!hasCookie && Number(cookieValueToMatch) === 0)
+      ||
+      (hasCookie && (Number(cookieValue) === Number(cookieValueToMatch)))
+    )
+  )>
     <div class="popup-modal-wrapper popup-modal-wrapper--display-overlay" id="newsletter-signup-modal">
       <div class="popup-modal-wrapper__overlay">
         <div class="newsletter-signup-modal-center-column-outer">
@@ -16,3 +33,8 @@
     </div>
   </if>
 </marko-web-identity-x-context>
+
+<marko-web-browser-component
+  name="NewsletterSignupModalListener"
+  props={ cookieName, cookieValue: Number(cookieValue), cookieValueToMatch, hasCookie }
+/>

--- a/packages/marko-web-theme-monorail/components/identity-x/newsletter-modal.marko
+++ b/packages/marko-web-theme-monorail/components/identity-x/newsletter-modal.marko
@@ -5,7 +5,7 @@ $ const { cookieName, cookieValue, hasCookie } = getAsObject(out.global, "newsle
 $ const { enabled: modalEnabled, cookieValueToMatch } =  site.getAsObject("newsletter.modal");
 $ const exclusions = ["user", "page", "subscribe"]
 $ const siteExclusions = site.getAsArray("newsletter.modal.routesToExclude");
-$ const routesToExclude = siteExclusions.length ? [...new Set(...exclusions.concat(siteExclusions))] : exclusions;
+$ const routesToExclude = siteExclusions.length ? [...new Set(exclusions.concat(siteExclusions))] : exclusions;
 $ const excludeRoute = req.path.match(`^\/${routesToExclude.join('|')}`)
 
 <marko-web-identity-x-context|{ hasUser }|>


### PR DESCRIPTION
Meaning move the cookie handler call into itself instead of the footer.   Move the getting of props & if wrapper into here as well.  This includes the new use of the site.newsletter.modal.routesToExclude prop to beable to exlcude firing of the modal on given page routes.

@todo investigate if the cookie handler should also be wrapped in a excludeRoute check?.?.?.?

This will be utilized and require the following org to do something with the next dep upgrade to the theme-monorail package.  

 - [Encore360](https://github.com/parameter1/encore360-websites/pull/37)
 - [Transpire](https://github.com/parameter1/transpire-media-websites/pull/92)
 - [SMG](https://github.com/parameter1/science-medicine-group-websites/pull/613)
 - [Datia](https://github.com/parameter1/datia-websites/pull/48) - will implement and setup configuration post this going live. 