### PR TITLE
Default `SortOrder` to `values` for `ContentContactSortInput`

### DIFF
--- a/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
+++ b/services/graphql-server/src/graphql/definitions/platform/content/types/contact.js
@@ -63,7 +63,7 @@ input ContentContactOwnedContentInput {
 
 input ContentContactSortInput {
   field: ContentContactSortField = id
-  order: SortOrder = desc
+  order: SortOrder = values
 }
 
 input CreateContentContactMutationInput {


### PR DESCRIPTION
Alternatively adjust here: https://github.com/parameter1/base-cms/blob/master/packages/marko-web-theme-monorail/graphql/fragments/content-page.js#L129 or utilize a tenant/site level defined fragment that changes the sort order as well.

No Change:
![Screenshot from 2024-10-23 09-01-11](https://github.com/user-attachments/assets/306e3fae-6ce3-438d-84bc-972ca389d3f3)

Following Change:
![Screenshot from 2024-10-23 09-00-55](https://github.com/user-attachments/assets/e153586c-fc6f-4a3c-865d-0bd452fe056a)

