### PR TITLE
Add p1event tracking for content meter component

### DIFF
--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -55,7 +55,7 @@ export default {
               overlayDisplayed,
             },
           };
-          this.emitP1Event('View');
+          this.emitP1Event({ action: 'View' });
           dataLayer.push(payload);
           const { searchParams } = new URL(window.location.href);
           if (searchParams.has('idxDebugger')) {
@@ -70,20 +70,18 @@ export default {
     this.EventBus.$on('identity-x-login-link-sent', ({ actionSource }) => {
       if (actionSource === 'content_meter_login') {
         this.classes.push('login-link-sent');
-        this.emitP1Event('Submit');
+        this.emitP1Event({ action: 'Submit' });
       }
     });
   },
   methods: {
-    emitP1Event(action) {
+    emitP1Event({ action }) {
       if (!window.p1events) return;
       const { views, remaining, overlayDisplayed } = this;
-      const label = !overlayDisplayed ? null : 'Gated';
-      console.log('label: ', label)
       window.p1events('track', {
         category: 'Content Meter',
         action,
-        ...(label && { label }),
+        ...(!overlayDisplayed && { label: 'Gated' }),
         props: { n: views },
       });
       this.EventBus.$emit(`identity-x-content-meter-${action}`, { payload: { views, remaining, overlayDisplayed }});

--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -77,14 +77,13 @@ export default {
   methods: {
     emitP1Event({ action }) {
       if (!window.p1events) return;
-      const { views, remaining, overlayDisplayed } = this;
+      const { views, overlayDisplayed } = this;
       window.p1events('track', {
         category: 'Content Meter',
         action,
         ...(overlayDisplayed && { label: 'Gated' }),
         props: { n: views },
       });
-      this.EventBus.$emit(`identity-x-content-meter-${action}`, { payload: { views, remaining, overlayDisplayed }});
     },
   },
 };

--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -81,7 +81,7 @@ export default {
       window.p1events('track', {
         category: 'Content Meter',
         action,
-        ...(!overlayDisplayed && { label: 'Gated' }),
+        ...(overlayDisplayed && { label: 'Gated' }),
         props: { n: views },
       });
       this.EventBus.$emit(`identity-x-content-meter-${action}`, { payload: { views, remaining, overlayDisplayed }});

--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -70,7 +70,7 @@ export default {
     this.EventBus.$on('identity-x-login-link-sent', ({ actionSource }) => {
       if (actionSource === 'content_meter_login') {
         this.classes.push('login-link-sent');
-        this.trackP1Event('login-login-link-sent');
+        this.trackP1Event('login-link-sent');
       }
     });
   },
@@ -78,12 +78,16 @@ export default {
     trackP1Event(action) {
       console.warn('action: ', action, window.p1events);
       // triggercall here
+      const { views, remaining, overlayDisplayed } = this;
       window.p1events('track', {
         category: 'Identity',
         action,
         label: 'content-meter',
-        // ctx,
-        // entity,
+        props: {
+          views,
+          remaining,
+          overlayDisplayed,
+        },
       });
     },
   },

--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -55,6 +55,7 @@ export default {
               overlayDisplayed,
             },
           };
+          this.trackP1Event('view');
           dataLayer.push(payload);
           const { searchParams } = new URL(window.location.href);
           if (searchParams.has('idxDebugger')) {
@@ -69,8 +70,22 @@ export default {
     this.EventBus.$on('identity-x-login-link-sent', ({ actionSource }) => {
       if (actionSource === 'content_meter_login') {
         this.classes.push('login-link-sent');
+        this.trackP1Event('login-login-link-sent');
       }
     });
+  },
+  methods: {
+    trackP1Event(action) {
+      console.warn('action: ', action, window.p1events);
+      // triggercall here
+      window.p1events('track', {
+        category: 'Identity',
+        action,
+        label: 'content-meter',
+        // ctx,
+        // entity,
+      });
+    },
   },
 };
 </script>

--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -78,11 +78,12 @@ export default {
     emitP1Event(action) {
       if (!window.p1events) return;
       const { views, remaining, overlayDisplayed } = this;
-      const lab = !overlayDisplayed ? null : 'Gated';
+      const label = !overlayDisplayed ? null : 'Gated';
+      console.log('label: ', label)
       window.p1events('track', {
         category: 'Content Meter',
         action,
-        lab,
+        label,
         props: { n: views },
       });
       this.EventBus.$emit(`identity-x-content-meter-${action}`, { payload: { views, remaining, overlayDisplayed }});

--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -83,7 +83,7 @@ export default {
       window.p1events('track', {
         category: 'Content Meter',
         action,
-        label,
+        ...(label && { label }),
         props: { n: views },
       });
       this.EventBus.$emit(`identity-x-content-meter-${action}`, { payload: { views, remaining, overlayDisplayed }});

--- a/packages/marko-web-theme-monorail/browser/content-meter-track.vue
+++ b/packages/marko-web-theme-monorail/browser/content-meter-track.vue
@@ -55,7 +55,7 @@ export default {
               overlayDisplayed,
             },
           };
-          this.trackP1Event('view');
+          this.emitP1Event('View');
           dataLayer.push(payload);
           const { searchParams } = new URL(window.location.href);
           if (searchParams.has('idxDebugger')) {
@@ -70,25 +70,22 @@ export default {
     this.EventBus.$on('identity-x-login-link-sent', ({ actionSource }) => {
       if (actionSource === 'content_meter_login') {
         this.classes.push('login-link-sent');
-        this.trackP1Event('login-link-sent');
+        this.emitP1Event('Submit');
       }
     });
   },
   methods: {
-    trackP1Event(action) {
-      console.warn('action: ', action, window.p1events);
-      // triggercall here
+    emitP1Event(action) {
+      if (!window.p1events) return;
       const { views, remaining, overlayDisplayed } = this;
+      const lab = !overlayDisplayed ? null : 'Gated';
       window.p1events('track', {
-        category: 'Identity',
+        category: 'Content Meter',
         action,
-        label: 'content-meter',
-        props: {
-          views,
-          remaining,
-          overlayDisplayed,
-        },
+        lab,
+        props: { n: views },
       });
+      this.EventBus.$emit(`identity-x-content-meter-${action}`, { payload: { views, remaining, overlayDisplayed }});
     },
   },
 };


### PR DESCRIPTION
This will work assuming the following...
 - sites are using the shared content meter component or are using the shared vue track portion of this component. 
 -  @todo ensure all sites are using a version of the above

### Example Payloads 

**Content Meter Submit - nonGated(without overlay displayed):**
<img width="574" alt="Screenshot 2024-12-02 at 11 08 51 AM" src="https://github.com/user-attachments/assets/7cef4a7b-bdbf-4165-a80a-e1c95e83e73a">
 **Content Meter Submit - Gated(with overlayDisplayed):**
<img width="555" alt="Screenshot 2024-12-02 at 11 06 54 AM" src="https://github.com/user-attachments/assets/be3cd21d-5783-43f8-a37e-175bf23d485b">

**Example payloads of views without gating:** 
<img width="328" alt="Screenshot 2024-12-02 at 11 00 11 AM" src="https://github.com/user-attachments/assets/c04272b8-4672-4bbd-a20d-bed680ce5357">
<img width="322" alt="Screenshot 2024-12-02 at 11 00 37 AM" src="https://github.com/user-attachments/assets/d153b63d-9eed-41f9-8a88-875f89a3382e">
<img width="602" alt="Screenshot 2024-12-02 at 11 00 59 AM" src="https://github.com/user-attachments/assets/ce8cf1cd-1f33-4ad1-9693-6c9eda2fa0bb">
<img width="518" alt="Screenshot 2024-12-02 at 11 01 30 AM" src="https://github.com/user-attachments/assets/24851a63-b81e-4d5f-9c5a-ce3230577931">

**Example payload of view with gating:**
<img width="520" alt="Screenshot 2024-12-02 at 11 05 54 AM" src="https://github.com/user-attachments/assets/01fc2f28-28b1-4483-8cdd-eb9aa6fd4c5b">
