### PR TITLE
Add tracking components for User and Static Routes

### DIFF
--- a/packages/marko-web-p1-events/components/marko.json
+++ b/packages/marko-web-p1-events/components/marko.json
@@ -70,6 +70,14 @@
     },
     "@event-name": "string"
   },
+  "<marko-web-p1-events-track-static-route-view>": {
+    "template": "./track-static-route-view.marko",
+    "@path": "string"
+  },
+  "<marko-web-p1-events-track-user-route-view>": {
+    "template": "./track-user-route-view.marko",
+    "@path": "string"
+  },
   "<marko-web-p1-events-track-website-section>": {
     "template": "./track-website-section.marko",
     "@node": "object"

--- a/packages/marko-web-p1-events/components/track-static-route-view.marko
+++ b/packages/marko-web-p1-events/components/track-static-route-view.marko
@@ -1,4 +1,3 @@
-import { getAsArray } from "@parameter1/base-cms-object-path";
 import ns from "../utils/create-namespace";
 
 $ const { site } = out.global;

--- a/packages/marko-web-p1-events/components/track-static-route-view.marko
+++ b/packages/marko-web-p1-events/components/track-static-route-view.marko
@@ -1,0 +1,22 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+import ns from "../utils/create-namespace";
+
+$ const { site } = out.global;
+$ const { path } = input;
+$ const config = site.getAsObject("p1events");
+
+<if(config.enabled)>
+  $ const { type, primarySection, company, createdBy } = node;
+  $ const entity = {
+    id: path.replace(/^\//, ""),
+    ns: ns("static-route"),
+  };
+  $ const data = {
+    action: 'View',
+    category: 'Static Route',
+    entity,
+  };
+  <script>
+    p1events('track', ${JSON.stringify(data)});
+  </script>
+</if>

--- a/packages/marko-web-p1-events/components/track-static-route-view.marko
+++ b/packages/marko-web-p1-events/components/track-static-route-view.marko
@@ -5,7 +5,6 @@ $ const { path } = input;
 $ const config = site.getAsObject("p1events");
 
 <if(config.enabled)>
-  $ const { type, primarySection, company, createdBy } = node;
   $ const entity = {
     id: path.replace(/^\//, ""),
     ns: ns("static-route"),

--- a/packages/marko-web-p1-events/components/track-user-route-view.marko
+++ b/packages/marko-web-p1-events/components/track-user-route-view.marko
@@ -1,0 +1,22 @@
+import { getAsArray } from "@parameter1/base-cms-object-path";
+import ns from "../utils/create-namespace";
+
+$ const { site } = out.global;
+$ const { path } = input;
+$ const config = site.getAsObject("p1events");
+
+<if(config.enabled)>
+  $ const { type, primarySection, company, createdBy } = node;
+  $ const entity = {
+    id: path.replace(/^\//, ""),
+    ns: ns("user-route"),
+  };
+  $ const data = {
+    action: 'View',
+    category: 'User Route',
+    entity,
+  };
+  <script>
+    p1events('track', ${JSON.stringify(data)});
+  </script>
+</if>

--- a/packages/marko-web-p1-events/components/track-user-route-view.marko
+++ b/packages/marko-web-p1-events/components/track-user-route-view.marko
@@ -1,4 +1,3 @@
-import { getAsArray } from "@parameter1/base-cms-object-path";
 import ns from "../utils/create-namespace";
 
 $ const { site } = out.global;

--- a/packages/marko-web-p1-events/components/track-user-route-view.marko
+++ b/packages/marko-web-p1-events/components/track-user-route-view.marko
@@ -5,7 +5,6 @@ $ const { path } = input;
 $ const config = site.getAsObject("p1events");
 
 <if(config.enabled)>
-  $ const { type, primarySection, company, createdBy } = node;
   $ const entity = {
     id: path.replace(/^\//, ""),
     ns: ns("user-route"),


### PR DESCRIPTION
Previously there was not applicable component(s) to track View events on Static Routes that are not served via Base (ex: https://www.feedstrategy.com/animal-feed-formulations-library) and User related routes such as /user/login.  This creates such components.

**Question:** Because these paths can be changed at any time setting uniqueness based on them (which is what this _is_ currently doing it would result in situations where if the path itself changes events would potentially be disjoint assuming they are not unified backwards, this is likely an acceptable thing but mostly something to keep in mind in the event any route is supposed to have all it's events tied together despite the route itself changing.