### PR TITLE
Ensure prop !null before getting node or setting fallback

### DIFF
--- a/packages/mindful/marko-web/utils/convert-advertising-post-to-native-story.js
+++ b/packages/mindful/marko-web/utils/convert-advertising-post-to-native-story.js
@@ -11,7 +11,9 @@ module.exports = ({ advertisingPost, preview }) => {
   const { label } = statusEdge && statusEdge.node ? statusEdge.node : {};
   const isPublished = label === 'Published' && (new Date() >= new Date(publishedDay));
   if (id && (isPublished || preview)) {
-    const { _id: imageId, src } = featuredImageEdge.node || { src: { settings: {} } };
+    const { _id: imageId, src } = (featuredImageEdge && featuredImageEdge.node)
+      ? featuredImageEdge.node
+      : { src: { settings: {} } };
     const primaryImage = {
       id: imageId,
       src: src.url,
@@ -20,8 +22,12 @@ module.exports = ({ advertisingPost, preview }) => {
         y: src.settings.fpY,
       },
     };
-    const { _id: companyId, name, logoEdge } = companyEdge.node || { logoEdge: {} };
-    const { _id: logoId, src: logoSrc } = logoEdge.node || { src: { settings: {} } };
+    const { _id: companyId, name, logoEdge } = (companyEdge && companyEdge.node)
+      ? companyEdge.node
+      : { logoEdge: {} };
+    const { _id: logoId, src: logoSrc } = (logoEdge && logoEdge.node)
+      ? logoEdge.node
+      : { src: { settings: {} } };
     const advertiser = {
       id: companyId,
       name,


### PR DESCRIPTION
This is within the new mindful native story middleware/converter util.  This will ensure that the props are there before trying to get node off of it.  It was error due to the logoEdge not being set on a company.  This should prevent the error when a company doesn't have a logo set within mindful. 