### PR TITLE
Add redirect handling of queryParams for mindful adverting post

### DIFF
--- a/packages/mindful/marko-web/middleware/get-advertising-post-as-native-story.js
+++ b/packages/mindful/marko-web/middleware/get-advertising-post-as-native-story.js
@@ -33,8 +33,7 @@ module.exports = (app, {
       // account for redirecting with all of the queryParams
       const newUrl = req.query && Object.keys(req.query).length !== 0
         ? `${storyURL.pathname}?${new URLSearchParams(req.query).toString()}`
-        : storyURL.pathname
-      ;
+        : storyURL.pathname;
       res.redirect(301, newUrl);
       return;
     }

--- a/packages/mindful/marko-web/middleware/get-advertising-post-as-native-story.js
+++ b/packages/mindful/marko-web/middleware/get-advertising-post-as-native-story.js
@@ -30,7 +30,12 @@ module.exports = (app, {
     // redirect path to story url if url does not match.
     const storyURL = new URL(story.url);
     if (storyURL.pathname !== path) {
-      res.redirect(301, storyURL.pathname);
+      // account for redirecting with all of the queryParams
+      const newUrl = req.query && Object.keys(req.query).length !== 0
+        ? `${storyURL.pathname}?${new URLSearchParams(req.query).toString()}`
+        : storyURL.pathname
+      ;
+      res.redirect(301, newUrl);
       return;
     }
 


### PR DESCRIPTION
Only came up cause I re tested on watt and they have a bunch of queryParams appended to their links withing the content section feed.

http://www-feedandgrain.dev.parameter1.com:9925/brand-insights/zoetis/vaccination-success-depends-on-crew-training/67094ddcc2bbee3e1b1af57d?pubid=644d5a06b225a200013c2da3&utm_source=NativeX&utm_medium=banner&utm_campaign=65943beafce1d00001661a52&utm_term=6452f9113738d30001f886aa&utm_content=65943beafce1d00001661a54

the following url, with an invalid primary section alias, should redirect to the above now. http://www-feedandgrain.dev.parameter1.com:9925/brand-insights/zoetis/vaccination-training/67094ddcc2bbee3e1b1af57d?pubid=644d5a06b225a200013c2da3&utm_source=NativeX&utm_medium=banner&utm_campaign=65943beafce1d00001661a52&utm_term=6452f9113738d30001f886aa&utm_content=65943beafce1d00001661a54