### PR TITLE
Add Mobile Number built in support on idx default form gate

### DIFF
--- a/packages/marko-web-identity-x/browser/custom-column.vue
+++ b/packages/marko-web-identity-x/browser/custom-column.vue
@@ -55,6 +55,13 @@
       :required="required"
       :label="label"
     />
+    <phone-number
+      v-else-if="fieldKey === 'mobileNumber'"
+      v-model="user.mobileNumber"
+      :class-name="className"
+      :required="required"
+      :label="label"
+    />
     <country-code
       v-else-if="fieldKey === 'countryCode'"
       v-model="user.countryCode"


### PR DESCRIPTION
This should allow https://github.com/parameter1/ac-business-media-websites/pull/747 to be update to just use Mobile Number with a type of mobileNumber
```
      {
        label: 'Mbile Number',
        key: 'mobileNumber',
        type: 'built-in',
        required: true,
        width: 0.5,
      },
```
https://github.com/parameter1/ac-business-media-websites/pull/747/files#diff-36f1687f63514dadef347cb75353972ee1a03e73bdd5c813d47b5031df2a4f72R43

<img width="1379" alt="Screenshot 2024-10-29 at 10 59 44 AM" src="https://github.com/user-attachments/assets/1ba1a0b8-acd3-48bc-b196-a03fc3664ce7">
